### PR TITLE
feat(ui): add chip component and Testnet tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/tari.svg" />
     <script type="module" crossorigin src="/assets/glApp.js"></script>
-    <title>Tari Universe</title>
+    <title>Tari Universe | Testnet</title>
     <style>
       #canvas {
         position: absolute;

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -13,5 +13,7 @@
     "hashrate": "Hashrate",
     "utilization": "Utilization",
     "mode": "Mode",
-    "day": "Day"
+    "day": "Day",
+    "tari-universe": "Tari Universe",
+    "testnet": "Testnet"
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
         "distDir": "../dist"
     },
     "package": {
-        "productName": "Tari Universe",
+        "productName": "Tari Universe | Testnet",
         "version": "0.2.1"
     },
     "tauri": {
@@ -15,9 +15,7 @@
         },
         "updater": {
             "active": true,
-            "endpoints": [
-                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
-            ],
+            "endpoints": ["https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"],
             "dialog": true,
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
         },
@@ -48,7 +46,7 @@
         },
         "windows": [
             {
-                "title": "Tari Universe",
+                "title": "Tari Universe | Testnet",
                 "label": "main",
                 "width": 1380,
                 "height": 780,
@@ -67,13 +65,7 @@
             "active": true,
             "targets": "all",
             "identifier": "com.tari.universe",
-            "icon": [
-                "icons/icon.icns",
-                "icons/icon.ico",
-                "icons/icon.png",
-                "icons/StoreLogo.png",
-                "icons/tari.png"
-            ]
+            "icon": ["icons/icon.icns", "icons/icon.ico", "icons/icon.png", "icons/StoreLogo.png", "icons/tari.png"]
         },
         "macOSPrivateApi": true
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
         "distDir": "../dist"
     },
     "package": {
-        "productName": "Tari Universe | Testnet",
+        "productName": "Tari Universe",
         "version": "0.2.1"
     },
     "tauri": {

--- a/src/components/elements/Chip.tsx
+++ b/src/components/elements/Chip.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+    display: flex;
+    padding: 6px 14px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 10px;
+    max-height: 20px;
+    background: ${({ theme }) => theme.palette.contrast};
+
+    span {
+        color: ${({ theme }) => theme.palette.text.contrast};
+        font-family: Poppins, sans-serif;
+        font-size: 11px;
+        font-weight: 600;
+        user-select: none;
+    }
+`;
+interface ChipProps {
+    children: ReactNode;
+}
+export function Chip({ children }: ChipProps) {
+    return (
+        <Wrapper>
+            <span>{children}</span>
+        </Wrapper>
+    );
+}

--- a/src/containers/SideBar/components/Heading.tsx
+++ b/src/containers/SideBar/components/Heading.tsx
@@ -1,11 +1,17 @@
 import SettingsDialog from './Settings/Settings.tsx';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { Stack } from '@app/components/elements/Stack.tsx';
+import { Chip } from '@app/components/elements/Chip.tsx';
+import { useTranslation } from 'react-i18next';
 
 function Heading() {
+    const { t } = useTranslation('common', { useSuspense: false });
     return (
         <Stack direction="row" justifyContent="space-between">
-            <Typography variant="h3">Tari Universe</Typography>
+            <Stack direction="row" alignItems="center" gap={10}>
+                <Typography variant="h3">{t('tari-universe')}</Typography>
+                <Chip>{t('testnet')}</Chip>
+            </Stack>
             <Stack>
                 <SettingsDialog />
             </Stack>


### PR DESCRIPTION
Description
---

- added basic chip component
- added chip with 'Testnet' to sidebar title
- added 'Testnet' to config window and app name

Motivation and Context
---

- resolves #92 

How Has This Been Tested?
---

- locally: 

<img width="862" alt="image" src="https://github.com/user-attachments/assets/06d26d8b-9c28-4308-b352-d1625b8a0b95">
