### PR TITLE
fix: success animation timing

### DIFF
--- a/src/hooks/mining/useVisualisation.ts
+++ b/src/hooks/mining/useVisualisation.ts
@@ -18,8 +18,10 @@ export function useVisualisation() {
 
             if (canAnimate) {
                 setAnimationState(state);
-                setPostBlockAnimation(true);
-                setTimerPaused(false);
+                if (state === 'fail') {
+                    setPostBlockAnimation(true);
+                    setTimerPaused(false);
+                }
             }
         },
         [setPostBlockAnimation, setTimerPaused]


### PR DESCRIPTION
only clear the animation pause & post-block animation flag if it was the `'fail'` state in `useVisualisation` (gets cleared for `'success'`in earnings after the fancy floating animation which takes longer)