### PR TITLE
chore(update): custom auto update

### DIFF
--- a/public/locales/af/setup-view.json
+++ b/public/locales/af/setup-view.json
@@ -19,5 +19,9 @@
         "download-completed": "Aflaai voltooi",
         "waiting-for-header-sync": "Wag vir kopkopsinchronisasie. {{local_height}}/{{tip_height}} gesinchroniseer",
         "waiting-for-block-sync": "Wag vir bloksinchronisasie. {{local_height}}/{{tip_height}} gesinchroniseer"
-    }
+    },
+    "new-tari-version-available": "'n Nuwe weergawe van Tari Universe is beskikbaar",
+    "would-you-like-to-install": "Wil jy nou Tari Universe {{version}} installeer?",
+    "yes": "Ja",
+    "no": "Nee"
 }

--- a/public/locales/en/setup-view.json
+++ b/public/locales/en/setup-view.json
@@ -19,5 +19,9 @@
         "download-completed": "Download completed",
         "waiting-for-header-sync": "Waiting for header sync. {{local_height}}/{{tip_height}} headers synced",
         "waiting-for-block-sync": "Waiting for block sync. {{local_height}}/{{tip_height}} blocks synced"
-    }
+    },
+    "new-tari-version-available": "A new version of Tari Universe is available!",
+    "would-you-like-to-install": "Would you like to install Tari Universe {{version}} now?",
+    "yes": "Yes",
+    "no": "No"
 }

--- a/public/locales/pl/setup-view.json
+++ b/public/locales/pl/setup-view.json
@@ -19,5 +19,9 @@
         "download-completed": "Pobieranie zakończone",
         "waiting-for-header-sync": "Oczekiwanie na synchronizację nagłówków. {{local_height}}/{{tip_height}} zsynchronizowano",
         "waiting-for-block-sync": "Oczekiwanie na synchronizację bloków. {{local_height}}/{{tip_height}} zsynchronizowano"
-    }
+    },
+    "new-tari-version-available": "Nowa wersja Tari Universe jest dostępna!",
+    "would-you-like-to-install": "Czy chciałbys zainstalować Tari Universe {{version}} teraz?",
+    "yes": "Tak",
+    "no": "Nie"
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,6 +143,17 @@ async fn setup_application(
     })
 }
 
+#[tauri::command]
+async fn restart_application<'r>(
+    _window: tauri::Window,
+    _state: tauri::State<'r, UniverseAppState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    // This restart doesn't need to shutdown all the miners
+    let _ = app.restart();
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
 async fn setup_inner(
     window: tauri::Window,
@@ -1050,7 +1061,8 @@ fn main() {
             update_applications,
             reset_settings,
             set_gpu_mining_enabled,
-            set_cpu_mining_enabled
+            set_cpu_mining_enabled,
+            restart_application
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,7 +42,6 @@ use crate::user_listener::UserListener;
 use crate::wallet_adapter::WalletBalance;
 use crate::wallet_manager::WalletManager;
 use crate::xmrig_adapter::XmrigAdapter;
-use anyhow::Error;
 use app_config::{AppConfig, MiningMode};
 use binary_resolver::{Binaries, BinaryResolver};
 use futures_lite::future::block_on;
@@ -55,15 +54,13 @@ use serde::Serialize;
 use setup_status_event::SetupStatusEvent;
 use std::collections::HashMap;
 use std::fs::remove_dir_all;
-use std::future::Future;
 use std::sync::Arc;
 use std::thread::sleep;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 use std::{panic, process};
 use systemtray_manager::{SystemtrayManager, SystrayData};
 use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddress;
-use tari_core::proof_of_work::PowAlgorithm;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::Shutdown;
 use tauri::{Manager, RunEvent, UpdaterEvent};
@@ -144,13 +141,13 @@ async fn setup_application(
 }
 
 #[tauri::command]
-async fn restart_application<'r>(
+async fn restart_application(
     _window: tauri::Window,
-    _state: tauri::State<'r, UniverseAppState>,
+    _state: tauri::State<'_, UniverseAppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     // This restart doesn't need to shutdown all the miners
-    let _ = app.restart();
+    app.restart();
     Ok(())
 }
 

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -227,7 +227,9 @@ impl WalletStatusMonitor {
             .map_err(|e| WalletStatusMonitorError::UnknownError(e.into()))?;
         let res = res.into_inner();
 
-        Ok(TariAddress::from_bytes(res.address.as_slice())
-            .map_err(WalletStatusMonitorError::TariAddress)?)
+        match TariAddress::from_bytes(res.address.as_slice()) {
+            Ok(address) => Ok(address),
+            Err(err) => Err(WalletStatusMonitorError::TariAddress(err)),
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
             "endpoints": [
                 "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
             ],
-            "dialog": true,
+            "dialog": false,
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
         },
         "allowlist": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { GlobalReset, GlobalStyle } from '@app/theme/GlobalStyle.ts';
 import { useMiningEffects } from './hooks/mining/useMiningEffects.ts';
 
 import ErrorSnackbar from '@app/containers/Error/ErrorSnackbar.tsx';
+import AutoUpdateDialog from './containers/AutoUpdateDialog/AutoUpdateDialog.tsx';
 
 export default function App() {
     useAirdropTokensRefresh();
@@ -30,6 +31,7 @@ export default function App() {
             <GlobalStyle />
             <AppBackground />
             <SplashScreen />
+            <AutoUpdateDialog />
             {!showSplash && (
                 <DashboardContainer>
                     <ContainerInner>

--- a/src/containers/AutoUpdateDialog/AutoUpdateDialog.styles.ts
+++ b/src/containers/AutoUpdateDialog/AutoUpdateDialog.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const ButtonsWrapper = styled.div(() => ({
+    display: 'flex',
+    justifyContent: 'right',
+    marginTop: '16px',
+    alignItems: 'center',
+    gap: '16px',
+}));

--- a/src/containers/AutoUpdateDialog/AutoUpdateDialog.tsx
+++ b/src/containers/AutoUpdateDialog/AutoUpdateDialog.tsx
@@ -46,7 +46,7 @@ function AutoUpdateDialog() {
         return () => {
             unlistenPromise?.then((unlisten) => unlisten());
         };
-    }, []);
+    }, [setIsAfterAutoUpdate]);
 
     const handleUpdate = async () => {
         setIsLoading(true);

--- a/src/containers/AutoUpdateDialog/AutoUpdateDialog.tsx
+++ b/src/containers/AutoUpdateDialog/AutoUpdateDialog.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { checkUpdate, installUpdate, onUpdaterEvent } from '@tauri-apps/api/updater';
+import { UnlistenFn } from '@tauri-apps/api/event';
+import { invoke } from '@tauri-apps/api/tauri';
+import { Button } from '@app/components/elements/Button';
+import Dialog from '@app/components/elements/Dialog';
+import useAppStateStore from '@app/store/appStateStore';
+import { DialogContent } from '../SideBar/components/Settings/Settings.styles';
+import { Typography } from '@app/components/elements/Typography';
+import { ButtonsWrapper } from './AutoUpdateDialog.styles';
+import { CircularProgress } from '@app/components/elements/CircularProgress';
+
+function AutoUpdateDialog() {
+    const setIsAfterAutoUpdate = useAppStateStore((s) => s.setIsAfterAutoUpdate);
+    const [latestVersion, setLatestVersion] = useState<string>();
+    const [isLoading, setIsLoading] = useState(false);
+    const [open, setOpen] = useState(false);
+    const { t } = useTranslation('setup-view', { useSuspense: false });
+
+    useEffect(() => {
+        let unlistenPromise: Promise<UnlistenFn>;
+
+        const checkUpdateTariUniverse = async () => {
+            unlistenPromise = onUpdaterEvent(({ error, status }) => {
+                // This will log all updater events, including status updates and errors.
+                console.info('Updater event', error, status);
+            });
+
+            try {
+                const { shouldUpdate, manifest } = await checkUpdate();
+                if (shouldUpdate) {
+                    console.info('New Tari Universe version available', manifest);
+                    setLatestVersion(manifest?.version);
+                    setOpen(true);
+                } else {
+                    setIsAfterAutoUpdate(true);
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        };
+
+        checkUpdateTariUniverse();
+        return () => {
+            unlistenPromise?.then((unlisten) => unlisten());
+        };
+    }, []);
+
+    const handleUpdate = async () => {
+        setIsLoading(true);
+        await installUpdate();
+        console.info('Installing latest version of Tari Universe');
+        try {
+            console.info('Restarting application after update');
+            await invoke('restart_application');
+            handleClose();
+        } catch (e) {
+            console.error('Relaunch error', e);
+        }
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+        setIsAfterAutoUpdate(true);
+    };
+
+    return (
+        <Dialog isNested open={open} onClose={handleClose}>
+            <DialogContent>
+                <Typography variant="h3">{t('new-tari-version-available')}</Typography>
+                <Typography variant="p">{t('would-you-like-to-install', { version: latestVersion })}</Typography>
+                <ButtonsWrapper>
+                    {!isLoading ? (
+                        <>
+                            <Button onClick={handleUpdate}>{t('yes')}</Button>
+                            <Button onClick={handleClose}>{t('no')}</Button>
+                        </>
+                    ) : (
+                        <CircularProgress />
+                    )}
+                </ButtonsWrapper>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export default AutoUpdateDialog;

--- a/src/store/appStateStore.ts
+++ b/src/store/appStateStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 
 interface AppState {
+    isAfterAutoUpdate: boolean;
+    setIsAfterAutoUpdate: (value: boolean) => void;
     error?: string;
     setError: (value: string | undefined) => void;
     topStatus: string;
@@ -20,6 +22,8 @@ interface AppState {
 }
 
 const useAppStateStore = create<AppState>()((set) => ({
+    isAfterAutoUpdate: false,
+    setIsAfterAutoUpdate: (value: boolean) => set({ isAfterAutoUpdate: value }),
     error: undefined,
     setError: (error) => set({ error }),
     topStatus: 'Not mining',


### PR DESCRIPTION
Description
---
Currently auto update asks you to 1) Download and then 2) Restart. It was a request to merge it into one(first) step. 

Motivation and Context
---
Unfortunately, tauri updater does not allow to do so and it does not show that second step on windows. I tried to catch "DOWNLOADED" and "DONE" events, but it took some time to restart the app so restart dialog was displayed on linux/mac anyway. I decided to create our own dialog with auto update and restart logic.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
if you're using linux, it's quite challenging for now. You have to build your own (old)version, create updater json, host it somewhere and place it inside `tauri.conf.json`. Ask me for help if you need any! :)

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
