### PR TITLE
fix(modes): restart mining when mode changed

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,11 +57,13 @@ mod setup_status_event;
 #[tauri::command]
 async fn set_mode<'r>(
     mode: String,
-    _window: tauri::Window,
+    window: tauri::Window,
     state: tauri::State<'r, UniverseAppState>,
-    _app: tauri::AppHandle,
+    app: tauri::AppHandle,
 ) -> Result<(), String> {
+    let _ = stop_mining(state.clone()).await;
     let _ = state.config.write().await.set_mode(mode).await;
+    let _ = start_mining(window, state.clone(), app).await;
 
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,9 +61,16 @@ async fn set_mode<'r>(
     state: tauri::State<'r, UniverseAppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    let _ = stop_mining(state.clone()).await;
-    let _ = state.config.write().await.set_mode(mode).await;
-    let _ = start_mining(window, state.clone(), app).await;
+    match stop_mining(state.clone()).await {
+        Ok(_) => {
+            let _ = state.config.write().await.set_mode(mode).await;
+            match start_mining(window, state.clone(), app).await {
+                Ok(_) => {}
+                Err(e) => warn!(target: LOG_TARGET, "Failed to start mining: {}", e.to_string()),
+            };
+        }
+        Err(e) => warn!(target: LOG_TARGET, "Failed to stop mining: {}", e.to_string()),
+    };
 
     Ok(())
 }

--- a/src/containers/SideBar/Miner/components/ModeSelect.tsx
+++ b/src/containers/SideBar/Miner/components/ModeSelect.tsx
@@ -8,6 +8,7 @@ import { Typography } from '@mui/material';
 import { TileItem } from '../styles';
 import { useAppStatusStore } from '@app/store/useAppStatusStore.ts';
 import { Theme, useTheme } from '@mui/material/styles';
+import { useUIStore } from '@app/store/useUIStore';
 
 const CustomSelect = styled(Select)(({ theme }: { theme: Theme }) => ({
     '& .MuiSelect-select': {
@@ -25,8 +26,10 @@ const CustomSelect = styled(Select)(({ theme }: { theme: Theme }) => ({
 function ModeSelect() {
     const mode = useAppStatusStore((s) => s.mode);
     const setConfigMode = useAppStatusStore((s) => s.setConfigMode);
-
+    const setMiningInitiated = useUIStore((s) => s.setMiningInitiated);
+    
     const handleChange = (event: SelectChangeEvent<unknown>) => {
+        setMiningInitiated(true);
         setConfigMode(event.target.value as modeType);
     };
     const theme = useTheme();


### PR DESCRIPTION
Description
---
Mode change had no implication on the running mining process. We need to restart mining.

Motivation and Context
---

How Has This Been Tested?
---
Manually, unfortunately I'm not able to attach screen recording since it does not work on my local along with mining

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
