### PR TITLE
chore(refactor): reuse more code in adapters

### DIFF
--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -97,7 +97,7 @@ impl CpuMiner {
                 select! {
                               _ = watch_timer.tick() => {
                                     println!("watching");
-                                    if xmrig_child.ping().expect("idk") {
+                                    if xmrig_child.ping() {
                                        println!("xmrig is running");
                                     } else {
                                        println!("xmrig is not running");

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -1,4 +1,6 @@
 use crate::app_config::MiningMode;
+use crate::mm_proxy_manager::MmProxyManager;
+use crate::process_adapter::ProcessAdapter;
 use crate::xmrig::http_api::XmrigHttpApiClient;
 use crate::xmrig_adapter::{XmrigAdapter, XmrigNodeConnection};
 use crate::{
@@ -76,17 +78,14 @@ impl CpuMiner {
         };
         let xmrig = XmrigAdapter::new(
             xmrig_node_connection,
-            "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A".to_string()
-        );
-        let (mut _rx, mut xmrig_child, client) = xmrig.spawn(
+            "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A".to_string(),
             cache_dir,
             log_dir,
-            base_path,
             progress_tracker,
             cpu_max_percentage,
-        )?;
-
-        self.api_client = Some(client);
+        );
+        let (mut xmrig_child, _xmrig_status_monitor) = xmrig.spawn_inner(base_path.clone())?;
+        self.api_client = Some(xmrig.client);
 
         self.watcher_task = Some(tauri::async_runtime::spawn(async move {
             println!("Starting process");

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -101,7 +101,7 @@ impl CpuMiner {
                                     } else {
                                        println!("xmrig is not running");
                                        match xmrig_child.stop().await {
-                                           Ok(()) => {
+                                           Ok(_) => {
                                               println!("xmrig exited successfully");
                                            }
                                            Err(e) => {

--- a/src-tauri/src/merge_mining_adapter.rs
+++ b/src-tauri/src/merge_mining_adapter.rs
@@ -3,13 +3,12 @@ use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use anyhow::Error;
 use async_trait::async_trait;
 use log::{debug, warn};
+use log::warn;
 use std::fs;
 use std::path::PathBuf;
 use tari_common_types::tari_address::TariAddress;
 use tari_shutdown::Shutdown;
-use tokio::runtime::Handle;
 use tokio::select;
-use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "tari::universe::merge_mining_proxy_adapter";
 
@@ -26,13 +25,12 @@ impl MergeMiningProxyAdapter {
 }
 
 impl ProcessAdapter for MergeMiningProxyAdapter {
-    type Instance = MergeMiningProxyInstance;
     type StatusMonitor = MergeMiningProxyStatusMonitor;
 
     fn spawn_inner(
         &self,
         data_dir: PathBuf,
-    ) -> Result<(Self::Instance, Self::StatusMonitor), Error> {
+    ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
         let shutdown_signal = inner_shutdown.to_signal();
 
@@ -55,7 +53,7 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
             "merge_mining_proxy.wait_for_initial_sync_at_startup=false".to_string(),
         ];
         Ok((
-            MergeMiningProxyInstance {
+            ProcessInstance {
                 shutdown: inner_shutdown,
                 handle: Some(tokio::spawn(async move {
                     let file_path = BinaryResolver::current()
@@ -117,41 +115,6 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
     }
 }
 
-pub struct MergeMiningProxyInstance {
-    pub shutdown: Shutdown,
-    handle: Option<JoinHandle<Result<i32, anyhow::Error>>>,
-}
-
 pub struct MergeMiningProxyStatusMonitor {}
-
-#[async_trait]
-impl ProcessInstance for MergeMiningProxyInstance {
-    fn ping(&self) -> bool {
-        self.handle
-            .as_ref()
-            .map(|m| !m.is_finished())
-            .unwrap_or_else(|| false)
-    }
-
-    async fn stop(&mut self) -> Result<i32, Error> {
-        self.shutdown.trigger();
-        let handle = self.handle.take();
-        let res = handle.unwrap().await??;
-        Ok(res)
-    }
-}
-impl Drop for MergeMiningProxyInstance {
-    fn drop(&mut self) {
-        println!("Drop being called");
-        self.shutdown.trigger();
-        if let Some(handle) = self.handle.take() {
-            Handle::current().block_on(async move {
-                let _ = handle.await.unwrap().map_err(|e| {
-                    warn!(target: LOG_TARGET, "Error in MergeMiningProxyInstance: {}", e);
-                });
-            });
-        }
-    }
-}
 
 impl StatusMonitor for MergeMiningProxyStatusMonitor {}

--- a/src-tauri/src/merge_mining_adapter.rs
+++ b/src-tauri/src/merge_mining_adapter.rs
@@ -1,9 +1,7 @@
 use crate::binary_resolver::{Binaries, BinaryResolver};
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use anyhow::Error;
-use async_trait::async_trait;
 use log::{debug, warn};
-use log::warn;
 use std::fs;
 use std::path::PathBuf;
 use tari_common_types::tari_address::TariAddress;

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -7,9 +7,7 @@ use humantime::format_duration;
 use log::{debug, info, warn};
 use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};
 use log::{info, warn};
-use minotari_node_grpc_client::grpc::{
-    Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo,
-};
+use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};
 use minotari_node_grpc_client::BaseNodeGrpcClient;
 use std::fs;
 use std::path::PathBuf;

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -7,6 +7,10 @@ use async_trait::async_trait;
 use humantime::format_duration;
 use log::{debug, info, warn};
 use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};
+use log::{info, warn};
+use minotari_node_grpc_client::grpc::{
+    Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo,
+};
 use minotari_node_grpc_client::BaseNodeGrpcClient;
 use std::fs;
 use std::path::PathBuf;
@@ -15,7 +19,6 @@ use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_shutdown::Shutdown;
 use tari_utilities::ByteArray;
-use tokio::runtime::Handle;
 use tokio::select;
 use tokio::task::JoinHandle;
 
@@ -32,13 +35,12 @@ impl MinotariNodeAdapter {
 }
 
 impl ProcessAdapter for MinotariNodeAdapter {
-    type Instance = MinotariNodeInstance;
     type StatusMonitor = MinotariNodeStatusMonitor;
 
     fn spawn_inner(
         &self,
         data_dir: PathBuf,
-    ) -> Result<(Self::Instance, Self::StatusMonitor), Error> {
+    ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
         let shutdown_signal = inner_shutdown.to_signal();
 
@@ -76,7 +78,7 @@ impl ProcessAdapter for MinotariNodeAdapter {
             );
         }
         Ok((
-            MinotariNodeInstance {
+            ProcessInstance {
                 shutdown: inner_shutdown,
                 handle: Some(tokio::spawn(async move {
                     let file_path = BinaryResolver::current()
@@ -138,42 +140,6 @@ impl ProcessAdapter for MinotariNodeAdapter {
     }
 }
 
-pub struct MinotariNodeInstance {
-    pub shutdown: Shutdown,
-    handle: Option<JoinHandle<Result<i32, anyhow::Error>>>,
-}
-
-#[async_trait]
-impl ProcessInstance for MinotariNodeInstance {
-    fn ping(&self) -> bool {
-        self.handle
-            .as_ref()
-            .map(|m| !m.is_finished())
-            .unwrap_or_else(|| false)
-    }
-
-    async fn stop(&mut self) -> Result<i32, Error> {
-        self.shutdown.trigger();
-        let handle = self.handle.take();
-        let res = handle.unwrap().await??;
-        Ok(res)
-    }
-}
-
-impl Drop for MinotariNodeInstance {
-    fn drop(&mut self) {
-        println!("Drop being called");
-        self.shutdown.trigger();
-        if let Some(handle) = self.handle.take() {
-            Handle::current().block_on(async move {
-                let _ = handle.await.unwrap().map_err(|e| {
-                    warn!(target: LOG_TARGET, "Error stopping minotari node: {:?}", e);
-                    e
-                });
-            });
-        }
-    }
-}
 pub struct MinotariNodeStatusMonitor {}
 
 impl StatusMonitor for MinotariNodeStatusMonitor {}

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -6,8 +6,6 @@ use anyhow::{anyhow, Error};
 use humantime::format_duration;
 use log::{debug, info, warn};
 use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};
-use log::{info, warn};
-use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};
 use minotari_node_grpc_client::BaseNodeGrpcClient;
 use std::fs;
 use std::path::PathBuf;
@@ -17,7 +15,6 @@ use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_shutdown::Shutdown;
 use tari_utilities::ByteArray;
 use tokio::select;
-use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "tari::universe::minotari_node_adapter";
 

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -3,7 +3,6 @@ use crate::node_manager::NodeIdentity;
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use crate::ProgressTracker;
 use anyhow::{anyhow, Error};
-use async_trait::async_trait;
 use humantime::format_duration;
 use log::{debug, info, warn};
 use minotari_node_grpc_client::grpc::{Empty, HeightRequest, NewBlockTemplateRequest, PowAlgo};

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -2,25 +2,28 @@ use crate::process_killer::kill_process;
 use anyhow::Error;
 use async_trait::async_trait;
 use log::{info, warn};
+use log::warn;
+use tokio::runtime::Handle;
 use std::fs;
 use std::path::PathBuf;
+use tari_shutdown::Shutdown;
+use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "tari::universe::process_adapter";
 
 pub trait ProcessAdapter {
-    type Instance: ProcessInstance;
     type StatusMonitor: StatusMonitor;
     // fn spawn(&self) -> Result<(Receiver<()>, TInstance), anyhow::Error>;
     fn spawn_inner(
         &self,
         base_folder: PathBuf,
-    ) -> Result<(Self::Instance, Self::StatusMonitor), anyhow::Error>;
+    ) -> Result<(ProcessInstance, Self::StatusMonitor), anyhow::Error>;
     fn name(&self) -> &str;
 
     fn spawn(
         &self,
         base_folder: PathBuf,
-    ) -> Result<(Self::Instance, Self::StatusMonitor), anyhow::Error> {
+    ) -> Result<(ProcessInstance, Self::StatusMonitor), anyhow::Error> {
         self.spawn_inner(base_folder)
     }
 
@@ -34,7 +37,7 @@ pub trait ProcessAdapter {
                 kill_process(pid)?;
             }
             Err(e) => {
-                warn!(target: LOG_TARGET, "Could not read node's pid file: {}", e);
+                warn!(target: LOG_TARGET, "Could not read {} pid file: {}", self.pid_file_name(), e);
             }
         }
         Ok(())
@@ -43,8 +46,37 @@ pub trait ProcessAdapter {
 
 pub trait StatusMonitor {}
 
-#[async_trait]
-pub trait ProcessInstance: Send + Sync + 'static {
-    fn ping(&self) -> bool;
-    async fn stop(&mut self) -> Result<i32, anyhow::Error>;
+pub struct ProcessInstance {
+    pub shutdown: Shutdown,
+    pub handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
+}
+
+impl ProcessInstance {
+    pub fn ping(&self) -> bool {
+        self
+            .handle
+            .as_ref()
+            .map(|m| !m.is_finished())
+            .unwrap_or_else(|| false)
+    }
+
+    pub async fn stop(&mut self) -> Result<(), anyhow::Error> {
+        self.shutdown.trigger();
+        let handle = self.handle.take();
+        handle.unwrap().await?
+    }
+}
+
+impl Drop for ProcessInstance {
+    fn drop(&mut self) {
+        println!("Drop being called");
+        self.shutdown.trigger();
+        if let Some(handle) = self.handle.take() {
+            Handle::current().block_on(async move {
+                let _ = handle.await.unwrap().map_err(|e| {
+                    warn!(target: LOG_TARGET, "Error in {}: {}", self.name(), e);
+                });
+            });
+        }
+    }
 }

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -3,10 +3,10 @@ use anyhow::Error;
 use async_trait::async_trait;
 use log::{info, warn};
 use log::warn;
-use tokio::runtime::Handle;
 use std::fs;
 use std::path::PathBuf;
 use tari_shutdown::Shutdown;
+use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "tari::universe::process_adapter";
@@ -53,8 +53,7 @@ pub struct ProcessInstance {
 
 impl ProcessInstance {
     pub fn ping(&self) -> bool {
-        self
-            .handle
+        self.handle
             .as_ref()
             .map(|m| !m.is_finished())
             .unwrap_or_else(|| false)

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -4,13 +4,6 @@ use std::process::Command;
 const LOG_TARGET: &str = "tari::universe::process_killer";
 
 pub fn kill_process(pid: u32) -> Result<(), anyhow::Error> {
-    #[cfg(target_os = "linux")]
-    {
-        let _ = Command::new("kill")
-            .args(&["-9", &pid.to_string()])
-            .output()?;
-    }
-
     #[cfg(target_os = "windows")]
     {
         let output = Command::new("taskkill")
@@ -27,7 +20,7 @@ pub fn kill_process(pid: u32) -> Result<(), anyhow::Error> {
         use nix::unistd::Pid;
 
         let pid = Pid::from_raw(pid as i32);
-        signal::kill(pid, Signal::SIGTERM);
+        let _ = signal::kill(pid, Signal::SIGTERM);
     }
     Ok(())
 }

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -4,6 +4,13 @@ use std::process::Command;
 const LOG_TARGET: &str = "tari::universe::process_killer";
 
 pub fn kill_process(pid: u32) -> Result<(), anyhow::Error> {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("kill")
+            .args(&["-9", &pid.to_string()])
+            .output()?;
+    }
+
     #[cfg(target_os = "windows")]
     {
         let output = Command::new("taskkill")

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -1,9 +1,7 @@
 use crate::binary_resolver::{Binaries, BinaryResolver};
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use anyhow::Error;
-use async_trait::async_trait;
 use log::{debug, info, warn};
-use log::{info, warn};
 use minotari_node_grpc_client::grpc::wallet_client::WalletClient;
 use minotari_node_grpc_client::grpc::GetBalanceRequest;
 use serde::Serialize;

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -3,6 +3,7 @@ use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use anyhow::Error;
 use async_trait::async_trait;
 use log::{debug, info, warn};
+use log::{info, warn};
 use minotari_node_grpc_client::grpc::wallet_client::WalletClient;
 use minotari_node_grpc_client::grpc::GetBalanceRequest;
 use serde::Serialize;
@@ -12,9 +13,7 @@ use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_shutdown::Shutdown;
 use tari_utilities::hex::Hex;
-use tokio::runtime::Handle;
 use tokio::select;
-use tokio::task::JoinHandle;
 
 const LOG_TARGET: &str = "tari::universe::wallet_adapter";
 
@@ -39,12 +38,12 @@ impl WalletAdapter {
 }
 
 impl ProcessAdapter for WalletAdapter {
-    type Instance = WalletInstance;
     type StatusMonitor = WalletStatusMonitor;
+
     fn spawn_inner(
         &self,
         data_dir: PathBuf,
-    ) -> Result<(Self::Instance, Self::StatusMonitor), Error> {
+    ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         // TODO: This was copied from node_adapter. This should be DRY'ed up
         let inner_shutdown = Shutdown::new();
         let shutdown_signal = inner_shutdown.to_signal();
@@ -97,7 +96,7 @@ impl ProcessAdapter for WalletAdapter {
             args.push("wallet.p2p.transport.tor.proxy_bypass_for_outbound_tcp=false".to_string())
         }
         Ok((
-            WalletInstance {
+            ProcessInstance {
                 shutdown: inner_shutdown,
                 handle: Some(tokio::spawn(async move {
                     let file_path = BinaryResolver::current()
@@ -155,43 +154,6 @@ impl ProcessAdapter for WalletAdapter {
 
     fn pid_file_name(&self) -> &str {
         "wallet_pid"
-    }
-}
-
-pub struct WalletInstance {
-    pub shutdown: Shutdown,
-    handle: Option<JoinHandle<Result<i32, anyhow::Error>>>,
-}
-
-#[async_trait]
-impl ProcessInstance for WalletInstance {
-    fn ping(&self) -> bool {
-        self.handle
-            .as_ref()
-            .map(|m| !m.is_finished())
-            .unwrap_or_else(|| false)
-    }
-
-    async fn stop(&mut self) -> Result<i32, Error> {
-        self.shutdown.trigger();
-        let handle = self.handle.take();
-        let res = handle.unwrap().await??;
-        Ok(res)
-    }
-}
-
-impl Drop for WalletInstance {
-    fn drop(&mut self) {
-        println!("Drop being called");
-        self.shutdown.trigger();
-        if let Some(handle) = self.handle.take() {
-            Handle::current().block_on(async move {
-                let _ = handle.await.unwrap().map_err(|e| {
-                    warn!(target: LOG_TARGET, "Error stopping wallet: {:?}", e);
-                    e
-                });
-            });
-        }
     }
 }
 

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -86,8 +86,7 @@ impl XmrigAdapter {
         process_instance.handle = Some(tokio::spawn(async move {
             // TODO: Ensure version string is not malicious
             let version =
-                Self::ensure_latest(cache_dir.clone(), force_download, progress_tracker)
-                    .await?;
+                Self::ensure_latest(cache_dir.clone(), force_download, progress_tracker).await?;
             let xmrig_dir = cache_dir
                 .join("xmrig")
                 .join(&version)
@@ -116,11 +115,7 @@ impl XmrigAdapter {
             Ok(())
         }));
 
-        Ok((
-            rx,
-            process_instance,
-            client,
-        ))
+        Ok((rx, process_instance, client))
     }
 
     pub async fn ensure_latest(

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -5,7 +5,7 @@ use crate::xmrig::http_api::XmrigHttpApiClient;
 use crate::xmrig::latest_release::fetch_latest_release;
 use crate::ProgressTracker;
 use anyhow::Error;
-use log::{debug, info, warn};
+use log::{info, warn};
 use std::path::PathBuf;
 use tari_shutdown::Shutdown;
 use tokio::fs;
@@ -192,7 +192,7 @@ impl ProcessAdapter for XmrigAdapter {
                         }
                     }
 
-                    Ok(())
+                    Ok(0)
                 })),
             },
             XmrigStatusMonitor {},
@@ -210,11 +210,7 @@ impl ProcessAdapter for XmrigAdapter {
 
 pub struct XmrigStatusMonitor {}
 
-impl StatusMonitor for XmrigStatusMonitor {
-    fn status(&self) -> Result<(), Error> {
-        todo!()
-    }
-}
+impl StatusMonitor for XmrigStatusMonitor {}
 
 #[allow(unreachable_code)]
 fn get_os_string_id() -> String {

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -112,8 +112,8 @@ impl XmrigAdapter {
 
                     match std::fs::remove_file(data_dir.join("xmrig_pid")) {
                         Ok(_) => {}
-                        Err(_e) => {
-                            debug!(target: LOG_TARGET, "Could not clear xmrig's pid file");
+                        Err(e) => {
+                            warn!(target: LOG_TARGET, "Could not clear xmrig's pid file {:?}", e);
                         }
                     }
 
@@ -179,7 +179,6 @@ impl ProcessAdapter for XmrigAdapter {
     fn spawn_inner(
         &self,
         base_folder: PathBuf,
-        _window: tauri::Window,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), anyhow::Error> {
         self.kill_previous_instances(base_folder.clone())?;
 


### PR DESCRIPTION
Description
---
I'm not satisfied with xmrig_adapter refactor - I can't satisfy ProcessAdapter trait without writing useless spawn_inner method
I reused ProcessInstance across all adapters

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
