### PR TITLE
fix(ui): sync display height and time timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,30 +67,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
-            "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-            "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.9",
-                "@babel/helper-compilation-targets": "^7.24.8",
-                "@babel/helper-module-transforms": "^7.24.9",
-                "@babel/helpers": "^7.24.8",
-                "@babel/parser": "^7.24.8",
-                "@babel/template": "^7.24.7",
-                "@babel/traverse": "^7.24.8",
-                "@babel/types": "^7.24.9",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -105,12 +105,27 @@
                 "url": "https://opencollective.com/babel"
             }
         },
+        "node_modules/@babel/core/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
-            "version": "7.24.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
-            "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+            "version": "7.25.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+            "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
             "dependencies": {
-                "@babel/types": "^7.24.9",
+                "@babel/types": "^7.25.4",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -120,12 +135,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
-            "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+            "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.24.8",
+                "@babel/compat-data": "^7.25.2",
                 "@babel/helper-validator-option": "^7.24.8",
                 "browserslist": "^4.23.1",
                 "lru-cache": "^5.1.1",
@@ -135,38 +150,13 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-            "dependencies": {
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-            "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-            "dependencies": {
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-module-imports": {
@@ -182,16 +172,15 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
-            "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+            "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.7",
                 "@babel/helper-module-imports": "^7.24.7",
                 "@babel/helper-simple-access": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7"
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/traverse": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -216,17 +205,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-            "dependencies": {
                 "@babel/types": "^7.24.7"
             },
             "engines": {
@@ -259,13 +237,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-            "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+            "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.8"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -286,9 +264,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
-            "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+            "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+            "dependencies": {
+                "@babel/types": "^7.25.4"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -327,9 +308,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-            "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
+            "integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -338,31 +319,28 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+            "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/parser": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
-            "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+            "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.8",
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-hoist-variables": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/parser": "^7.24.8",
-                "@babel/types": "^7.24.8",
+                "@babel/generator": "^7.25.4",
+                "@babel/parser": "^7.25.4",
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.4",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -379,9 +357,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.9",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
-            "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+            "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.24.8",
                 "@babel/helper-validator-identifier": "^7.24.7",
@@ -407,22 +385,6 @@
                 "find-root": "^1.1.0",
                 "source-map": "^0.5.7",
                 "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@emotion/cache": {
@@ -923,18 +885,6 @@
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
             }
         },
-        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.11.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
@@ -945,9 +895,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
-            "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
             "dev": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.4",
@@ -956,6 +906,28 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -981,6 +953,16 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -993,10 +975,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@eslint/js": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
-            "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
+            "version": "9.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.1.tgz",
+            "integrity": "sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1623,9 +1617,9 @@
             }
         },
         "node_modules/@tauri-apps/cli": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.6.0.tgz",
-            "integrity": "sha512-DBBpBl6GhTzm8ImMbKkfaZ4fDTykWrC7Q5OXP4XqD91recmDEn2LExuvuiiS3HYe7uP8Eb5B9NPHhqJb+Zo7qQ==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.6.1.tgz",
+            "integrity": "sha512-2S8WGmkz54Z9WxpaFVbUYsTiwx5OIEmdD5DDWRygX9VhaWwZg0y6DctsUtCRVre9I/Un/hTnmqkhZqPamCEx8A==",
             "dev": true,
             "bin": {
                 "tauri": "tauri.js"
@@ -1638,22 +1632,22 @@
                 "url": "https://opencollective.com/tauri"
             },
             "optionalDependencies": {
-                "@tauri-apps/cli-darwin-arm64": "1.6.0",
-                "@tauri-apps/cli-darwin-x64": "1.6.0",
-                "@tauri-apps/cli-linux-arm-gnueabihf": "1.6.0",
-                "@tauri-apps/cli-linux-arm64-gnu": "1.6.0",
-                "@tauri-apps/cli-linux-arm64-musl": "1.6.0",
-                "@tauri-apps/cli-linux-x64-gnu": "1.6.0",
-                "@tauri-apps/cli-linux-x64-musl": "1.6.0",
-                "@tauri-apps/cli-win32-arm64-msvc": "1.6.0",
-                "@tauri-apps/cli-win32-ia32-msvc": "1.6.0",
-                "@tauri-apps/cli-win32-x64-msvc": "1.6.0"
+                "@tauri-apps/cli-darwin-arm64": "1.6.1",
+                "@tauri-apps/cli-darwin-x64": "1.6.1",
+                "@tauri-apps/cli-linux-arm-gnueabihf": "1.6.1",
+                "@tauri-apps/cli-linux-arm64-gnu": "1.6.1",
+                "@tauri-apps/cli-linux-arm64-musl": "1.6.1",
+                "@tauri-apps/cli-linux-x64-gnu": "1.6.1",
+                "@tauri-apps/cli-linux-x64-musl": "1.6.1",
+                "@tauri-apps/cli-win32-arm64-msvc": "1.6.1",
+                "@tauri-apps/cli-win32-ia32-msvc": "1.6.1",
+                "@tauri-apps/cli-win32-x64-msvc": "1.6.1"
             }
         },
         "node_modules/@tauri-apps/cli-darwin-arm64": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.6.0.tgz",
-            "integrity": "sha512-SNRwUD9nqGxY47mbY1CGTt/jqyQOU7Ps7Mx/mpgahL0FVUDiCEY/5L9QfEPPhEgccgcelEVn7i6aQHIkHyUtCA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.6.1.tgz",
+            "integrity": "sha512-n+16Z9qQksBmY55Xwful8GGrw2dlyeqKPsjuNcwKUgVB5a4gIq6K6uUsbhwMUMUA3gqewQMBn44QXbSe5qNKfA==",
             "cpu": [
                 "arm64"
             ],
@@ -1667,9 +1661,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-darwin-x64": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.6.0.tgz",
-            "integrity": "sha512-g2/uDR/eeH2arvuawA4WwaEOqv/7jDO/ZLNI3JlBjP5Pk8GGb3Kdy0ro1xQzF94mtk2mOnOXa4dMgAet4sUJ1A==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.6.1.tgz",
+            "integrity": "sha512-OHzm6qiywv0GEwBDowlzLSuztKE85NMxp2loVynQ4vDoVk6V0jMtQy/N9YvYA0BetvfNTuuAiz3hsTkMHMYm+g==",
             "cpu": [
                 "x64"
             ],
@@ -1683,9 +1677,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.6.0.tgz",
-            "integrity": "sha512-EVwf4oRkQyG8BpSrk0gqO7oA0sDM2MdNDtJpMfleYFEgCxLIOGZKNqaOW3M7U+0Y4qikmG3TtRK+ngc8Ymtrjg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.6.1.tgz",
+            "integrity": "sha512-ZA4ByaiZbrXUbhaoWUVab4lHI2yI1/ucrRO6b9pky6ytgqx37hA/YOWoctD0yaf5giQJQZw160euaBIUOKzRXA==",
             "cpu": [
                 "arm"
             ],
@@ -1699,9 +1693,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.6.0.tgz",
-            "integrity": "sha512-YdpY17cAySrhK9dX4BUVEmhAxE2o+6skIEFg8iN/xrDwRxhaNPI9I80YXPatUTX54Kx55T5++25VJG9+3iw83A==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.6.1.tgz",
+            "integrity": "sha512-VBU4GRJPU9jzzeqaEGLHAJzqQhpl7WnRFyHPR8Qby0D17av3CClJ7nBa+CI3ob3JbIERfJM9kwFHdY9eQpfxnw==",
             "cpu": [
                 "arm64"
             ],
@@ -1715,9 +1709,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.0.tgz",
-            "integrity": "sha512-4U628tuf2U8pMr4tIBJhEkrFwt+46dwhXrDlpdyWSZtnop5RJAVKHODm0KbWns4xGKfTW1F3r6sSv+2ZxLcISA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.1.tgz",
+            "integrity": "sha512-gyMgNZ8fwQFYzrIiHwhmKECkbuAZtzsRyl+bi1Ua11XVWYVUpY8+cNp7Y5ilMJ9AwNFI/HFKjzzua9r+e9FNzw==",
             "cpu": [
                 "arm64"
             ],
@@ -1731,9 +1725,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.6.0.tgz",
-            "integrity": "sha512-AKRzp76fVUaJyXj5KRJT9bJyhwZyUnRQU0RqIRqOtZCT5yr6qGP8rjtQ7YhCIzWrseBlOllc3Qvbgw3Yl0VQcA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.6.1.tgz",
+            "integrity": "sha512-aYLjLXEBcOf4GUrLBZRQcoLSL3KgCKHwfAyGmTilH4juAw42ZaAYWIZwa59hp2kC4w1XrlmwAzGpi1RESBr5Mw==",
             "cpu": [
                 "x64"
             ],
@@ -1747,9 +1741,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-linux-x64-musl": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.0.tgz",
-            "integrity": "sha512-0edIdq6aMBTaRMIXddHfyAFL361JqulLLd2Wi2aoOie7DkQ2MYh6gv3hA7NB9gqFwNIGE+xtJ4BkXIP2tSGPlg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.1.tgz",
+            "integrity": "sha512-j1M7ovICUrBDbrH8CNUwbMe0zk0/IAR7MXRv5PEanktAZ1w/LG3nlO/AhY5/Cbqqo3ziKTcMpe6x0j3aE8jYOA==",
             "cpu": [
                 "x64"
             ],
@@ -1763,9 +1757,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-1.6.0.tgz",
-            "integrity": "sha512-QwWpWk4ubcwJ1rljsRAmINgB2AwkyzZhpYbalA+MmzyYMREcdXWGkyixWbRZgqc6fEWEBmq5UG73qz5eBJiIKg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-1.6.1.tgz",
+            "integrity": "sha512-yCGT1jXHvZtu+yYPDmDOJDfgsj5EKdBPvya+kmN03BmLfOF+8EWHA9s6yXUdk9pSr6M9OQS0SXocbGDOu5AkMw==",
             "cpu": [
                 "arm64"
             ],
@@ -1779,9 +1773,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.6.0.tgz",
-            "integrity": "sha512-Vtw0yxO9+aEFuhuxQ57ALG43tjECopRimRuKGbtZYDCriB/ty5TrT3QWMdy0dxBkpDTu3Rqsz30sbDzw6tlP3Q==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.6.1.tgz",
+            "integrity": "sha512-klAt+KNcczC4gxz9vm6tSvFB4iyXVj4r+TtDVhStLCKkAZOVm0ZsFym1kDzltxrB/3xSjgzsgIiEJydN2cP7xw==",
             "cpu": [
                 "ia32"
             ],
@@ -1795,9 +1789,9 @@
             }
         },
         "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.6.0.tgz",
-            "integrity": "sha512-h54FHOvGi7+LIfRchzgZYSCHB1HDlP599vWXQQJ/XnwJY+6Rwr2E5bOe/EhqoG8rbGkfK0xX3KPAvXPbUlmggg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.6.1.tgz",
+            "integrity": "sha512-WEzQzBgcaqjZoA5M/KOupHmt8W3QQ20vwETXpGEMPd7spj4eZsRv/2ZDuCz4ELbai1XlIsTITFNe2LlJjzqISA==",
             "cpu": [
                 "x64"
             ],
@@ -1852,9 +1846,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-            "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -1920,9 +1914,9 @@
             }
         },
         "node_modules/@types/react-transition-group": {
-            "version": "4.4.10",
-            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-            "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+            "version": "4.4.11",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+            "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -2070,42 +2064,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/utils": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
@@ -2143,18 +2101,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -2414,13 +2360,12 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
@@ -2436,9 +2381,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-            "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
             "dev": true,
             "funding": [
                 {
@@ -2455,9 +2400,9 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001640",
-                "electron-to-chromium": "^1.4.820",
-                "node-releases": "^2.0.14",
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
                 "update-browserslist-db": "^1.1.0"
             },
             "bin": {
@@ -2495,9 +2440,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001642",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
-            "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+            "version": "1.0.30001653",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+            "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
             "dev": true,
             "funding": [
                 {
@@ -2525,6 +2470,14 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/chalk/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/clsx": {
@@ -2555,10 +2508,9 @@
             "dev": true
         },
         "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
@@ -2646,9 +2598,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2735,9 +2687,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.829",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.829.tgz",
-            "integrity": "sha512-5qp1N2POAfW0u1qGAxXEtz6P7bO1m6gpZr5hdf5ve6lxpLM7MpiM4jIPz7xcrNlClQMafbyUDDWjlIQZ1Mw0Rw==",
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
             "dev": true
         },
         "node_modules/error-ex": {
@@ -2954,24 +2906,27 @@
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "engines": {
-                "node": ">=0.8.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
-            "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
+            "version": "9.9.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.1.tgz",
+            "integrity": "sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.11.0",
-                "@eslint/config-array": "^0.17.1",
+                "@eslint/config-array": "^0.18.0",
                 "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.9.0",
+                "@eslint/js": "9.9.1",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.3.0",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3076,6 +3031,28 @@
                 "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
+        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
             "version": "2.0.0-next.5",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -3091,6 +3068,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-scope": {
@@ -3110,12 +3096,12 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -3134,6 +3120,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/eslint/node_modules/chalk": {
@@ -3170,16 +3166,16 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/eslint/node_modules/escape-string-regexp": {
+        "node_modules/eslint/node_modules/eslint-visitor-keys": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/has-flag": {
@@ -3189,6 +3185,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/eslint/node_modules/supports-color": {
@@ -3213,6 +3221,18 @@
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^4.0.0"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+            "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -3391,9 +3411,9 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "11.3.29",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.29.tgz",
-            "integrity": "sha512-uyDuUOeOElJEA3kbkbyoTNEf75Jih1EUg0ouLKYMlGDdt/LaJPmO+FyOGAGxM2HwKhHcAoKFNveR5A8peb7yhw==",
+            "version": "11.3.30",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.30.tgz",
+            "integrity": "sha512-9VmqGe9OIjfMoCcs+ZsKXlv6JaG5QagKX2F1uSbkG3Z33wgjnz60Kw+CngC1M49rDYau+Y9aL+8jGagAwrbVyw==",
             "dependencies": {
                 "tslib": "^2.4.0"
             },
@@ -3683,9 +3703,9 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/ignore": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -3806,9 +3826,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-            "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -4263,9 +4283,9 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
                 "braces": "^3.0.3",
@@ -4276,15 +4296,18 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ms": {
@@ -4317,9 +4340,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.17.tgz",
-            "integrity": "sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==",
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true
         },
         "node_modules/object-assign": {
@@ -4670,9 +4693,9 @@
             }
         },
         "node_modules/react-hook-form": {
-            "version": "7.52.2",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz",
-            "integrity": "sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==",
+            "version": "7.53.0",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+            "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -4901,12 +4924,15 @@
             }
         },
         "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/set-function-length": {
@@ -5200,9 +5226,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
@@ -8,14 +8,19 @@ import {
     RulerMark,
     BlockHeightBg,
 } from './BlockHeight.styles';
+import { useCPUStatusStore } from '@app/store/useCPUStatusStore.ts';
+import { useShallow } from 'zustand/react/shallow';
+import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
 
 function BlockHeight() {
+    const isMining = useCPUStatusStore(useShallow((s) => s.is_mining));
+    const block_height = useBaseNodeStatusStore((s) => s.block_height);
     const displayBlockHeight = useMiningStore((s) => s.displayBlockHeight) ?? 0;
     const formattedBlockHeight = displayBlockHeight.toLocaleString();
-
+    const height = isMining ? displayBlockHeight : block_height;
     const renderRulerMarks = () => {
         const marks = [];
-        let rulerNum = displayBlockHeight;
+        let rulerNum = height;
         for (let i = 0; i < 100; i++) {
             const opacity = i % 5 === 0 ? 1 : 0.2;
             marks.push(

--- a/src/containers/Dashboard/MiningView/components/Earnings.tsx
+++ b/src/containers/Dashboard/MiningView/components/Earnings.tsx
@@ -30,11 +30,13 @@ export default function Earnings() {
     const earnings = useMiningStore((s) => s.earnings);
     const setEarnings = useMiningStore((s) => s.setEarnings);
     const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
+    const setTimerPaused = useMiningStore((s) => s.setTimerPaused);
     const formatted = formatBalance(earnings || 0);
     const handleComplete = useCallback(() => {
         setEarnings(undefined);
         setPostBlockAnimation(true);
-    }, [setEarnings, setPostBlockAnimation]);
+        setTimerPaused(false);
+    }, [setEarnings, setPostBlockAnimation, setTimerPaused]);
 
     return (
         <EarningsContainer>

--- a/src/hooks/mining/useBalanceInfo.ts
+++ b/src/hooks/mining/useBalanceInfo.ts
@@ -14,24 +14,24 @@ export default function useBalanceInfo() {
     const setEarnings = useMiningStore((s) => s.setEarnings);
     const setDisplayBlockHeight = useMiningStore((s) => s.setDisplayBlockHeight);
     const block_height = useBaseNodeStatusStore((s) => s.block_height);
-    const toggleTimerPaused = useMiningStore((s) => s.toggleTimerPaused);
+    const setTimerPaused = useMiningStore((s) => s.setTimerPaused);
     const postBlockAnimation = useMiningStore((s) => s.postBlockAnimation);
     const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
-
+    const timerPaused = useMiningStore((s) => s.timerPaused);
     const blockHeightRef = useRef(block_height);
     const prevBalanceRef = useRef(previousBalance);
 
     const handleEarnings = useCallback(() => {
+        setTimerPaused(true);
         const hasChanges = prevBalanceRef.current !== previousBalance;
         const diff = hasChanges ? balance - previousBalance : 0;
         const hasEarnings = Boolean(diff && diff > 0);
         if (hasEarnings) {
             setEarnings(diff);
         }
-        toggleTimerPaused({ pause: true });
         handleVisual(!hasEarnings ? 'fail' : 'success');
         prevBalanceRef.current = previousBalance;
-    }, [balance, handleVisual, previousBalance, setEarnings, toggleTimerPaused]);
+    }, [balance, handleVisual, previousBalance, setEarnings, setTimerPaused]);
 
     useEffect(() => {
         if (prevBalanceRef.current !== previousBalance) {
@@ -55,16 +55,15 @@ export default function useBalanceInfo() {
     }, [balanceChangeBlock, block_height, handleEarnings]);
 
     useEffect(() => {
-        if (postBlockAnimation) {
+        if (postBlockAnimation && !timerPaused) {
             const blockTimeout = setTimeout(() => {
-                setDisplayBlockHeight(blockHeightRef.current);
                 setPostBlockAnimation(false);
-                toggleTimerPaused({ pause: false });
-            }, 2000);
+                setDisplayBlockHeight(blockHeightRef.current);
+            }, 1000);
 
             return () => {
                 clearTimeout(blockTimeout);
             };
         }
-    }, [postBlockAnimation, setDisplayBlockHeight, setPostBlockAnimation]);
+    }, [postBlockAnimation, setDisplayBlockHeight, setPostBlockAnimation, timerPaused]);
 }

--- a/src/hooks/mining/useBlockInfo.ts
+++ b/src/hooks/mining/useBlockInfo.ts
@@ -10,11 +10,11 @@ export function useBlockInfo() {
     const setDisplayBlockTime = useMiningStore((s) => s.setDisplayBlockTime);
     const timerPaused = useMiningStore((s) => s.timerPaused);
 
-    const timeSince = useRef(0);
+    const timeSince = useRef(-1);
 
     useEffect(() => {
         if (timerPaused) {
-            timeSince.current = 0;
+            timeSince.current = -1;
         }
     }, [timerPaused]);
 

--- a/src/hooks/mining/useVisualisation.ts
+++ b/src/hooks/mining/useVisualisation.ts
@@ -5,14 +5,15 @@ import { useMiningStore } from '@app/store/useMiningStore.ts';
 
 export function useVisualisation() {
     const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
+    const setTimerPaused = useMiningStore((s) => s.setTimerPaused);
     return useCallback(
         (state: GlAppState) => {
             setAnimationState(state);
-
             if (state === 'fail') {
+                setTimerPaused(false);
                 setPostBlockAnimation(true);
             }
         },
-        [setPostBlockAnimation]
+        [setPostBlockAnimation, setTimerPaused]
     );
 }

--- a/src/hooks/mining/useVisualisation.ts
+++ b/src/hooks/mining/useVisualisation.ts
@@ -1,19 +1,28 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { setAnimationState } from '../../visuals';
 import { GlAppState } from '@app/glApp';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 
 export function useVisualisation() {
+    const [failure, setFailure] = useState(false);
     const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
     const setTimerPaused = useMiningStore((s) => s.setTimerPaused);
-    return useCallback(
-        (state: GlAppState) => {
-            setAnimationState(state);
-            if (state === 'fail') {
-                setTimerPaused(false);
+
+    useEffect(() => {
+        if (failure) {
+            const failTimeout = setTimeout(() => {
                 setPostBlockAnimation(true);
-            }
-        },
-        [setPostBlockAnimation, setTimerPaused]
-    );
+                setTimerPaused(false);
+                setFailure(false);
+            }, 1500);
+            return () => clearTimeout(failTimeout);
+        }
+    }, [failure, setPostBlockAnimation, setTimerPaused]);
+
+    return useCallback((state: GlAppState) => {
+        setAnimationState(state);
+        if (state === 'fail') {
+            setFailure(true);
+        }
+    }, []);
 }

--- a/src/store/useMiningStore.ts
+++ b/src/store/useMiningStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { BlockTimeData } from '@app/types/mining.ts';
+import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
 
 interface State {
     displayBlockTime?: BlockTimeData;
@@ -14,12 +15,12 @@ interface Actions {
     setDisplayBlockHeight: (displayBlockHeight: number) => void;
     setEarnings: (earnings?: number) => void;
     setPostBlockAnimation: (postBlockAnimation: boolean) => void;
-    toggleTimerPaused: ({ pause }: { pause?: boolean }) => void;
+    setTimerPaused: (timerPaused: boolean) => void;
 }
 type MiningStoreState = State & Actions;
 
 const initialState: State = {
-    displayBlockHeight: undefined,
+    displayBlockHeight: useBaseNodeStatusStore.getState().block_height,
     timerPaused: false,
     postBlockAnimation: false,
 };
@@ -32,13 +33,12 @@ export const useMiningStore = create<MiningStoreState>()(
             setDisplayBlockHeight: (displayBlockHeight) => set({ displayBlockHeight }),
             setEarnings: (earnings) => set({ earnings }),
             setPostBlockAnimation: (postBlockAnimation) => set({ postBlockAnimation }),
-            toggleTimerPaused: ({ pause }) =>
-                set((state) => ({ timerPaused: pause !== undefined ? pause : !state.timerPaused })),
+            setTimerPaused: (timerPaused) => set({ timerPaused }),
         }),
         {
             name: 'mining',
             storage: createJSONStorage(() => sessionStorage),
-            version: 1,
+            version: 2,
         }
     )
 );


### PR DESCRIPTION
Description
---

- only update `displayBlockHeight` if timer is not paused
- update `timerPaused` after success (earnings) animation callback, and with a small timeout on a failed block animation (success and fail animations have differing durations)
- changed display block time init value to `-1` so the counter starts at `00:00:00` instead of `00:00:01`
- also just used actual block_height value if not mining, so we're up to date even if there's no animation changes

Motivation and Context
---
- display block height was changing before the display block time

How Has This Been Tested?
---
- locally


https://github.com/user-attachments/assets/a3050a2b-812e-44fc-945b-58a320c66345

https://github.com/user-attachments/assets/47feaba7-acfb-4f52-89e3-6e72d50c0f73


