### PR TITLE
fix(ui): add block height delay after animations and set up background

### DIFF
--- a/src/containers/Dashboard/Dashboard.tsx
+++ b/src/containers/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { DashboardContainer } from './styles';
+import { DashboardContainer, SetupGradient } from './styles';
 import MiningView from './MiningView/MiningView';
 import TribesView from './TribesView/TribesView';
 import { viewType } from '../../store/types';
@@ -8,7 +8,12 @@ function Dashboard({ status }: { status: viewType }) {
     const viewMarkup =
         status == 'setup' ? <SetupViewContainer /> : status == 'tribes' ? <TribesView /> : <MiningView />;
 
-    return <DashboardContainer>{viewMarkup}</DashboardContainer>;
+    return (
+        <DashboardContainer>
+            {status == 'setup' ? <SetupGradient /> : null}
+            {viewMarkup}
+        </DashboardContainer>
+    );
 }
 
 export default Dashboard;

--- a/src/containers/Dashboard/MiningView/components/Earnings.tsx
+++ b/src/containers/Dashboard/MiningView/components/Earnings.tsx
@@ -29,10 +29,12 @@ const variants = {
 export default function Earnings() {
     const earnings = useMiningStore((s) => s.earnings);
     const setEarnings = useMiningStore((s) => s.setEarnings);
+    const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
     const formatted = formatBalance(earnings || 0);
     const handleComplete = useCallback(() => {
         setEarnings(undefined);
-    }, [setEarnings]);
+        setPostBlockAnimation(true);
+    }, [setEarnings, setPostBlockAnimation]);
 
     return (
         <EarningsContainer>

--- a/src/containers/Dashboard/SetupView/SetupView.tsx
+++ b/src/containers/Dashboard/SetupView/SetupView.tsx
@@ -4,7 +4,7 @@ import { StyledLinearProgress, ProgressBox, SetupDescription, SetupPercentage } 
 
 function SetupView({ title, progressPercentage }: { title: string; progressPercentage: number }) {
     return (
-        <Stack spacing={0} alignItems="center" marginBottom={5}>
+        <Stack spacing={0} alignItems="center" sx={{ position: 'relative', zIndex: '1' }}>
             <img src={setup} alt="Setup" style={{ maxWidth: '260px', height: 'auto' }} />
             <Typography variant="h3" fontSize={21} mt={3.4}>
                 Setting up the Tari truth machine...

--- a/src/containers/Dashboard/styles.ts
+++ b/src/containers/Dashboard/styles.ts
@@ -9,6 +9,8 @@ export const DashboardContainer = styled(Box)(() => ({
     justifyContent: 'center',
     height: '100%',
     flexGrow: '1',
+    position: 'relative',
+    zIndex: '1',
 }));
 
 export const ProgressBox = styled(Box)(() => ({
@@ -62,3 +64,11 @@ export const SetupPercentage = styled(Typography)(({ theme }) => ({
     fontSize: '15px',
     textAlign: 'center',
 }));
+
+export const SetupGradient = styled('div')`
+    position: absolute;
+    z-index: 0;
+    background-image: radial-gradient(circle 500px at 50% 100%, rgb(255, 255, 255, 1), rgba(255, 255, 255, 0));
+    width: 100%;
+    height: 100vh;
+`;

--- a/src/containers/Dashboard/styles.ts
+++ b/src/containers/Dashboard/styles.ts
@@ -68,7 +68,7 @@ export const SetupPercentage = styled(Typography)(({ theme }) => ({
 export const SetupGradient = styled('div')`
     position: absolute;
     z-index: 0;
-    background-image: radial-gradient(circle 500px at 50% 100%, rgb(255, 255, 255, 1), rgba(255, 255, 255, 0));
+    background-image: radial-gradient(circle 1000px at 50% 100%, rgb(255, 255, 255, 1), rgba(255, 255, 255, 0));
     width: 100%;
     height: 100vh;
 `;

--- a/src/hooks/mining/useBalanceInfo.ts
+++ b/src/hooks/mining/useBalanceInfo.ts
@@ -15,8 +15,10 @@ export default function useBalanceInfo() {
     const setDisplayBlockHeight = useMiningStore((s) => s.setDisplayBlockHeight);
     const block_height = useBaseNodeStatusStore((s) => s.block_height);
     const toggleTimerPaused = useMiningStore((s) => s.toggleTimerPaused);
-    const blockHeightRef = useRef(block_height);
+    const postBlockAnimation = useMiningStore((s) => s.postBlockAnimation);
+    const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
 
+    const blockHeightRef = useRef(block_height);
     const prevBalanceRef = useRef(previousBalance);
 
     const handleEarnings = useCallback(() => {
@@ -38,19 +40,31 @@ export default function useBalanceInfo() {
     }, [previousBalance, block_height]);
 
     useEffect(() => {
-        console.debug('block refs: ', block_height, blockHeightRef.current, balanceChangeBlock);
         if ((block_height && block_height !== blockHeightRef.current) || !!balanceChangeBlock) {
             const timer = balanceChangeBlock === block_height ? 1 : TIMER_VALUE;
             const timeout = setTimeout(() => {
                 handleEarnings();
                 setBalanceChangeBlock(null);
                 blockHeightRef.current = block_height;
-                setDisplayBlockHeight(blockHeightRef.current);
             }, timer);
 
             return () => {
                 clearTimeout(timeout);
             };
         }
-    }, [balanceChangeBlock, block_height, handleEarnings, setDisplayBlockHeight]);
+    }, [balanceChangeBlock, block_height, handleEarnings]);
+
+    useEffect(() => {
+        if (postBlockAnimation) {
+            const blockTimeout = setTimeout(() => {
+                setDisplayBlockHeight(blockHeightRef.current);
+
+                setPostBlockAnimation(false);
+            }, 1500);
+
+            return () => {
+                clearTimeout(blockTimeout);
+            };
+        }
+    }, [postBlockAnimation, setDisplayBlockHeight, setPostBlockAnimation]);
 }

--- a/src/hooks/mining/useVisualisation.ts
+++ b/src/hooks/mining/useVisualisation.ts
@@ -5,11 +5,16 @@ import { useMiningStore } from '@app/store/useMiningStore.ts';
 
 export function useVisualisation() {
     const toggleTimerPaused = useMiningStore((s) => s.toggleTimerPaused);
+    const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
     return useCallback(
         (state: GlAppState) => {
             setAnimationState(state);
+
+            if (state === 'fail') {
+                setPostBlockAnimation(true);
+            }
             toggleTimerPaused({ pause: false });
         },
-        [toggleTimerPaused]
+        [setPostBlockAnimation, toggleTimerPaused]
     );
 }

--- a/src/store/useMiningStore.ts
+++ b/src/store/useMiningStore.ts
@@ -6,12 +6,14 @@ interface State {
     blockTime?: BlockTimeData;
     displayBlockHeight?: number;
     earnings?: number;
+    postBlockAnimation?: boolean;
     timerPaused?: boolean;
 }
 interface Actions {
     setBlockTime: (blockTime: BlockTimeData) => void;
     setDisplayBlockHeight: (displayBlockHeight: number) => void;
     setEarnings: (earnings?: number) => void;
+    setPostBlockAnimation: (postBlockAnimation: boolean) => void;
     toggleTimerPaused: ({ pause }: { pause?: boolean }) => void;
 }
 type MiningStoreState = State & Actions;
@@ -19,6 +21,7 @@ type MiningStoreState = State & Actions;
 const initialState: State = {
     displayBlockHeight: undefined,
     timerPaused: false,
+    postBlockAnimation: false,
 };
 
 export const useMiningStore = create<MiningStoreState>()(
@@ -28,6 +31,7 @@ export const useMiningStore = create<MiningStoreState>()(
             setBlockTime: (blockTime) => set({ blockTime }),
             setDisplayBlockHeight: (displayBlockHeight) => set({ displayBlockHeight }),
             setEarnings: (earnings) => set({ earnings }),
+            setPostBlockAnimation: (postBlockAnimation) => set({ postBlockAnimation }),
             toggleTimerPaused: ({ pause }) =>
                 set((state) => ({ timerPaused: pause !== undefined ? pause : !state.timerPaused })),
         }),


### PR DESCRIPTION
Description
---
- added gradient opacity bg to setup screen so you can read the status better
- added flag for animation completed before updating block height

Motivation and Context
---


How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<img width="732" alt="image" src="https://github.com/user-attachments/assets/bb1e5912-63c0-4062-860c-11e72084952b">


https://github.com/user-attachments/assets/2c4739d5-b7a2-4cd3-8d7f-8dc5ce447af3





<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
