### PR TITLE
fix(ui): success animation after minimising & unit cut off

### DIFF
--- a/src/components/CharSpinner/CharSpinner.styles.ts
+++ b/src/components/CharSpinner/CharSpinner.styles.ts
@@ -53,5 +53,5 @@ export const Character = styled('div')<Props>`
     display: flex;
     justify-self: center;
     font-size: ${({ $fontSize }) => `${$fontSize}px`};
-    letter-spacing: -3px;
+    letter-spacing: -0.05ch;
 `;

--- a/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
@@ -12,10 +12,17 @@ export const EarningsContainer = styled('div')`
 export const EarningsWrapper = styled(motion.div)`
     display: flex;
     align-items: flex-end;
+    flex-direction: row;
     justify-content: center;
     span {
+        display: flex;
         font-family: 'DrukWideLCGBold', sans-serif;
         font-size: 14px;
         letter-spacing: -0.1px;
+    }
+
+    @media (max-width: 920px) {
+        flex-direction: column;
+        align-items: center;
     }
 `;

--- a/src/containers/Dashboard/MiningView/components/Earnings.tsx
+++ b/src/containers/Dashboard/MiningView/components/Earnings.tsx
@@ -28,15 +28,13 @@ const variants = {
 
 export default function Earnings() {
     const earnings = useMiningStore((s) => s.earnings);
-    const setEarnings = useMiningStore((s) => s.setEarnings);
     const setPostBlockAnimation = useMiningStore((s) => s.setPostBlockAnimation);
     const setTimerPaused = useMiningStore((s) => s.setTimerPaused);
     const formatted = formatBalance(earnings || 0);
     const handleComplete = useCallback(() => {
-        setEarnings(undefined);
         setPostBlockAnimation(true);
         setTimerPaused(false);
-    }, [setEarnings, setPostBlockAnimation, setTimerPaused]);
+    }, [setPostBlockAnimation, setTimerPaused]);
 
     return (
         <EarningsContainer>
@@ -47,8 +45,7 @@ export default function Earnings() {
                         variants={variants}
                         animate="visible"
                         exit="hidden"
-                        onAnimationComplete={(s) => {
-                            console.log(s);
+                        onAnimationComplete={() => {
                             handleComplete();
                         }}
                     >

--- a/src/containers/Dashboard/MiningView/components/Earnings.tsx
+++ b/src/containers/Dashboard/MiningView/components/Earnings.tsx
@@ -47,12 +47,13 @@ export default function Earnings() {
                         variants={variants}
                         animate="visible"
                         exit="hidden"
-                        onAnimationComplete={() => {
+                        onAnimationComplete={(s) => {
+                            console.log(s);
                             handleComplete();
                         }}
                     >
                         <span>YOUR REWARD IS</span>
-                        <CharSpinner value={formatted.toString()} fontSize={75} />
+                        <CharSpinner value={formatted.toString()} fontSize={72} />
                     </EarningsWrapper>
                 ) : null}
             </AnimatePresence>

--- a/src/containers/SideBar/components/Wallet.tsx
+++ b/src/containers/SideBar/components/Wallet.tsx
@@ -10,7 +10,7 @@ import { WalletBalance } from './Wallet.styles.ts';
 function Wallet() {
     const balance = useWalletStore((state) => state.balance);
     const formatted = formatBalance(balance);
-    const balanceFontSize = formatted.length <= 5 ? 60 : formatted.length <= 8 ? 45 : 30;
+    const balanceFontSize = formatted.length <= 6 ? 60 : formatted.length <= 8 ? 44 : 32;
 
     return (
         <ThemeProvider theme={darkTheme}>

--- a/src/hooks/mining/useBalanceInfo.ts
+++ b/src/hooks/mining/useBalanceInfo.ts
@@ -4,7 +4,7 @@ import { useVisualisation } from '@app/hooks/mining/useVisualisation.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
 
-const TIMER_VALUE = 10 * 1000; //10s
+const TIMER_VALUE = 15 * 1000; // 15s
 export default function useBalanceInfo() {
     const [balanceChangeBlock, setBalanceChangeBlock] = useState<number | null>(null);
     const handleVisual = useVisualisation();
@@ -59,11 +59,12 @@ export default function useBalanceInfo() {
             const blockTimeout = setTimeout(() => {
                 setPostBlockAnimation(false);
                 setDisplayBlockHeight(blockHeightRef.current);
+                setEarnings(undefined);
             }, 1000);
 
             return () => {
                 clearTimeout(blockTimeout);
             };
         }
-    }, [postBlockAnimation, setDisplayBlockHeight, setPostBlockAnimation, timerPaused]);
+    }, [postBlockAnimation, setDisplayBlockHeight, setEarnings, setPostBlockAnimation, timerPaused]);
 }


### PR DESCRIPTION
Description
---
- fix `m` unit being cut off in wallet balance
- fix earnings animation text ugliness if window is smaller
- increased timeout to wait for balance change to 15 seconds
- reset earnings on `setDisplayBlockHeight` change so we don't get an old earnings animation on a failed block when we return 

