### PR TITLE
fix(ui): block height display

### DIFF
--- a/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
@@ -37,11 +37,13 @@ function BlockHeight() {
 
     return (
         <>
-            <BlockHeightContainer>
-                <BlockHeightBg length={formattedBlockHeight.length}>{formattedBlockHeight}</BlockHeightBg>
-                <RulerContainer>{renderRulerMarks()}</RulerContainer>
-                <BlockHeightLrg>{formattedBlockHeight}</BlockHeightLrg>
-            </BlockHeightContainer>
+            {displayBlockHeight > 0 ? (
+                <BlockHeightContainer>
+                    <BlockHeightBg length={formattedBlockHeight.length}>{formattedBlockHeight}</BlockHeightBg>
+                    <RulerContainer>{renderRulerMarks()}</RulerContainer>
+                    <BlockHeightLrg>{formattedBlockHeight}</BlockHeightLrg>
+                </BlockHeightContainer>
+            ) : null}
         </>
     );
 }

--- a/src/containers/Dashboard/MiningView/components/BlockTime.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockTime.styles.ts
@@ -2,7 +2,7 @@ import { styled } from '@mui/material/styles';
 import { Box, Typography } from '@mui/material';
 
 export const BlockTimeContainer = styled(Box)(() => ({
-    zIndex: 1,
+    zIndex: 100,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-end',


### PR DESCRIPTION
Description
---
Adjusted the timer z-index
Conditionally render the block height component only if the height is bigger than 0

Motivation and Context
---
The block height background was overlapping the timer at the bottom of the screen

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
