### PR TITLE
feat: implement better caching for applications versions

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -131,7 +131,7 @@ async fn setup_inner<'r>(
     if now
         .duration_since(last_binaries_update_timestamp)
         .unwrap_or(Duration::from_secs(0))
-        > Duration::from_secs(60 * 60 * 24)
+        > Duration::from_secs(60 * 60 * 6)
     {
         state
             .config

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,10 +40,9 @@ use node_manager::NodeManagerError;
 use progress_tracker::ProgressTracker;
 use serde::Serialize;
 use setup_status_event::SetupStatusEvent;
-use std::ops::DerefMut;
 use std::sync::Arc;
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use std::{panic, process};
 use tari_common_types::tari_address::TariAddress;
 use tari_core::transactions::tari_amount::MicroMinotari;
@@ -116,34 +115,64 @@ async fn setup_inner<'r>(
 
     let progress = ProgressTracker::new(window.clone());
 
-    progress.set_max(10).await;
-    progress
-        .update("Checking for latest version of node".to_string(), 0)
-        .await;
-    BinaryResolver::current()
-        .ensure_latest(Binaries::MinotariNode, progress.clone())
-        .await?;
+    let last_binaries_update_timestamp = state.config.read().await.last_binaries_update_timestamp;
+    let now = SystemTime::now();
 
-    progress.set_max(15).await;
-    progress
-        .update("Checking for latest version of mmproxy".to_string(), 0)
+    BinaryResolver::current()
+        .read_current_highest_version(Binaries::MinotariNode)
         .await;
     BinaryResolver::current()
-        .ensure_latest(Binaries::MergeMiningProxy, progress.clone())
-        .await?;
-    progress.set_max(20).await;
-    progress
-        .update("Checking for latest version of wallet".to_string(), 0)
+        .read_current_highest_version(Binaries::MergeMiningProxy)
         .await;
     BinaryResolver::current()
-        .ensure_latest(Binaries::Wallet, progress.clone())
-        .await?;
+        .read_current_highest_version(Binaries::Wallet)
+        .await;
 
-    progress.set_max(30).await;
-    progress
-        .update("Checking for latest version of xmrig".to_string(), 0)
-        .await;
-    XmrigAdapter::ensure_latest(cache_dir, false, progress.clone()).await?;
+    if now
+        .duration_since(last_binaries_update_timestamp)
+        .unwrap_or(Duration::from_secs(0))
+        > Duration::from_secs(60 * 60 * 24)
+    {
+        state
+            .config
+            .write()
+            .await
+            .set_last_binaries_update_timestamp(now)
+            .await?;
+
+        progress.set_max(10).await;
+        progress
+            .update("Checking for latest version of node".to_string(), 0)
+            .await;
+        BinaryResolver::current()
+            .ensure_latest(Binaries::MinotariNode, progress.clone())
+            .await?;
+        sleep(Duration::from_secs(1));
+
+        progress.set_max(15).await;
+        progress
+            .update("Checking for latest version of mmproxy".to_string(), 0)
+            .await;
+        sleep(Duration::from_secs(1));
+        BinaryResolver::current()
+            .ensure_latest(Binaries::MergeMiningProxy, progress.clone())
+            .await?;
+        progress.set_max(20).await;
+        progress
+            .update("Checking for latest version of wallet".to_string(), 0)
+            .await;
+        sleep(Duration::from_secs(1));
+        BinaryResolver::current()
+            .ensure_latest(Binaries::Wallet, progress.clone())
+            .await?;
+
+        progress.set_max(30).await;
+        progress
+            .update("Checking for latest version of xmrig".to_string(), 0)
+            .await;
+        sleep(Duration::from_secs(1));
+        XmrigAdapter::ensure_latest(cache_dir, false, progress.clone()).await?;
+    }
 
     for i in 0..2 {
         match state
@@ -215,12 +244,9 @@ async fn set_auto_mining<'r>(
     state: tauri::State<'r, UniverseAppState>,
 ) -> Result<(), String> {
     let mut config = state.config.write().await;
-    config.set_auto_mining(auto_mining).await;
+    let _ = config.set_auto_mining(auto_mining).await;
     let timeout = config.get_user_inactivity_timeout();
     let mut user_listener = state.user_listener.write().await;
-
-    println!("Auto mining: {}", auto_mining);
-    println!("Timeout: {:?}", timeout);
 
     if auto_mining {
         user_listener.start_listening_to_mouse_poisition_change(timeout, window);
@@ -311,6 +337,8 @@ fn open_log_dir(app: tauri::AppHandle) {
 
 #[tauri::command]
 async fn get_applications_versions(app: tauri::AppHandle) -> Result<ApplicationsVersions, String> {
+    //TODO could be move to status command when XmrigAdapter will be implemented in BinaryResolver
+
     let default_message = "Failed to read version".to_string();
 
     let progress_tracker = ProgressTracker::new(app.get_window("main").unwrap().clone());
@@ -337,6 +365,41 @@ async fn get_applications_versions(app: tauri::AppHandle) -> Result<Applications
         mm_proxy: mm_proxy_version.to_string(),
         wallet: wallet_version.to_string(),
     })
+}
+
+#[tauri::command]
+async fn update_applications(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, UniverseAppState>,
+) -> Result<(), String> {
+    let _ = state
+        .config
+        .write()
+        .await
+        .set_last_binaries_update_timestamp(SystemTime::now())
+        .await;
+    let progress_tracker = ProgressTracker::new(app.get_window("main").unwrap().clone());
+    let cache_dir = app.path_resolver().app_cache_dir().unwrap();
+    XmrigAdapter::ensure_latest(cache_dir, true, progress_tracker.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    sleep(Duration::from_secs(1));
+    BinaryResolver::current()
+        .ensure_latest(Binaries::MinotariNode, progress_tracker.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    sleep(Duration::from_secs(1));
+    BinaryResolver::current()
+        .ensure_latest(Binaries::MergeMiningProxy, progress_tracker.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    sleep(Duration::from_secs(1));
+    BinaryResolver::current()
+        .ensure_latest(Binaries::Wallet, progress_tracker.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    sleep(Duration::from_secs(1));
+    Ok(())
 }
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
@@ -591,7 +654,8 @@ fn main() {
             open_log_dir,
             get_seed_words,
             get_applications_versions,
-            set_user_inactivity_timeout
+            set_user_inactivity_timeout,
+            update_applications
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useGetStatus } from './hooks/useGetStatus.ts';
 
 import { useGetApplicationsVersions } from './hooks/useGetApplicationsVersions.ts';
 import { useSetUp } from './hooks/useSetUp.ts';
+import { useEnvironment } from './hooks/useEnvironment.ts';
 
 function App() {
     useSetUp();
@@ -20,6 +21,7 @@ function App() {
 
     useGetStatus();
     useGetApplicationsVersions();
+    useEnvironment();
 
     return (
         <StrictMode>

--- a/src/containers/SideBar/components/Settings/Settings.tsx
+++ b/src/containers/SideBar/components/Settings/Settings.tsx
@@ -25,6 +25,7 @@ import { useHardwareStatus } from '@app/hooks/useHardwareStatus.ts';
 import { CardComponent } from './Card.component.tsx';
 import { ControlledNumberInput } from '@app/components/NumberInput/NumberInput.component.tsx';
 import { useForm } from 'react-hook-form';
+import { Environment, useEnvironment } from '@app/hooks/useEnvironment.ts';
 
 enum FormFields {
     IDLE_TIMEOUT = 'idleTimeout',
@@ -35,6 +36,8 @@ interface FormState {
 }
 
 const Settings: React.FC = () => {
+    const currentEnvironment = useEnvironment();
+
     const mainAppVersion = useAppStatusStore((state) => state.main_app_version);
     const userInActivityTimeout = useAppStatusStore((state) => state.user_inactivity_timeout);
     const { getApplicationsVersions, applicationsVersions } = useGetApplicationsVersions();
@@ -198,6 +201,11 @@ const Settings: React.FC = () => {
                                 <HorisontalBox>
                                     <Typography variant="h6">Versions</Typography>
                                     <RightHandColumn>
+                                        {currentEnvironment === Environment.Development && (
+                                            <Button onClick={getApplicationsVersions} variant="text">
+                                                Update Versions
+                                            </Button>
+                                        )}
                                         <Button onClick={getApplicationsVersions} variant="text">
                                             Refresh Versions
                                         </Button>

--- a/src/hooks/useEnvironment.ts
+++ b/src/hooks/useEnvironment.ts
@@ -1,0 +1,9 @@
+export enum Environment {
+    Development = 'development',
+    Production = 'production',
+}
+
+export const useEnvironment = () => {
+    if (window.location.host.startsWith('localhost:')) return Environment.Development;
+    return Environment.Production;
+};

--- a/src/hooks/useGetApplicationsVersions.ts
+++ b/src/hooks/useGetApplicationsVersions.ts
@@ -1,7 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { useAppStatusStore } from '../store/useAppStatusStore';
 import { invoke } from '@tauri-apps/api';
-import { ApplicationsVersions } from '../types/app-status';
 import { getVersion } from '@tauri-apps/api/app';
 
 export const useGetApplicationsVersions = () => {
@@ -11,7 +10,7 @@ export const useGetApplicationsVersions = () => {
     const mainAppVersion = useAppStatusStore((state) => state.main_app_version);
     const setMainAppVersion = useAppStatusStore((state) => state.setMainAppVersion);
     const getApplicationsVersions = useCallback(async () => {
-        invoke<ApplicationsVersions>('get_applications_versions')
+        invoke('get_applications_versions')
             .then((applicationsVersions) => {
                 setApplicationsVersions(applicationsVersions);
             })
@@ -42,5 +41,15 @@ export const useGetApplicationsVersions = () => {
         };
     }, [applicationsVersions, getApplicationsVersions]);
 
-    return { applicationsVersions, getApplicationsVersions };
+    const updateApplicationsVersions = useCallback(() => {
+        invoke('update_applications')
+            .then((_) => {
+                getApplicationsVersions();
+            })
+            .catch((error) => {
+                console.error('Error updating applications versions', error);
+            });
+    }, [getApplicationsVersions]);
+
+    return { applicationsVersions, getApplicationsVersions, updateApplicationsVersions };
 };

--- a/src/hooks/useGetSeedWords.ts
+++ b/src/hooks/useGetSeedWords.ts
@@ -8,7 +8,7 @@ export function useGetSeedWords() {
     const getSeedWords = useCallback(async () => {
         setSeedWordsFetching(true);
         try {
-            const seedWords = await invoke('get_seed_words') as string[];
+            const seedWords = await invoke('get_seed_words');
             setSeedWords(seedWords);
         } catch (e) {
             console.error('Could not get seed words', e);

--- a/src/store/useAppStatusStore.ts
+++ b/src/store/useAppStatusStore.ts
@@ -33,7 +33,7 @@ export const useAppStatusStore = create<AppStatusStoreState>()(
             setApplicationsVersions: (applications_versions) => set({ applications_versions }),
             setMainAppVersion: (main_app_version) => set({ main_app_version }),
             setMode: (mode) => set({ mode }),
-            setConfigMode: async (mode: modeType) => {
+            setConfigMode: async (mode) => {
                 try {
                     await invoke('set_mode', { mode });
                     set({ mode });

--- a/src/types/invoke.ts
+++ b/src/types/invoke.ts
@@ -1,4 +1,5 @@
-import { AppStatus } from './app-status';
+import { modeType } from '@app/store/types';
+import { ApplicationsVersions, AppStatus } from './app-status';
 
 declare module '@tauri-apps/api/tauri' {
     function invoke(param: 'setup_application'): Promise<void>;
@@ -6,12 +7,10 @@ declare module '@tauri-apps/api/tauri' {
     function invoke(param: 'status'): Promise<AppStatus>;
     function invoke(param: 'start_mining'): Promise<void>;
     function invoke(param: 'stop_mining'): Promise<void>;
-    function invoke(
-        param: 'set_auto_mining',
-        payload: { autoMining: boolean }
-    ): Promise<void>;
-    function invoke(
-        param: 'set_user_inactivity_timeout',
-        payload: { timeout: number }
-    ): Promise<void>;
+    function invoke(param: 'set_auto_mining', payload: { autoMining: boolean }): Promise<void>;
+    function invoke(param: 'set_user_inactivity_timeout', payload: { timeout: number }): Promise<void>;
+    function invoke(param: 'update_applications'): Promise<void>;
+    function invoke(param: 'set_mode', payload: { mode: modeType }): Promise<void>;
+    function invoke(param: 'get_seed_words'): Promise<string[]>;
+    function invoke(param: 'get_applications_versions'): Promise<ApplicationsVersions>;
 }


### PR DESCRIPTION
Description
---

-  Added 6h period for calling to github for newest version of application during app startup
-  Added temporary method for loading versions data from cache folder
-  Added hook for checking app Environment
-  Added button in settings for dev Environment for forcing check and download of newest versions 

Motivation and Context
---
Currently when application was started many times in short span of time it would hit rate limit for github api

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
