### PR TITLE
fix: check file physically exists when looking for versions

### DIFF
--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -183,24 +183,7 @@ impl BinaryResolver {
             .get(&binary)
             .ok_or_else(|| anyhow!("No latest version found for binary {}", binary.name()))?;
         let base_dir = adapter.get_binary_folder().join(version.to_string());
-        match binary {
-            Binaries::Xmrig => {
-                let xmrig_bin = base_dir.join("xmrig");
-                Ok(xmrig_bin)
-            }
-            Binaries::MergeMiningProxy => {
-                let mmproxy_bin = base_dir.join("minotari_merge_mining_proxy");
-                Ok(mmproxy_bin)
-            }
-            Binaries::MinotariNode => {
-                let minotari_node_bin = base_dir.join("minotari_node");
-                Ok(minotari_node_bin)
-            }
-            Binaries::Wallet => {
-                let wallet_bin = base_dir.join("minotari_console_wallet");
-                Ok(wallet_bin)
-            }
-        }
+        get_binary_name(binary, base_dir)
     }
 
     pub async fn ensure_latest(
@@ -303,6 +286,18 @@ impl BinaryResolver {
             };
             let path = entry.path();
             if path.is_dir() {
+                // Check for actual binary existing. It can happen that the folder is there,
+                // for in_progress downloads or perhaps the antivirus has quarantined the file
+                let mut executable_name = get_binary_name(binary, path.clone())?;
+
+                if cfg!(target_os = "windows") {
+                    executable_name = executable_name.with_extension("exe");
+                }
+
+                if !executable_name.exists() {
+                    continue;
+                }
+
                 let version = path.file_name().unwrap().to_str().unwrap();
                 versions.push(Version::parse(version).unwrap());
             }
@@ -343,6 +338,27 @@ impl BinaryResolver {
     pub async fn get_latest_version(&self, binary: Binaries) -> Version {
         let guard = self.latest_versions.read().await;
         guard.get(&binary).cloned().unwrap_or(Version::new(0, 0, 0))
+    }
+}
+
+fn get_binary_name(binary: Binaries, base_dir: PathBuf) -> Result<PathBuf, Error> {
+    match binary {
+        Binaries::Xmrig => {
+            let xmrig_bin = base_dir.join("xmrig");
+            Ok(xmrig_bin)
+        }
+        Binaries::MergeMiningProxy => {
+            let mmproxy_bin = base_dir.join("minotari_merge_mining_proxy");
+            Ok(mmproxy_bin)
+        }
+        Binaries::MinotariNode => {
+            let minotari_node_bin = base_dir.join("minotari_node");
+            Ok(minotari_node_bin)
+        }
+        Binaries::Wallet => {
+            let wallet_bin = base_dir.join("minotari_console_wallet");
+            Ok(wallet_bin)
+        }
     }
 }
 


### PR DESCRIPTION
Checks if a file actually exists when checking versions. 

We had a user who had an in_progress dir for a version:
![image](https://github.com/user-attachments/assets/99b78195-8330-4f4c-ad66-a537aa0fc923)

This would cause a crash on startup