### PR TITLE
fix(ui): block height bg scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <div id="root"></div>
   <script type="module" src="src/main.tsx"></script>
   <script>
+    let time;
     function preload() {
       glApp?.preload(
           {
@@ -37,7 +38,6 @@
       glApp.init();
       time = performance.now() / 1000;
       window.addEventListener("resize", onResize);
-      glApp.properties.cameraOffsetX = (348 + 16) / window.innerWidth; // 348 is sidebar width with some padding
 
       onResize();
       animate();
@@ -45,6 +45,7 @@
 
     function onResize() {
       glApp.setSize(window.innerWidth, window.innerHeight);
+      glApp.properties.cameraOffsetX = (348 + 10) / window.innerWidth; // 348 is sidebar width with some padding
     }
 
     function animate() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,9 +15,7 @@
         },
         "updater": {
             "active": true,
-            "endpoints": [
-                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
-            ],
+            "endpoints": ["https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"],
             "dialog": true,
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
         },
@@ -52,8 +50,8 @@
                 "label": "main",
                 "width": 1380,
                 "height": 780,
-                "minWidth": 388,
-                "minHeight": 455,
+                "minWidth": 997,
+                "minHeight": 620,
                 "resizable": true,
                 "fullscreen": false,
                 "decorations": true,
@@ -67,13 +65,7 @@
             "active": true,
             "targets": "all",
             "identifier": "com.tari.universe",
-            "icon": [
-                "icons/icon.icns",
-                "icons/icon.ico",
-                "icons/icon.png",
-                "icons/StoreLogo.png",
-                "icons/tari.png"
-            ]
+            "icon": ["icons/icon.icns", "icons/icon.ico", "icons/icon.png", "icons/StoreLogo.png", "icons/tari.png"]
         },
         "macOSPrivateApi": true
     }

--- a/src/components/elements/Select.tsx
+++ b/src/components/elements/Select.tsx
@@ -39,7 +39,7 @@ const Options = styled.div<{ $open?: boolean }>`
     box-shadow: 0 0 45px 0 rgba(0, 0, 0, 0.15);
     background: ${({ theme }) => theme.palette.background.paper};
     border-radius: ${({ theme }) => theme.shape.borderRadius.app};
-    z-index: 1;
+    z-index: 100;
     height: ${({ $open }) => ($open ? 'auto' : 0)};
     opacity: ${({ $open }) => ($open ? 1 : 0)};
     pointer-events: ${({ $open }) => ($open ? 'auto' : 'none')};
@@ -116,8 +116,7 @@ type OnClickEvent = MouseEvent<HTMLDivElement>;
 
 export function Select({ options, selectedValue, disabled, loading, onChange, ...props }: Props) {
     const [expanded, setExpanded] = useState(false);
-    function toggleOpen(e: OnClickEvent) {
-        e.stopPropagation();
+    function toggleOpen() {
         setExpanded((c) => !c);
     }
 
@@ -130,7 +129,7 @@ export function Select({ options, selectedValue, disabled, loading, onChange, ..
     const selectedOption = selectedValue ? options.find((o) => o.value === selectedValue) : options[0];
     const selectedLabel = selectedOption?.selectedLabel || selectedOption?.label;
     return (
-        <Wrapper onClick={(e) => toggleOpen(e)} $disabled={disabled}>
+        <Wrapper onClick={() => toggleOpen()} $disabled={disabled}>
             <StyledSelect {...props}>
                 <SelectedOption $selected>
                     <Typography>{selectedLabel}</Typography>

--- a/src/containers/Dashboard/MiningView/MiningView.styles.ts
+++ b/src/containers/Dashboard/MiningView/MiningView.styles.ts
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const MiningViewContainer = styled.div`
     display: flex;
     flex-direction: column;
-    //align-items: flex-end;
     justify-content: space-between;
     width: 100%;
     height: 100%;

--- a/src/containers/Dashboard/MiningView/MiningView.tsx
+++ b/src/containers/Dashboard/MiningView/MiningView.tsx
@@ -9,9 +9,9 @@ import P2pool from '@app/containers/Dashboard/MiningView/components/P2pool.tsx';
 export default function MiningView() {
     return (
         <MiningViewContainer>
+            <BlockHeight />
             <P2pool />
             <Earnings />
-            <BlockHeight />
             <BlockTime />
         </MiningViewContainer>
     );

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
@@ -12,11 +12,11 @@ export const Wrapper = styled.div`
     height: 100%;
 `;
 
-export const RulerContainer = styled.div`
-    top: 50%;
+export const RulerContainer = styled.div<{ $height?: number }>`
+    top: ${({ $height }) => ($height ? `calc(50% - ${$height / 2}px)` : '50%')};
     position: absolute;
     height: 100%;
-    transform: translateY(-50%);
+    transform: translateY(${({ $height }) => ($height ? `-calc(50% - ${$height / 2}px)` : '-50%')});
     display: flex;
     flex-direction: column;
     align-items: end;
@@ -25,13 +25,12 @@ export const RulerContainer = styled.div`
 
 export const RulerMarkContainer = styled.div`
     display: grid;
-    position: relative;
     grid-template-areas: 'number line';
     grid-template-columns: auto 10px;
     grid-template-rows: 7px;
     justify-items: end;
     align-items: center;
-    column-gap: 20px;
+    column-gap: 10px;
     row-gap: 0;
 `;
 
@@ -47,14 +46,39 @@ export const RulerNumber = styled.div`
     font-variant-numeric: tabular-nums;
     font-size: 11px;
     color: ${({ theme }) => theme.palette.text.primary};
-    opacity: 0.2;
+    opacity: 0.16;
     text-align: right;
     font-weight: 700;
     line-height: 1.1;
     grid-area: number;
 `;
 
+export const BlockHeightAccent = styled.div<{ $content: string; $height?: number }>`
+    width: 100vh;
+    height: 100%;
+    font-family: Druk, sans-serif;
+    line-height: 1.1;
+    letter-spacing: -1px;
+    font-size: 110px;
+    transform: rotate(-90deg) translate(0, calc(100vh - ${({ $height = 100 }) => `${$height * 100 - 20}px`}));
+    position: fixed;
+    z-index: -1;
+
+    &:before {
+        content: ${({ $content }) => $content || ''};
+        position: absolute;
+        width: 100%;
+        color: ${({ theme }) => theme.palette.base};
+        opacity: 0.4;
+        transform: ${({ $height }) => ($height ? `scale(${$height})` : `scale(1.3)`)};
+        text-align: center;
+        z-index: -1;
+    }
+`;
+
 export const BlockHeightText = styled.div`
+    position: absolute;
+    right: 20px;
     color: #000;
     text-align: right;
     font-family: Druk, sans-serif;

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
@@ -5,11 +5,11 @@ export const Wrapper = styled.div`
     align-items: flex-end;
     justify-content: flex-end;
     position: absolute;
-    right: 0;
-    top: 0;
+    right: -10px;
+    top: 30px;
     overflow: hidden;
     width: 100%;
-    height: 100%;
+    height: calc(100% - 60px);
 `;
 
 export const RulerContainer = styled.div<{ $height?: number }>`
@@ -21,6 +21,7 @@ export const RulerContainer = styled.div<{ $height?: number }>`
     flex-direction: column;
     align-items: end;
     justify-content: center;
+    z-index: 0;
 `;
 
 export const RulerMarkContainer = styled.div`
@@ -57,10 +58,11 @@ export const BlockHeightAccent = styled.div<{ $content: string; $height?: number
     width: 100vh;
     height: 100%;
     font-family: Druk, sans-serif;
+    font-variant-numeric: tabular-nums;
     line-height: 1.1;
-    letter-spacing: -1px;
-    font-size: 110px;
-    transform: rotate(-90deg) translate(0, calc(100vh - ${({ $height = 100 }) => `${$height * 100 - 20}px`}));
+    letter-spacing: -2px;
+    font-size: 105px;
+    transform: rotate(-90deg) translate(0, calc(100vh - ${({ $height = 100 }) => `${$height * 100 - 40}px`}));
     position: fixed;
     z-index: -1;
 
@@ -72,7 +74,14 @@ export const BlockHeightAccent = styled.div<{ $content: string; $height?: number
         opacity: 0.4;
         transform: ${({ $height }) => ($height ? `scale(${$height})` : `scale(1.3)`)};
         text-align: center;
-        z-index: -1;
+    }
+
+    @media (max-width: 1100px) {
+        transform: rotate(-90deg) translate(0, calc(100vh - ${({ $height = 100 }) => `${$height * 100 - 10}px`}));
+        &:before {
+            width: 95%;
+            transform: ${({ $height }) => ($height ? `scale(${$height})` : `scale(1.1)`)};
+        }
     }
 `;
 
@@ -85,4 +94,8 @@ export const BlockHeightText = styled.div`
     font-size: 25px;
     font-weight: 700;
     line-height: normal;
+
+    @media (max-width: 1100px) {
+        font-size: 20px;
+    }
 `;

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.styles.ts
@@ -1,87 +1,64 @@
 import styled from 'styled-components';
 
-interface BlockHeightBgProps {
-    length: number;
-}
-
-const topHeight = 55;
-const bottomHeight = 115;
-
-export const Wrapper = styled.div``;
-export const RulerAbsoluteWrapper = styled.div`
-    z-index: 100;
+export const Wrapper = styled.div`
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
     position: absolute;
     right: 0;
-    height: calc(100vh - ${topHeight}px - ${bottomHeight}px);
-    flex-direction: column;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 0;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
 `;
 
 export const RulerContainer = styled.div`
+    top: 50%;
+    position: absolute;
+    height: 100%;
+    transform: translateY(-50%);
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    height: 100%;
-    z-index: 2;
+    align-items: end;
+    justify-content: center;
 `;
 
 export const RulerMarkContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    min-width: 50px;
+    display: grid;
+    position: relative;
+    grid-template-areas: 'number line';
+    grid-template-columns: auto 10px;
+    grid-template-rows: 7px;
+    justify-items: end;
     align-items: center;
-    justify-content: flex-end;
-    height: 3px;
-    overflow: visible;
-    gap: 10px;
+    column-gap: 20px;
+    row-gap: 0;
 `;
 
 export const RulerMark = styled('div')`
     width: 10px;
     height: 1px;
     background-color: ${({ theme }) => theme.palette.text.primary};
+    grid-area: line;
 `;
 
-export const BlockHeightLrg = styled.div`
-    font-family: Druk, sans-serif;
-    font-weight: 700;
-    font-size: 25px;
-    letter-spacing: -0.01px;
-    color: ${({ theme }) => theme.palette.text.primary};
-    position: absolute;
-    top: 50%;
-    right: 15px;
-    display: flex;
-    z-index: 2;
-    transform: translateY(-50%);
-`;
-
-export const BlockHeightSml = styled.div`
+export const RulerNumber = styled.div`
     font-family: Poppins, sans-serif;
     font-variant-numeric: tabular-nums;
     font-size: 11px;
     color: ${({ theme }) => theme.palette.text.primary};
     opacity: 0.2;
+    text-align: right;
+    font-weight: 700;
+    line-height: 1.1;
+    grid-area: number;
 `;
 
-export const BlockHeightBg = styled.div<BlockHeightBgProps>`
+export const BlockHeightText = styled.div`
+    color: #000;
+    text-align: right;
     font-family: Druk, sans-serif;
+    font-size: 25px;
     font-weight: 700;
-    font-size: ${({ length }) => (length > 5 ? '100px' : '152px')};
-    line-height: ${({ length }) => (length > 5 ? '100px' : '152px')};
-    letter-spacing: -1px;
-    color: rgba(255, 255, 255, 0.4);
-    text-transform: uppercase;
-    position: absolute;
-    width: calc(100vh - ${topHeight}px - ${bottomHeight}px);
-    top: 0;
-    right: ${({ length }) => (length > 5 ? '100px' : '130px')};
-    height: ${({ length }) => (length > 5 ? '100px' : '152px')};
-    rotate: 270deg;
-    z-index: 1;
-    transform-origin: top right;
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
+    line-height: normal;
 `;

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
@@ -1,54 +1,66 @@
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import {
-    BlockHeightLrg,
-    BlockHeightSml,
     RulerContainer,
     RulerMarkContainer,
     RulerMark,
     Wrapper,
-    BlockHeightBg,
-    RulerAbsoluteWrapper,
+    RulerNumber,
+    BlockHeightText,
 } from './BlockHeight.styles';
 import { useCPUStatusStore } from '@app/store/useCPUStatusStore.ts';
 import { useShallow } from 'zustand/react/shallow';
 import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
-import { ReactNode } from 'react';
 
-function BlockHeight() {
+export default function BlockHeight() {
     const isMining = useCPUStatusStore(useShallow((s) => s.is_mining));
     const block_height = useBaseNodeStatusStore((s) => s.block_height);
     const displayBlockHeight = useMiningStore((s) => s.displayBlockHeight) ?? 0;
     const formattedBlockHeight = displayBlockHeight.toLocaleString();
     const height = isMining ? displayBlockHeight : block_height;
 
-    const renderRulerMarks = () => {
-        const marks: ReactNode[] = [];
-        let rulerNum = height;
-        for (let i = 0; i < 100; i++) {
-            const opacity = i % 5 === 0 ? 1 : 0.2;
-            marks.push(
-                <RulerMarkContainer key={`mark-${i}`}>
-                    <BlockHeightSml key={`height-${i}`}>
-                        {i % 5 === 0 && i > 50 && rulerNum > 10 ? (rulerNum -= 10).toLocaleString() : null}
-                    </BlockHeightSml>
-                    <RulerMark key={`ruler-${i}`} style={{ opacity }} />
+    const rulerSegments = [...Array(10)];
+    const rulerMarks = [...Array(5)];
+    const blankSegments = rulerSegments.map((_, i) =>
+        rulerMarks.map((_, idx) => (
+            <RulerMarkContainer key={`blank-mark-${i}${idx}`}>
+                <div />
+                <RulerMark style={{ opacity: idx == 0 ? 1 : 0.2 }} />
+            </RulerMarkContainer>
+        ))
+    );
+
+    let heightSegment = height;
+    const heightSegments = rulerSegments.map((_, i) => {
+        return rulerMarks.map((_, idx) => {
+            const renderNumber = Boolean(idx == 0);
+            if (renderNumber && heightSegment > 10) {
+                heightSegment -= 10;
+            }
+            return (
+                <RulerMarkContainer key={`ruler-${i}${idx}`}>
+                    {renderNumber ? <RulerNumber>{heightSegment}</RulerNumber> : null}
+                    <RulerMark style={{ opacity: idx == 0 ? 1 : 0.2 }} />
                 </RulerMarkContainer>
             );
-        }
-        return marks;
-    };
+        });
+    });
+    const rulerMarkup = (
+        <RulerContainer>
+            {blankSegments}
+            <BlockHeightText>{formattedBlockHeight}s</BlockHeightText>
+            {heightSegments}
+        </RulerContainer>
+    );
 
     return displayBlockHeight > 0 ? (
         <Wrapper>
-            <BlockHeightBg id="BlockHeightBg" length={formattedBlockHeight.length}>
-                {formattedBlockHeight}
-            </BlockHeightBg>
-            <RulerAbsoluteWrapper id="RulerAbsoluteWrapper">
-                <RulerContainer id="RulerContainer">{renderRulerMarks()}</RulerContainer>
-            </RulerAbsoluteWrapper>
-            <BlockHeightLrg>{formattedBlockHeight}</BlockHeightLrg>
+            {rulerMarkup}
+            {/*<BlockHeightBg id="BlockHeightBg" length={formattedBlockHeight.length}>*/}
+            {/*    {formattedBlockHeight}*/}
+            {/*</BlockHeightBg>*/}
+            {/*<RulerAbsoluteWrapper id="RulerAbsoluteWrapper">*/}
+            {/*    <RulerContainer id="RulerContainer">{renderRulerMarks()}</RulerContainer>*/}
+            {/*</RulerAbsoluteWrapper>*/}
         </Wrapper>
     ) : null;
 }
-
-export default BlockHeight;

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
@@ -12,6 +12,7 @@ import { useCPUStatusStore } from '@app/store/useCPUStatusStore.ts';
 import { useShallow } from 'zustand/react/shallow';
 import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
 import { useRef } from 'react';
+import useWindowSize from '@app/hooks/helpers/useWindowSize.ts';
 
 export default function BlockHeight() {
     const isMining = useCPUStatusStore(useShallow((s) => s.is_mining));
@@ -19,10 +20,10 @@ export default function BlockHeight() {
     const displayBlockHeight = useMiningStore((s) => s.displayBlockHeight) ?? 0;
     const height = isMining ? displayBlockHeight : block_height;
     const formattedBlockHeight = height.toLocaleString();
-
+    const windowSize = useWindowSize();
     const containerRef = useRef<HTMLDivElement>(null);
 
-    const rulerSegments = [...Array(11)];
+    const rulerSegments = [...Array(21)];
     const rulerMarks = [...Array(5)];
     const blankSegments = rulerSegments.map((_, i) =>
         rulerMarks.map((_, idx) => (
@@ -34,7 +35,7 @@ export default function BlockHeight() {
     );
 
     let heightSegment = height;
-    const heightSegments = [...Array(9)].map((_, i) => {
+    const heightSegments = [...Array(19)].map((_, i) => {
         return rulerMarks.map((_, idx) => {
             const renderNumber = Boolean(idx == 0);
             if (renderNumber && heightSegment > 10) {
@@ -60,7 +61,7 @@ export default function BlockHeight() {
         <Wrapper>
             <BlockHeightAccent
                 $content={formattedBlockHeight ? `'${formattedBlockHeight}'` : ''}
-                $height={window.innerHeight / (formattedBlockHeight.length * 100)}
+                $height={windowSize.height / (formattedBlockHeight.length * 100)}
             />
             {rulerMarkup}
         </Wrapper>

--- a/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeight.tsx
@@ -6,19 +6,23 @@ import {
     Wrapper,
     RulerNumber,
     BlockHeightText,
+    BlockHeightAccent,
 } from './BlockHeight.styles';
 import { useCPUStatusStore } from '@app/store/useCPUStatusStore.ts';
 import { useShallow } from 'zustand/react/shallow';
 import { useBaseNodeStatusStore } from '@app/store/useBaseNodeStatusStore.ts';
+import { useRef } from 'react';
 
 export default function BlockHeight() {
     const isMining = useCPUStatusStore(useShallow((s) => s.is_mining));
     const block_height = useBaseNodeStatusStore((s) => s.block_height);
     const displayBlockHeight = useMiningStore((s) => s.displayBlockHeight) ?? 0;
-    const formattedBlockHeight = displayBlockHeight.toLocaleString();
     const height = isMining ? displayBlockHeight : block_height;
+    const formattedBlockHeight = height.toLocaleString();
 
-    const rulerSegments = [...Array(10)];
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const rulerSegments = [...Array(11)];
     const rulerMarks = [...Array(5)];
     const blankSegments = rulerSegments.map((_, i) =>
         rulerMarks.map((_, idx) => (
@@ -30,7 +34,7 @@ export default function BlockHeight() {
     );
 
     let heightSegment = height;
-    const heightSegments = rulerSegments.map((_, i) => {
+    const heightSegments = [...Array(9)].map((_, i) => {
         return rulerMarks.map((_, idx) => {
             const renderNumber = Boolean(idx == 0);
             if (renderNumber && heightSegment > 10) {
@@ -45,22 +49,20 @@ export default function BlockHeight() {
         });
     });
     const rulerMarkup = (
-        <RulerContainer>
+        <RulerContainer ref={containerRef} $height={containerRef.current?.offsetHeight}>
             {blankSegments}
-            <BlockHeightText>{formattedBlockHeight}s</BlockHeightText>
+            <BlockHeightText>{formattedBlockHeight}</BlockHeightText>
             {heightSegments}
         </RulerContainer>
     );
 
-    return displayBlockHeight > 0 ? (
+    return height > 0 ? (
         <Wrapper>
+            <BlockHeightAccent
+                $content={formattedBlockHeight ? `'${formattedBlockHeight}'` : ''}
+                $height={window.innerHeight / (formattedBlockHeight.length * 100)}
+            />
             {rulerMarkup}
-            {/*<BlockHeightBg id="BlockHeightBg" length={formattedBlockHeight.length}>*/}
-            {/*    {formattedBlockHeight}*/}
-            {/*</BlockHeightBg>*/}
-            {/*<RulerAbsoluteWrapper id="RulerAbsoluteWrapper">*/}
-            {/*    <RulerContainer id="RulerContainer">{renderRulerMarks()}</RulerContainer>*/}
-            {/*</RulerAbsoluteWrapper>*/}
         </Wrapper>
     ) : null;
 }

--- a/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
@@ -22,7 +22,7 @@ export const EarningsWrapper = styled(motion.div)`
         letter-spacing: -0.1px;
     }
 
-    @media (max-width: 920px) {
+    @media (max-width: 1100px) {
         flex-direction: column;
         align-items: center;
     }

--- a/src/containers/SideBar/Miner/Miner.tsx
+++ b/src/containers/SideBar/Miner/Miner.tsx
@@ -32,7 +32,7 @@ export default function Miner() {
 
     const hash_rate = useCPUStatusStore((s) => s.hash_rate);
     const gpu_hash_rate = useGPUStatusStore((s) => s.hash_rate) || 0;
-    console.log('gpu_hash_rate', gpu_hash_rate);
+    console.info('gpu_hash_rate', gpu_hash_rate);
     const estimated_earnings = useCPUStatusStore((s) => s.estimated_earnings);
     const gpu_estimated_earnings = useGPUStatusStore((s) => s.estimated_earnings);
 

--- a/src/hooks/helpers/useWindowSize.ts
+++ b/src/hooks/helpers/useWindowSize.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+
+export default function useWindowSize() {
+    const windowSize = useRef({ width: window.innerWidth, height: window.innerHeight });
+    useEffect(() => {
+        function handleResize() {
+            windowSize.current = {
+                width: window.innerWidth,
+                height: window.innerHeight,
+            };
+        }
+        window.addEventListener('resize', handleResize);
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, []);
+    return windowSize.current;
+}

--- a/src/hooks/useGetStatus.ts
+++ b/src/hooks/useGetStatus.ts
@@ -36,7 +36,7 @@ export function useGetStatus() {
                         setAppStatus(status);
                         setCPUStatus(status.cpu);
                         setBaseNodeStatus(status.base_node);
-                        console.log('status', status.gpu);
+                        console.info('status', status.gpu);
                         const gpuStatus: GpuMinerStatus = {
                             is_mining: status.gpu === undefined ? false : true,
                             hash_rate: status.gpu?.hash_rate || 0,


### PR DESCRIPTION
Description
---

- adjusted visual camera offset slightly
- added minimum window size
- adjusted `BlockHeight` component structure and styling so it's always vertically centered
- use `height` value which for the render check since displayBlockHeight might not always be set (which is why it sometimes wouldn't show initially)
- adjusted `BlockHeight` component's big height accent number to scale based on number length as well as window height
- added basic screensize helper hook 
- updated media query below new min screen size and some lints


Motivation and Context
---

- broke the font-size scaling of the big block height accent in a previous PR
- some times the ruler and centered block-height would overlap the block tower

How Has This Been Tested?
---
- locally:

---

![ScreenRecording2024-09-04](https://github.com/user-attachments/assets/36d06689-5767-4e1c-973b-427d2e6ce495)


---
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/37886420-8d6d-48f9-8af3-9370520b2153">

---
<img width="1673" alt="image" src="https://github.com/user-attachments/assets/d69904bc-1a52-461c-a336-c5303ab2e372">

---

<img width="1674" alt="image" src="https://github.com/user-attachments/assets/60e7929a-59be-4409-a78e-bafb122ffa02">
---
<img width="1699" alt="image" src="https://github.com/user-attachments/assets/54693f0a-c3d0-4b10-8012-98768d081a4e">
---
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/edb3840b-f4d3-4f2e-9c3c-a081833b001a">
