### PR TITLE
fix: startup config for mm proxy when p2pool enabled

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -332,6 +332,7 @@ async fn setup_inner<'r>(
         telemetry_id = "unknown_miner_tari_universe".to_string();
     }
 
+    let config = state.config.read().await;
     mm_proxy_manager
         .start(StartConfig::new(
             state.shutdown.to_signal().clone(),
@@ -341,6 +342,7 @@ async fn setup_inner<'r>(
             cpu_miner_config.tari_address.clone(),
             base_node_grpc_port,
             telemetry_id,
+            config.p2pool_enabled,
         ))
         .await?;
     mm_proxy_manager.wait_ready().await?;
@@ -385,7 +387,12 @@ async fn set_p2pool_enabled<'r>(
                 .get_grpc_port()
                 .await
                 .map_err(|error| error.to_string())?;
-            MergeMiningProxyConfig::new(origin_config.port, base_node_grpc_port, None)
+            MergeMiningProxyConfig::new(
+                origin_config.port,
+                p2pool_config.grpc_port,
+                base_node_grpc_port,
+                None,
+            )
         };
         state
             .mm_proxy_manager
@@ -908,7 +915,12 @@ fn main() {
     let mm_proxy_config = if app_config_raw.p2pool_enabled {
         MergeMiningProxyConfig::new_with_p2pool(mm_proxy_port, p2pool_config.grpc_port, None)
     } else {
-        MergeMiningProxyConfig::new(mm_proxy_port, base_node_grpc_port, None)
+        MergeMiningProxyConfig::new(
+            mm_proxy_port,
+            p2pool_config.grpc_port,
+            base_node_grpc_port,
+            None,
+        )
     };
     let mm_proxy_manager = MmProxyManager::new(mm_proxy_config);
     let app_state = UniverseAppState {

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -25,11 +25,16 @@ pub struct MergeMiningProxyConfig {
 }
 
 impl MergeMiningProxyConfig {
-    pub fn new(port: u16, base_node_grpc_port: u16, coinbase_extra: Option<String>) -> Self {
+    pub fn new(
+        port: u16,
+        p2pool_grpc_port: u16,
+        base_node_grpc_port: u16,
+        coinbase_extra: Option<String>,
+    ) -> Self {
         Self {
             port,
             p2pool_enabled: false,
-            p2pool_grpc_port: 0,
+            p2pool_grpc_port,
             base_node_grpc_port,
             coinbase_extra: coinbase_extra.unwrap_or("tari_universe_mmproxy".to_string()),
         }

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -23,6 +23,7 @@ pub struct StartConfig {
     pub tari_address: TariAddress,
     pub base_node_grpc_port: u16,
     pub coinbase_extra: String,
+    pub p2pool_enabled: bool,
 }
 
 impl PartialEq for StartConfig {
@@ -45,6 +46,7 @@ impl StartConfig {
         tari_address: TariAddress,
         base_node_grpc_port: u16,
         coinbase_extra: String,
+        p2pool_enabled: bool,
     ) -> Self {
         Self {
             app_shutdown,
@@ -54,6 +56,7 @@ impl StartConfig {
             tari_address,
             base_node_grpc_port,
             coinbase_extra,
+            p2pool_enabled,
         }
     }
 }
@@ -120,6 +123,7 @@ impl MmProxyManager {
         process_watcher.adapter.tari_address = config.tari_address;
         process_watcher.adapter.config.base_node_grpc_port = config.base_node_grpc_port;
         process_watcher.adapter.config.coinbase_extra = config.coinbase_extra;
+        process_watcher.adapter.config.p2pool_enabled = config.p2pool_enabled;
         info!(target: LOG_TARGET, "Starting mmproxy");
         process_watcher
             .start(


### PR DESCRIPTION
Description
---
When p2pool is enabled in config, merge-mining proxy was initialized with p2pool as not enabled by default.
The actual p2pool config must be passed even when its startup.

Motivation and Context
---
Initially CPU mining was not used p2pool even when it was enabled.

How Has This Been Tested?
---
Start Universe and start mining.
Check logs that new blocks are submitted to p2pool from cpu miner as well.

What process can a PR reviewer use to test or verify this change?
---
See tests.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
