### PR TITLE
feat(log): add shutdown log

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -966,13 +966,16 @@ fn main() {
                 info!(target: LOG_TARGET, "Updater event: {:?}", updater_event);
             }
         },
-        tauri::RunEvent::ExitRequested { api: _, .. } | tauri::RunEvent::Exit => {
+        tauri::RunEvent::ExitRequested { api: _, .. } => {
             // api.prevent_exit();
             info!(target: LOG_TARGET, "App shutdown caught");
             shutdown.trigger();
             // TODO: Find a better way of knowing that all miners have stopped
             sleep(std::time::Duration::from_secs(5));
             info!(target: LOG_TARGET, "App shutdown complete");
+        }
+        tauri::RunEvent::Exit => {
+            info!(target: LOG_TARGET, "Tari Universe v{} shut down successfully", _app_handle.package_info().version);
         }
         RunEvent::MainEventsCleared => {
             // no need to handle


### PR DESCRIPTION
Description
Add a log message when Tari universe shuts down so that we can see if it shut down cleanly.
Split `ExitRequest` and `Exit` events to not run the same twice

Motivation and Context
resolves #247 

How Has This Been Tested?
Manually logs checked

Before:
![image](https://github.com/user-attachments/assets/c8672a00-b4a8-4076-9311-e454e2a2dbc1)

After:
![image](https://github.com/user-attachments/assets/729f194a-00da-4598-be74-727f07ab079e)


What process can a PR reviewer use to test or verify this change?
Manually check

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
