### PR TITLE
fix(ui): fixed visualisation overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,21 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <title>Tari Universe</title>
-    <style>
-      canvas {
-        visibility: visible;
-        padding: 0 0 0 200px;
-        position: absolute;
-        top: 0;
-        left: 0;
-
-      }
-      canvas.hidden {
-        visibility: hidden;
-        z-index:0;
-
-      }
-    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,75 +1,75 @@
 {
-  "build": {
-    "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build",
-    "devPath": "http://localhost:1420",
-    "distDir": "../dist"
-  },
-  "package": {
-    "productName": "Tari Universe",
-    "version": "0.1.27"
-  },
-  "tauri": {
-    "updater": {
-      "active": true,
-      "endpoints": [
-        "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
-      ],
-      "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
+    "build": {
+        "beforeDevCommand": "npm run dev",
+        "beforeBuildCommand": "npm run build",
+        "devPath": "http://localhost:1420",
+        "distDir": "../dist"
     },
-    "allowlist": {
-      "all": false,
-      "shell": {
-        "all": false,
-        "open": true,
-        "sidecar": false
-      },
-      "window": {
-        "all": false,
-        "close": true,
-        "hide": true,
-        "show": true,
-        "maximize": true,
-        "minimize": true,
-        "unmaximize": true,
-        "unminimize": true,
-        "startDragging": true
-      }
+    "package": {
+        "productName": "Tari Universe",
+        "version": "0.1.27"
     },
-    "pattern": {
-      "use": "isolation",
-      "options": {
-        "dir": "../dist-isolation"
-      }
-    },
-    "windows": [
-      {
-        "title": "tari-universe",
-        "label": "main",
-        "width": 1200,
-        "height": 800,
-        "resizable": true,
-        "fullscreen": false,
-        "decorations": false,
-        "transparent": true
-      }
-    ],
-    "security": {
-      "csp": null
-    },
-    "bundle": {
-      "active": true,
-      "targets": "all",
-      "identifier": "com.tari.universe",
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ]
-    },
-    "macOSPrivateApi": true
-  }
+    "tauri": {
+        "updater": {
+            "active": true,
+            "endpoints": [
+                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
+            ],
+            "dialog": true,
+            "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
+        },
+        "allowlist": {
+            "all": false,
+            "shell": {
+                "all": false,
+                "open": true,
+                "sidecar": false
+            },
+            "window": {
+                "all": false,
+                "close": true,
+                "hide": true,
+                "show": true,
+                "maximize": true,
+                "minimize": true,
+                "unmaximize": true,
+                "unminimize": true,
+                "startDragging": true
+            }
+        },
+        "pattern": {
+            "use": "isolation",
+            "options": {
+                "dir": "../dist-isolation"
+            }
+        },
+        "windows": [
+            {
+                "title": "tari-universe",
+                "label": "main",
+                "width": 1380,
+                "height": 780,
+                "resizable": true,
+                "fullscreen": false,
+                "decorations": false,
+                "transparent": true
+            }
+        ],
+        "security": {
+            "csp": null
+        },
+        "bundle": {
+            "active": true,
+            "targets": "all",
+            "identifier": "com.tari.universe",
+            "icon": [
+                "icons/32x32.png",
+                "icons/128x128.png",
+                "icons/128x128@2x.png",
+                "icons/icon.icns",
+                "icons/icon.ico"
+            ]
+        },
+        "macOSPrivateApi": true
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './theme/theme.css';
-import { useEffect, useRef } from 'react';
+import { CSSProperties, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
@@ -19,6 +19,7 @@ import { useMining } from './hooks/useMining.ts';
 
 import { useGetApplicatonsVersions } from './hooks/useGetApplicatonsVersions.ts';
 import { preload } from './visuals';
+import { appBorderRadius } from './theme/tokens.ts';
 
 function App() {
     const background = useUIStore((s) => s.background);
@@ -91,10 +92,15 @@ function App() {
     useGetApplicatonsVersions();
 
     const hideCanvas = !visualMode || view === 'setup';
-
+    const canvasStyle: CSSProperties = {
+        visibility: hideCanvas ? 'hidden' : 'visible',
+        borderRadius: appBorderRadius,
+        position: 'absolute',
+        zIndex: '0',
+    };
     return (
         <>
-            <canvas id="canvas" className={hideCanvas ? 'hidden' : undefined} />
+            <canvas id="canvas" style={canvasStyle} />
             <ThemeProvider theme={lightTheme}>
                 <CssBaseline enableColorScheme />
                 <AppBackground status={background}>

--- a/src/containers/TitleBar/TitleBar.tsx
+++ b/src/containers/TitleBar/TitleBar.tsx
@@ -1,24 +1,24 @@
-import { useState } from 'react'
-import { appWindow } from '@tauri-apps/api/window'
-import { Stack } from '@mui/material'
-import { IoClose, IoRemove } from 'react-icons/io5'
-import { RiExpandUpDownFill, RiContractUpDownFill } from 'react-icons/ri'
+import { useState } from 'react';
+import { appWindow } from '@tauri-apps/api/window';
+import { Stack } from '@mui/material';
+import { IoClose, IoRemove } from 'react-icons/io5';
+import { RiExpandUpDownFill, RiContractUpDownFill } from 'react-icons/ri';
 import {
     CloseButton,
     MinimizeButton,
     ToggleButton,
     MinMaxStyle,
     TitleBarContainer,
-} from './styles'
+} from './styles';
 
 const TitleBar = () => {
-    const [isExpanded, setIsExpanded] = useState(false)
-    const minimize = () => appWindow.minimize()
-    const close = () => appWindow.close()
+    const [isExpanded, setIsExpanded] = useState(false);
+    const minimize = () => appWindow.minimize();
+    const close = () => appWindow.close();
     const toggleMaximize = () => {
-        setIsExpanded(!isExpanded)
-        appWindow.toggleMaximize()
-    }
+        setIsExpanded(!isExpanded);
+        appWindow.toggleMaximize();
+    };
 
     return (
         <TitleBarContainer data-tauri-drag-region>
@@ -44,7 +44,7 @@ const TitleBar = () => {
                 </ToggleButton>
             </Stack>
         </TitleBarContainer>
-    )
-}
+    );
+};
 
-export default TitleBar
+export default TitleBar;


### PR DESCRIPTION
Description
---

- moved canvas styling to App.tsx to be able to access the `appBorderRadius` value 
- updated styling (removed padding to fix the ugly left side cut-off & adjusted the window sizes slightly) - still need to get a better positioned version from lusion though

Motivation and Context
---

How Has This Been Tested?
---

- locally 

![image](https://github.com/user-attachments/assets/ab63c612-5bed-463d-93d3-94b583fc6025)
![image](https://github.com/user-attachments/assets/230d803a-8def-450b-a9e5-0d8ad3e8e150)


What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
