### PR TITLE
chore: update tari refs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3150,8 +3150,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -3168,6 +3168,7 @@ dependencies = [
  "tari_core",
  "tari_crypto",
  "tari_features",
+ "tari_max_size",
  "tari_script",
  "tari_utilities",
  "thiserror",
@@ -3179,13 +3180,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
+dependencies = [
+ "bs58 0.5.1",
+]
 
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -3193,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -5684,8 +5688,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "config",
@@ -5708,8 +5712,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -5722,8 +5726,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.6.0",
@@ -5748,8 +5752,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5792,8 +5796,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5827,8 +5831,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5837,8 +5841,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5887,6 +5891,7 @@ dependencies = [
  "tari_features",
  "tari_hashing",
  "tari_key_manager",
+ "tari_max_size",
  "tari_mmr",
  "tari_p2p",
  "tari_script",
@@ -5927,13 +5932,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 
 [[package]]
 name = "tari_hashing"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "borsh",
  "digest",
@@ -5942,8 +5947,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5974,9 +5979,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_max_size"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
+dependencies = [
+ "borsh",
+ "serde",
+ "tari_utilities",
+ "thiserror",
+]
+
+[[package]]
 name = "tari_mmr"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "borsh",
  "digest",
@@ -5989,8 +6005,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "fs2",
@@ -6019,8 +6035,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "blake2",
  "borsh",
@@ -6030,14 +6046,15 @@ dependencies = [
  "sha2",
  "sha3",
  "tari_crypto",
+ "tari_max_size",
  "tari_utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "tari_service_framework"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6051,16 +6068,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "futures 0.3.30",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -6071,8 +6088,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "1.1.0-pre.2"
-source = "git+https://github.com/tari-project/tari.git?branch=development#90a4c282d5ee61ccd1abd54b8e14e9b5c75052a9"
+version = "1.3.1-pre.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.3.1-pre.1#c1b5c0220774a0adfc56b273537a2b50973a0724"
 dependencies = [
  "futures 0.3.30",
  "rand 0.8.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,15 +14,15 @@ tauri-build = { version = "1", features = ["isolation"] }
 
 [dependencies]
 jsonwebtoken = "9.3.0"
-tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development" }
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development" }
-tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", features = [
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1", features = [
     "transactions",
 ] }
-tari_key_manager = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1.3.1-pre.1" }
 tari_utilities = "0.7.0"
 tari_crypto = "0.20.3"
 anyhow = "1"


### PR DESCRIPTION
 updates to 1.3.1-pre.1