### PR TITLE
fix(ui): remove Setup view gradient bg and just use AppBackground on set up

### DIFF
--- a/src/containers/AppBackground/AppBackground.tsx
+++ b/src/containers/AppBackground/AppBackground.tsx
@@ -5,8 +5,9 @@ import { useUIStore } from '@app/store/useUIStore.ts';
 function AppBackground() {
     const theme = useTheme();
     const visualMode = useUIStore((s) => s.visualMode);
+    const view = useUIStore((s) => s.view);
 
-    return !visualMode ? <BackgroundImage theme={theme} /> : null;
+    return !visualMode || view === 'setup' ? <BackgroundImage theme={theme} /> : null;
 }
 
 export default AppBackground;

--- a/src/containers/Dashboard/Dashboard.tsx
+++ b/src/containers/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { DashboardContainer, SetupGradient } from './styles';
+import { DashboardContainer } from './styles';
 import MiningView from './MiningView/MiningView';
 import TribesView from './TribesView/TribesView';
 import { viewType } from '../../store/types';
@@ -8,12 +8,7 @@ function Dashboard({ status }: { status: viewType }) {
     const viewMarkup =
         status == 'setup' ? <SetupViewContainer /> : status == 'tribes' ? <TribesView /> : <MiningView />;
 
-    return (
-        <DashboardContainer>
-            {status == 'setup' ? <SetupGradient /> : null}
-            {viewMarkup}
-        </DashboardContainer>
-    );
+    return <DashboardContainer>{viewMarkup}</DashboardContainer>;
 }
 
 export default Dashboard;

--- a/src/containers/Dashboard/styles.ts
+++ b/src/containers/Dashboard/styles.ts
@@ -43,14 +43,6 @@ export const VisualModeContainer = styled(Box)(({ theme }) => ({
     paddingBottom: theme.spacing(1),
 }));
 
-export const InfoContainer = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    width: '100%',
-    gap: theme.spacing(2),
-}));
-
 export const SetupDescription = styled(Typography)(({ theme }) => ({
     color: `${theme.palette.text.primary} !important`,
     fontFamily: '"PoppinsRegular", sans-serif',
@@ -64,11 +56,3 @@ export const SetupPercentage = styled(Typography)(({ theme }) => ({
     fontSize: '15px',
     textAlign: 'center',
 }));
-
-export const SetupGradient = styled('div')`
-    position: absolute;
-    z-index: 0;
-    background-image: radial-gradient(circle 1000px at 50% 100%, rgb(255, 255, 255, 1), rgba(255, 255, 255, 0));
-    width: 100%;
-    height: 100vh;
-`;


### PR DESCRIPTION
Description
---
- just added a flag for 'setup' view in `AppBackground`
- remove `SetupGradient`


<img width="1332" alt="image" src="https://github.com/user-attachments/assets/d170dc7a-30d4-46eb-a4f0-01195a5bd813">



Motivation and Context
---
- resolves #136 
