### PR TITLE
feat(ui): display syncing progress for minotari node during initialization

### DIFF
--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -276,7 +276,11 @@ impl BinaryResolver {
         Ok(latest_release.version)
     }
 
-    pub async fn read_current_highest_version(&self, binary: Binaries,progress_tracker: ProgressTracker,) -> Result<Version, Error> {
+    pub async fn read_current_highest_version(
+        &self,
+        binary: Binaries,
+        progress_tracker: ProgressTracker,
+    ) -> Result<Version, Error> {
         let adapter = self
             .adapters
             .get(&binary)
@@ -284,14 +288,12 @@ impl BinaryResolver {
         let bin_folder = adapter.get_binary_folder();
         let version_folders_list = match std::fs::read_dir(&bin_folder) {
             Ok(list) => list,
-            Err(_) => {
-                match std::fs::create_dir_all(&bin_folder) {
-                    Ok(_) =>  std::fs::read_dir(&bin_folder).unwrap(),
-                    Err(e) => {
-                        return Err(anyhow!("Failed to create dir: {}", e));
-                    }
+            Err(_) => match std::fs::create_dir_all(&bin_folder) {
+                Ok(_) => std::fs::read_dir(&bin_folder).unwrap(),
+                Err(e) => {
+                    return Err(anyhow!("Failed to create dir: {}", e));
                 }
-            }
+            },
         };
         let mut versions = vec![];
         for entry in version_folders_list {
@@ -307,7 +309,10 @@ impl BinaryResolver {
         }
 
         if versions.is_empty() {
-            match self.ensure_latest_inner(binary, true, progress_tracker).await {
+            match self
+                .ensure_latest_inner(binary, true, progress_tracker)
+                .await
+            {
                 Ok(version) => {
                     self.latest_versions
                         .write()
@@ -332,7 +337,7 @@ impl BinaryResolver {
             .await
             .insert(binary, highest_version.clone());
 
-        Ok(highest_version.clone()) 
+        Ok(highest_version.clone())
     }
 
     pub async fn get_latest_version(&self, binary: Binaries) -> Version {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,13 +130,13 @@ async fn setup_inner<'r>(
     let now = SystemTime::now();
 
     BinaryResolver::current()
-        .read_current_highest_version(Binaries::MinotariNode,progress.clone())
+        .read_current_highest_version(Binaries::MinotariNode, progress.clone())
         .await?;
     BinaryResolver::current()
-        .read_current_highest_version(Binaries::MergeMiningProxy,progress.clone())
+        .read_current_highest_version(Binaries::MergeMiningProxy, progress.clone())
         .await?;
     BinaryResolver::current()
-        .read_current_highest_version(Binaries::Wallet,progress.clone())
+        .read_current_highest_version(Binaries::Wallet, progress.clone())
         .await?;
 
     if now

--- a/src-tauri/src/progress_tracker.rs
+++ b/src-tauri/src/progress_tracker.rs
@@ -62,9 +62,9 @@ impl ProgressTrackerInner {
             SetupStatusEvent {
                 event_type: "setup_status".to_string(),
                 title,
-                progress: (self.min
-                    + ((self.next_max - self.min) as f64 * (progress as f64 / 100.0)) as u64)
-                    as f64
+                progress: ((self.min
+                    + ((((self.next_max - self.min) as f64) * ((progress as f64) / 100.0)) as u64))
+                    as f64)
                     / 100.0,
             },
         );


### PR DESCRIPTION
Description
---
Use `get_sync_progress` call to get current block height and store last 10 results to calculate syncing speed. Display those values and calculated how much of this task is done in percentage. 

Motivation and Context
---
Syncing blocks make take a lot of time (even 20 minutes). During this time user have no idea if something went wrong and is stuck or it's supposed to work like that.

How Has This Been Tested?
---
Tested manually. Wait a bit to have local node out of date state and at start up it will sync.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
