### PR TITLE
feat(UI): Floating animation for Meditating Soon

### DIFF
--- a/src/containers/Dashboard/SetupView/SetupView.tsx
+++ b/src/containers/Dashboard/SetupView/SetupView.tsx
@@ -1,11 +1,12 @@
 import setup from '@app/assets/setup.png';
 import { Stack, Typography } from '@mui/material';
 import { StyledLinearProgress, ProgressBox, SetupDescription, SetupPercentage } from '../styles';
+import { FloatingImage } from './styles';
 
 function SetupView({ title, progressPercentage }: { title: string; progressPercentage: number }) {
     return (
         <Stack spacing={0} alignItems="center" sx={{ position: 'relative', zIndex: '1' }}>
-            <img src={setup} alt="Setup" style={{ maxWidth: '260px', height: 'auto' }} />
+            <FloatingImage src={setup} alt="Setup" style={{ maxWidth: '260px', height: 'auto' }} />
             <Typography variant="h3" fontSize={21} mt={3.4}>
                 Setting up the Tari truth machine...
             </Typography>

--- a/src/containers/Dashboard/SetupView/SetupView.tsx
+++ b/src/containers/Dashboard/SetupView/SetupView.tsx
@@ -6,7 +6,7 @@ import { FloatingImage } from './styles';
 function SetupView({ title, progressPercentage }: { title: string; progressPercentage: number }) {
     return (
         <Stack spacing={0} alignItems="center" sx={{ position: 'relative', zIndex: '1' }}>
-            <FloatingImage src={setup} alt="Setup" style={{ maxWidth: '260px', height: 'auto' }} />
+            <FloatingImage src={setup} alt="Soon Meditating" />
             <Typography variant="h3" fontSize={21} mt={3.4}>
                 Setting up the Tari truth machine...
             </Typography>

--- a/src/containers/Dashboard/SetupView/styles.ts
+++ b/src/containers/Dashboard/SetupView/styles.ts
@@ -1,0 +1,19 @@
+import { keyframes, styled } from '@mui/material/styles';
+
+const float = keyframes`
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+`;
+
+export const FloatingImage = styled('img')`
+    max-width: 260px;
+    height: auto;
+    animation: ${float} 3s ease-in-out infinite;
+`;


### PR DESCRIPTION
Description
---

Added a nice "floating" animation to the Meditating Soon character on the initial setup screen. 

Video of the animation: 

https://www.loom.com/share/d7c4f7bfbadf480abdae47f73f027b78?sid=27890e94-314e-416d-842d-410b1c480648

Motivation and Context
---

Because it looks nice :) 

How Has This Been Tested?
---

Running on local Dev, Mac M1 Pro

What process can a PR reviewer use to test or verify this change?
---

1. On the initial setup screen when the app first loads, the SOON character should be floating up and down. 

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


