### PR TITLE
Feat/optimize mining button actions

### DIFF
--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -192,10 +192,19 @@ impl CpuMiner {
                     }
                 });
 
+                // mining should be true if the hashrate is greater than 0
+                let mut is_mining = false;
+                let hasrate_sum = xmrig_status.hashrate.total.iter().fold(0.0, |acc, x| {
+                    acc + x.unwrap_or(0.0)
+                });
+
+                if hasrate_sum > 0.0 {
+                    is_mining = true;
+                }
+
                 Ok(CpuMinerStatus {
-                    is_mining: xmrig_status.hashrate.total.len() > 0
-                        && xmrig_status.hashrate.total[0].is_some()
-                        && xmrig_status.hashrate.total[0].unwrap() > 0.0,
+                    is_mining_enabled: true,
+                    is_mining,
                     hash_rate,
                     cpu_usage: cpu_usage as u32,
                     cpu_brand: cpu_brand.to_string(),
@@ -211,6 +220,7 @@ impl CpuMiner {
                 })
             }
             None => Ok(CpuMinerStatus {
+                is_mining_enabled: false,
                 is_mining: false,
                 hash_rate: 0.0,
                 cpu_usage: cpu_usage as u32,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::Shutdown;
 use tauri::{Manager, RunEvent, UpdaterEvent};
 use tokio::sync::RwLock;
+use xmrig_adapter::XmrigNodeConnection;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct SetupStatusEvent {
@@ -143,6 +144,9 @@ async fn setup_application<'r>(
     let data_dir = app.path_resolver().app_local_data_dir().unwrap();
     let cache_dir = app.path_resolver().app_cache_dir().unwrap();
 
+    let cpu_miner_config = state.cpu_miner_config.read().await;
+    let mm_proxy_manager = state.mm_proxy_manager.clone();
+
     let mut progress = ProgressTracker::new(window.clone());
 
     progress.set_max(10).await;
@@ -207,7 +211,7 @@ async fn setup_application<'r>(
         .await
         .map_err(|e| e.to_string())?;
 
-    progress.set_max(80).await;
+    progress.set_max(55).await;
     progress.update("Waiting for wallet".to_string(), 0).await;
     state
         .wallet_manager
@@ -217,6 +221,17 @@ async fn setup_application<'r>(
             error!(target: LOG_TARGET, "Could not start wallet manager: {:?}", e);
             e.to_string()
         })?;
+
+    progress.set_max(75).await;
+    progress.update("Starting MMProxy".to_string(), 0).await;
+    let _ = mm_proxy_manager
+        .start(
+            state.shutdown.to_signal().clone(),
+            app.path_resolver().app_local_data_dir().unwrap().clone(),
+            cpu_miner_config.tari_address.clone(),
+        )
+        .await;
+    let _ = mm_proxy_manager.wait_ready().await;
 
     _ = window.emit(
         "message",
@@ -401,6 +416,8 @@ async fn status(state: tauri::State<'_, UniverseAppState>) -> Result<AppStatus, 
     };
 
     let config_guard = state.config.read().await;
+
+    println!("is mining {}", cpu.is_mining);
 
     Ok(AppStatus {
         cpu,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -459,6 +459,7 @@ pub struct BaseNodeStatus {
 
 #[derive(Debug, Serialize)]
 pub struct CpuMinerStatus {
+    pub is_mining_enabled: bool,
     pub is_mining: bool,
     pub hash_rate: f64,
     pub cpu_usage: u32,

--- a/src/containers/Dashboard/MiningView/components/MiningButton.tsx
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.tsx
@@ -1,11 +1,15 @@
 import { Button } from '@mui/material';
 import { IoChevronForwardCircle, IoPauseCircle } from 'react-icons/io5';
 import { AiOutlineLoading } from 'react-icons/ai';
-import { useAppStatusStore } from '../../../../store/useAppStatusStore.ts';
 import { useMining } from '../../../../hooks/useMining.ts';
 import { styled } from '@mui/material/styles';
 import { keyframes } from '@emotion/react';
-import { useUIStore } from '../../../../store/useUIStore.ts';
+
+const selectButtonText = (isMining: boolean, hasMiningBeenStopped: boolean) => {
+    if (hasMiningBeenStopped) return 'Resume Mining';
+    if (isMining) return 'Stop Mining';
+    if (!isMining) return 'Start Mining';
+};
 
 const StartStyle = {
     background: '#06C983',
@@ -44,30 +48,29 @@ const StyledIcon = styled(AiOutlineLoading)(() => ({
 }));
 
 function MiningButton() {
-    const isMining = useAppStatusStore((s) => s.cpu?.is_mining);
-    const hashRate = useAppStatusStore((s) => s.cpu?.hash_rate);
-    const isHashRatePresent = hashRate !== undefined && hashRate > 0;
-    console.log('hashRate', hashRate);
-    const isLoading = useUIStore((s) => s.isMiningLoading);
-
-    const { startMining, stopMining } = useMining();
+    const {
+        startMining,
+        stopMining,
+        isMining,
+        shouldDisplayLoading,
+        hasMiningBeenStopped,
+    } = useMining();
 
     const handleMining = () => {
-        if (isLoading) return;
-        if (isMining && isHashRatePresent) {
+        if (shouldDisplayLoading) return;
+        if (isMining) {
             stopMining();
         } else {
             startMining();
         }
     };
 
-    const buttonStyle = isMining && isHashRatePresent ? StopStyle : StartStyle;
-    const buttonIcon =
-        isMining && isHashRatePresent ? (
-            <IoPauseCircle />
-        ) : (
-            <IoChevronForwardCircle />
-        );
+    const buttonStyle = isMining ? StopStyle : StartStyle;
+    const buttonIcon = isMining ? (
+        <IoPauseCircle />
+    ) : (
+        <IoChevronForwardCircle />
+    );
 
     return (
         <StyledButton
@@ -75,17 +78,19 @@ function MiningButton() {
             color="primary"
             size="large"
             style={
-                isLoading ? { ...buttonStyle, ...LoadingStyle } : buttonStyle
+                shouldDisplayLoading
+                    ? { ...buttonStyle, ...LoadingStyle }
+                    : buttonStyle
             }
             onClick={() => handleMining()}
-            endIcon={isLoading ? <StyledIcon /> : buttonIcon}
+            endIcon={shouldDisplayLoading ? <StyledIcon /> : buttonIcon}
             sx={{
                 display: 'flex',
                 alignItems: 'center',
             }}
         >
             <span style={{ flexGrow: 1 }}>
-                {isMining && isHashRatePresent ? 'Stop Mining' : 'Start Mining'}
+                {selectButtonText(Boolean(isMining), hasMiningBeenStopped)}
             </span>
         </StyledButton>
     );

--- a/src/containers/Dashboard/MiningView/components/MiningButton.tsx
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.tsx
@@ -44,22 +44,30 @@ const StyledIcon = styled(AiOutlineLoading)(() => ({
 }));
 
 function MiningButton() {
-    const mining = useAppStatusStore((s) => s.cpu?.is_mining);
+    const isMining = useAppStatusStore((s) => s.cpu?.is_mining);
+    const hashRate = useAppStatusStore((s) => s.cpu?.hash_rate);
+    const isHashRatePresent = hashRate !== undefined && hashRate > 0;
+    console.log('hashRate', hashRate);
     const isLoading = useUIStore((s) => s.isMiningLoading);
 
     const { startMining, stopMining } = useMining();
 
     const handleMining = () => {
         if (isLoading) return;
-        if (mining) {
+        if (isMining && isHashRatePresent) {
             stopMining();
         } else {
             startMining();
         }
     };
 
-    const buttonStyle = mining ? StopStyle : StartStyle;
-    const buttonIcon = mining ? <IoPauseCircle /> : <IoChevronForwardCircle />;
+    const buttonStyle = isMining && isHashRatePresent ? StopStyle : StartStyle;
+    const buttonIcon =
+        isMining && isHashRatePresent ? (
+            <IoPauseCircle />
+        ) : (
+            <IoChevronForwardCircle />
+        );
 
     return (
         <StyledButton
@@ -77,7 +85,7 @@ function MiningButton() {
             }}
         >
             <span style={{ flexGrow: 1 }}>
-                {mining ? 'Stop Mining' : 'Start Mining'}
+                {isMining && isHashRatePresent ? 'Stop Mining' : 'Start Mining'}
             </span>
         </StyledButton>
     );

--- a/src/hooks/useMining.ts
+++ b/src/hooks/useMining.ts
@@ -1,46 +1,80 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
 import { useUIStore } from '../store/useUIStore';
 import { setStart, setStop, setRestart } from '../visuals';
+import { useAppStatusStore } from '../store/useAppStatusStore';
 
 export function useMining() {
-    const setIsLoading = useUIStore((s) => s.setIsMiningLoading);
+    const isMiningEnabled = useAppStatusStore((s) => s.cpu?.is_mining_enabled);
+    const isMining = useAppStatusStore((s) => s.cpu?.is_mining);
+    const isMiningSwitchingState = useUIStore((s) => s.isMiningSwitchingState);
+
+    const setIsMiningSwitchingState = useUIStore(
+        (s) => s.setIsMiningSwitchingState
+    );
     const setBackground = useUIStore((s) => s.setBackground);
-    const hasStarted = useRef(false);
+
+    const isMiningAnimationRunning = useRef(false);
+    const hasMiningStartedAtLeastOnce = useRef(false);
+
+    useEffect(() => {
+        if (isMiningSwitchingState) return;
+
+        if (isMiningEnabled && isMining) {
+            if (!isMiningAnimationRunning.current) {
+                setStart();
+                isMiningAnimationRunning.current = true;
+                hasMiningStartedAtLeastOnce.current = true;
+            } else {
+                setRestart();
+            }
+            setBackground('mining');
+            return;
+        }
+
+        if (!isMiningEnabled) {
+            if (isMiningAnimationRunning.current) {
+                setBackground('idle');
+                setStop();
+                isMiningAnimationRunning.current = false;
+            }
+            return;
+        }
+    }, [isMiningEnabled, isMining, isMiningSwitchingState]);
 
     const startMining = useCallback(async () => {
-        setIsLoading(true);
+        setIsMiningSwitchingState(true);
         try {
             await invoke('start_mining', {});
         } catch (e) {
             console.error('Could not start mining', e);
         } finally {
-            setIsLoading(false);
-            setBackground('mining');
-            if (!hasStarted.current) {
-                hasStarted.current = true;
-                setStart();
-            } else {
-                setRestart();
-            }
+            setIsMiningSwitchingState(false);
         }
-    }, [setIsLoading, setIsLoading]);
+    }, []);
 
     const stopMining = useCallback(async () => {
-        setIsLoading(true);
+        setIsMiningSwitchingState(true);
         try {
             await invoke('stop_mining', {});
-            setStop();
         } catch (e) {
             console.error('Could not stop mining', e);
         } finally {
-            setIsLoading(false);
-            setBackground('idle');
+            setIsMiningSwitchingState(false);
         }
-    }, [setIsLoading, setIsLoading]);
+    }, []);
+
+    const shouldDisplayLoading =
+        isMiningSwitchingState || (!isMining && isMiningEnabled);
+
+    const hasMiningBeenStopped =
+        hasMiningStartedAtLeastOnce.current && !isMiningEnabled;
 
     return {
         startMining,
         stopMining,
+        shouldDisplayLoading,
+        isMining,
+        hasMiningBeenStopped,
     };
 }

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -6,14 +6,16 @@ interface State {
     view: viewType;
     visualMode: boolean;
     sidebarOpen: boolean;
-    isMiningLoading: boolean;
+    isMiningSwitchingState: boolean;
 }
 interface Actions {
     setBackground: (background: State['background']) => void;
     setView: (view: State['view']) => void;
     setVisualMode: (visualMode: State['visualMode']) => void;
     setSidebarOpen: (sidebarOpen: State['sidebarOpen']) => void;
-    setIsMiningLoading: (isMiningLoading: State['isMiningLoading']) => void;
+    setIsMiningSwitchingState: (
+        isMiningSwitchingState: State['isMiningSwitchingState']
+    ) => void;
 }
 
 type UIStoreState = State & Actions;
@@ -23,7 +25,7 @@ const initialState: State = {
     view: 'setup',
     visualMode: true,
     sidebarOpen: false,
-    isMiningLoading: false,
+    isMiningSwitchingState: false,
 };
 
 export const useUIStore = create<UIStoreState>()((set) => ({
@@ -32,5 +34,6 @@ export const useUIStore = create<UIStoreState>()((set) => ({
     setView: (view) => set({ view }),
     setVisualMode: (visualMode) => set({ visualMode }),
     setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
-    setIsMiningLoading: (isMiningLoading) => set({ isMiningLoading }),
+    setIsMiningSwitchingState: (isMiningSwitchingState) =>
+        set({ isMiningSwitchingState }),
 }));

--- a/src/types/app-status.ts
+++ b/src/types/app-status.ts
@@ -11,6 +11,7 @@ export interface AppStatus {
 }
 
 export interface CpuMinerStatus {
+    is_mining_enabled: boolean;
     is_mining: boolean;
     hash_rate: number;
     cpu_usage: number;


### PR DESCRIPTION
Description
---
- Move mm_proxy start to startup process
- Change how mining state is detected to include valid hash_rate
- Improve loading display on mining button
- After user starts mining and stop, button will show "Resume mining" instead "Start Mining" which fits with blocks in background that stop moving

Motivation and Context
---
Currently when user click "Start mining button" it start mm_proxy before actual mining take place and it takes some time which can cause bad experience for users 


How Has This Been Tested?
Manually
---

What process can a PR reviewer use to test or verify this change?
---
Open application and start mining

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
