### PR TITLE
feat(p2pool): add wallet address and p2pool stats to settings

### DIFF
--- a/public/locales/en/mining-view.json
+++ b/public/locales/en/mining-view.json
@@ -1,19 +1,15 @@
 {
-    "floor": "Floor",
-    "tribe": "Tribe",
-    "miners": "Miners",
-    "tribe-earnings": "Tribe earnings",
-    "tribe-pool-height": "Pool height",
-    "current-block-time": "Current block time",
-    "your-reward-is": "Your reward is",
-    "connection-to-node-lost": "Connection to miner lost. Please wait for the miner to reconnect or restart the miner.",
-    "mining-button-text": {
-        "starting-mining": "Starting Mining",
-        "start-mining": "Start Mining",
-        "pause-mining": "Pause Mining",
-        "changing-mode": "Changing mode",
-        "cancel-mining": "Cancel Mining",
-        "waiting-for-idle": "Waiting for Idle",
-        "started-auto-mining": "Auto Mining Started"
-    }
+  "floor": "Floor",
+  "current-block-time": "Current block time",
+  "your-reward-is": "Your reward is",
+  "connection-to-node-lost": "Connection to miner lost. Please wait for the miner to reconnect or restart the miner.",
+  "mining-button-text": {
+    "starting-mining": "Starting Mining",
+    "start-mining": "Start Mining",
+    "pause-mining": "Pause Mining",
+    "changing-mode": "Changing mode",
+    "cancel-mining": "Cancel Mining",
+    "waiting-for-idle": "Waiting for Idle",
+    "started-auto-mining": "Auto Mining Started"
+  }
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -1,27 +1,36 @@
 {
-    "settings": "Settings",
-    "seed-words": "Seed words",
-    "change-language": "Change language",
-    "logs": "Logs",
-    "open-logs-directory": "Open logs directory",
-    "debug-info": "Debug",
-    "hardware-status": "Hardware status",
-    "update-versions": "Update versions",
-    "refresh-versions": "Refresh versions",
-    "idle-timeout": {
-        "title": "Time after which machine is considered idle",
-        "placeholder": "Enter idle timeout in seconds",
-        "max": "Maximum is 21600 seconds",
-        "min": "Minimum is 1 second"
-    },
-    "monero-address": {
-        "title": "Monero address",
-        "placeholder": "Enter Monero address"
-    },
-    "last-block-added-time": "Last block added to chain time",
-    "visual-mode": "Visual mode",
-    "pool-mining": "Pool Mining",
-    "pool-mining-description": "When enabled, you will mine in a pool and join a group of miners (tribe).",
-    "cpu-mining-enabled": "CPU Mining",
-    "gpu-mining-enabled": "GPU Mining"
+  "settings": "Settings",
+  "seed-words": "Seed words",
+  "change-language": "Change language",
+  "logs": "Logs",
+  "open-logs-directory": "Open logs directory",
+  "debug-info": "Debug",
+  "hardware-status": "Hardware status",
+  "update-versions": "Update versions",
+  "refresh-versions": "Refresh versions",
+  "idle-timeout": {
+    "title": "Time after which machine is considered idle",
+    "placeholder": "Enter idle timeout in seconds",
+    "max": "Maximum is 21600 seconds",
+    "min": "Minimum is 1 second"
+  },
+  "monero-address": {
+    "title": "Monero address",
+    "placeholder": "Enter Monero address"
+  },
+  "last-block-added-time": "Last block added to chain time",
+  "visual-mode": "Visual mode",
+  "pool-mining": "Pool Mining",
+  "pool-mining-description": "When enabled, you will mine in a pool and join a group of miners (tribe).",
+  "cpu-mining-enabled": "CPU Mining",
+  "gpu-mining-enabled": "GPU Mining",
+  "p2pool-stats": "P2Pool Stats",
+  "tribe": "Tribe",
+  "miners": "Miners",
+  "tribe-earnings": "Tribe earnings",
+  "tribe-pool-height": "Pool height",
+  "p2pool-hash-rate": "Pool hash rates",
+  "p2pool-total-earnings": "Pool total earnings",
+  "p2pool-chain-tip": "Tip of chains",
+  "p2pool-user-total-earnings": "Total earnings"
 }

--- a/public/locales/pl/mining-view.json
+++ b/public/locales/pl/mining-view.json
@@ -1,20 +1,15 @@
 {
-    "floor": "Poziom",
-    "tribe": "Plemię",
-    "miners": "Górniczy",
-    "tribe-earnings": "Dochody plemienia",
-    "tribe-pool-height": "Wysokość basenu",
-    "current-block-time": "Aktualny czas bloku",
-    "your-reward-is": "Twoja nagroda wynosi",
-    "connection-to-node-lost": "Połączenie z węzłem kopania zostało utracone. Poczekaj, aż wznowi połącznie lub uruchom go ponownie.",
-    "mining-button-text": {
-        "starting-mining": "Uruchamianie kopania",
-        "start-mining": "Uruchom kopanie",
-        "pause-mining": "Wstrzymaj kopanie",
-        "changing-mode": "Zmiana trybu",
-        "cancel-mining": "Anuluj kopanie",
-        "waiting-for-idle": "Oczekiwanie na bezczynność",
-        "started-auto-mining": "Automatyczne kopanie uruchomione"
-    }
-
+  "floor": "Poziom",
+  "current-block-time": "Aktualny czas bloku",
+  "your-reward-is": "Twoja nagroda wynosi",
+  "connection-to-node-lost": "Połączenie z węzłem kopania zostało utracone. Poczekaj, aż wznowi połącznie lub uruchom go ponownie.",
+  "mining-button-text": {
+    "starting-mining": "Uruchamianie kopania",
+    "start-mining": "Uruchom kopanie",
+    "pause-mining": "Wstrzymaj kopanie",
+    "changing-mode": "Zmiana trybu",
+    "cancel-mining": "Anuluj kopanie",
+    "waiting-for-idle": "Oczekiwanie na bezczynność",
+    "started-auto-mining": "Automatyczne kopanie uruchomione"
+  }
 }

--- a/public/locales/pl/settings.json
+++ b/public/locales/pl/settings.json
@@ -1,25 +1,25 @@
 {
-    "settings": "Ustawienia",
-    "seed-words": "Słowa kluczowe",
-    "change-language": "Zmień język",
-    "logs": "Logi",
-    "open-logs-directory": "Otwórz katalog logów",
-    "debug-info": "Informacje debugowania",
-    "hardware-status": "Status sprzętu",
-    "update-versions": "Aktualizuj wersje",
-    "refresh-versions": "Odśwież wersje",
-    "idle-timeout": {
-        "title": "Czas po którym urządzenie jest uważane za bezczynne",
-        "placeholder": "Wprowadź czas bezczynności w sekundach",
-        "max": "Maksymalny czas to 21600 sekund",
-        "min": "Minimalny czas to 1 sekunda"
-    },
-    "monero-address": {
-        "title": "Address Monero",
-        "placeholder": "Wprowadź address Monero"
-    },
-    "last-block-added-time": "Czas dodania ostatniego bloku do łańcucha",
-    "visual-mode": "Tryb wizualny",
-    "pool-mining": "Pool Mining",
-    "pool-mining-description": "Po włączeniu tej opcji będziesz wydobywać w puli i dołączać do grupy górników (plemienia)."
+  "settings": "Ustawienia",
+  "seed-words": "Słowa kluczowe",
+  "change-language": "Zmień język",
+  "logs": "Logi",
+  "open-logs-directory": "Otwórz katalog logów",
+  "debug-info": "Informacje debugowania",
+  "hardware-status": "Status sprzętu",
+  "update-versions": "Aktualizuj wersje",
+  "refresh-versions": "Odśwież wersje",
+  "idle-timeout": {
+    "title": "Czas po którym urządzenie jest uważane za bezczynne",
+    "placeholder": "Wprowadź czas bezczynności w sekundach",
+    "max": "Maksymalny czas to 21600 sekund",
+    "min": "Minimalny czas to 1 sekunda"
+  },
+  "monero-address": {
+    "title": "Address Monero",
+    "placeholder": "Wprowadź address Monero"
+  },
+  "last-block-added-time": "Czas dodania ostatniego bloku do łańcucha",
+  "visual-mode": "Tryb wizualny",
+  "pool-mining": "Pool Mining",
+  "pool-mining-description": "Po włączeniu tej opcji będziesz wydobywać w puli i dołączać do grupy górników (plemienia)."
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ use crate::user_listener::UserListener;
 use crate::wallet_adapter::WalletBalance;
 use crate::wallet_manager::WalletManager;
 use crate::xmrig_adapter::XmrigAdapter;
+use anyhow::Error;
 use app_config::{AppConfig, MiningMode};
 use binary_resolver::{Binaries, BinaryResolver};
 use futures_lite::future::block_on;
@@ -54,9 +55,10 @@ use serde::Serialize;
 use setup_status_event::SetupStatusEvent;
 use std::collections::HashMap;
 use std::fs::remove_dir_all;
+use std::future::Future;
 use std::sync::Arc;
 use std::thread::sleep;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 use std::{panic, process};
 use systemtray_manager::{SystemtrayManager, SystrayData};
 use tari_common::configuration::Network;
@@ -686,20 +688,20 @@ async fn status(
         }
     };
 
+    let tari_address = match state.wallet_manager.wallet_address().await {
+        Ok(addr) => addr,
+        Err(error) => {
+            warn!(target: LOG_TARGET, "Error getting wallet address: {}", error);
+            String::new()
+        }
+    };
+
     let hardware_status = HardwareMonitor::current()
         .write()
         .await
         .read_hardware_parameters();
 
-    let mut p2pool_stats = HashMap::with_capacity(2);
-    p2pool_stats.insert(
-        PowAlgorithm::Sha3x.to_string().to_lowercase(),
-        Stats::default(),
-    );
-    p2pool_stats.insert(
-        PowAlgorithm::RandomX.to_string().to_lowercase(),
-        Stats::default(),
-    );
+    let p2pool_stats = state.p2pool_manager.stats().await;
 
     let config_guard = state.config.read().await;
 
@@ -729,6 +731,7 @@ async fn status(
         monero_address: config_guard.monero_address.clone(),
         cpu_mining_enabled: config_guard.cpu_mining_enabled,
         gpu_mining_enabled: config_guard.gpu_mining_enabled,
+        tari_address,
     })
 }
 
@@ -797,6 +800,7 @@ pub struct AppStatus {
     auto_mining: bool,
     p2pool_enabled: bool,
     p2pool_stats: HashMap<String, Stats>,
+    tari_address: String,
     monero_address: String,
     cpu_mining_enabled: bool,
     gpu_mining_enabled: bool,

--- a/src-tauri/src/p2pool/models.rs
+++ b/src-tauri/src/p2pool/models.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_utilities::epoch_time::EpochTime;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StatsBlock {
     pub hash: String,
     pub height: u64,
@@ -12,13 +12,13 @@ pub struct StatsBlock {
     pub miner_wallet_address: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct TribeDetails {
     pub id: String,
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Stats {
     pub connected: bool,
     pub connected_since: Option<EpochTime>,
@@ -35,14 +35,14 @@ pub struct Stats {
     pub p2pool_block_stats: BlockStats,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct BlockStats {
     pub accepted: u64,
     pub rejected: u64,
     pub submitted: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct EstimatedEarnings {
     #[serde(rename = "1min")]
     pub one_minute: MicroMinotari,

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -1,17 +1,20 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
+use tari_core::proof_of_work::PowAlgorithm;
 use tari_shutdown::ShutdownSignal;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::sleep;
 
 use crate::p2pool::models::Stats;
 use crate::p2pool_adapter::P2poolAdapter;
 use crate::process_adapter::StatusMonitor;
 use crate::process_watcher::ProcessWatcher;
+
+const P2POOL_STATS_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct P2poolConfig {
@@ -57,9 +60,15 @@ impl Default for P2poolConfig {
     }
 }
 
+struct P2poolStats {
+    last_updated: Instant,
+    stats: HashMap<String, Stats>,
+}
+
 pub struct P2poolManager {
     config: Arc<P2poolConfig>,
     watcher: Arc<RwLock<ProcessWatcher<P2poolAdapter>>>,
+    stats: Arc<Mutex<Option<P2poolStats>>>,
 }
 
 impl P2poolManager {
@@ -70,10 +79,57 @@ impl P2poolManager {
         Self {
             config,
             watcher: Arc::new(RwLock::new(process_watcher)),
+            stats: Arc::new(Mutex::new(None)),
         }
     }
 
-    pub async fn stats(&self) -> Result<HashMap<String, Stats>, anyhow::Error> {
+    fn default_stats(&self) -> HashMap<String, Stats> {
+        let mut p2pool_stats = HashMap::with_capacity(2);
+        p2pool_stats.insert(
+            PowAlgorithm::Sha3x.to_string().to_lowercase(),
+            Stats::default(),
+        );
+        p2pool_stats.insert(
+            PowAlgorithm::RandomX.to_string().to_lowercase(),
+            Stats::default(),
+        );
+        p2pool_stats
+    }
+
+    pub async fn stats(&self) -> HashMap<String, Stats> {
+        let mut curr_stats = self.stats.lock().await;
+        match &mut *curr_stats {
+            Some(curr_stats) => {
+                if Instant::now()
+                    .duration_since(curr_stats.last_updated)
+                    .lt(&P2POOL_STATS_UPDATE_INTERVAL)
+                {
+                    curr_stats.stats.clone()
+                } else {
+                    match self.get_stats().await {
+                        Ok(stats) => {
+                            curr_stats.stats = stats.clone();
+                            curr_stats.last_updated = Instant::now();
+                            stats
+                        }
+                        Err(_) => self.default_stats(),
+                    }
+                }
+            }
+            None => match self.get_stats().await {
+                Ok(stats) => {
+                    *curr_stats = Some(P2poolStats {
+                        last_updated: Instant::now(),
+                        stats: stats.clone(),
+                    });
+                    stats
+                }
+                Err(_) => self.default_stats(),
+            },
+        }
+    }
+
+    async fn get_stats(&self) -> Result<HashMap<String, Stats>, anyhow::Error> {
         let process_watcher = self.watcher.read().await;
         if let Some(status_monitor) = &process_watcher.status_monitor {
             return status_monitor.status().await;

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -95,4 +95,19 @@ impl WalletManager {
                 _ => WalletManagerError::UnknownError(e.into()),
             })?)
     }
+
+    pub async fn wallet_address(&self) -> Result<String, WalletManagerError> {
+        let process_watcher = self.watcher.read().await;
+        Ok(process_watcher
+            .status_monitor
+            .as_ref()
+            .ok_or_else(|| WalletManagerError::WalletNotStarted)?
+            .get_wallet_address()
+            .await
+            .map_err(|e| match e {
+                WalletStatusMonitorError::WalletNotStarted => WalletManagerError::WalletNotStarted,
+                _ => WalletManagerError::UnknownError(e.into()),
+            })?
+            .to_base58())
+    }
 }

--- a/src/containers/SideBar/components/Settings/Settings.tsx
+++ b/src/containers/SideBar/components/Settings/Settings.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
 
 import {
-    IoSettingsOutline,
+    IoCheckmarkOutline,
     IoClose,
     IoCopyOutline,
-    IoEyeOutline,
     IoEyeOffOutline,
-    IoCheckmarkOutline,
+    IoEyeOutline,
+    IoSettingsOutline,
 } from 'react-icons/io5';
 import { useGetSeedWords } from '../../../../hooks/useGetSeedWords';
 
@@ -14,7 +14,7 @@ import { invoke } from '@tauri-apps/api/tauri';
 
 import { useAppStatusStore } from '@app/store/useAppStatusStore.ts';
 import VisualMode from '../../../Dashboard/components/VisualMode';
-import { DialogContent, Form, HorisontalBox } from './Settings.styles';
+import { CardContainer, DialogContent, Form, HorisontalBox } from './Settings.styles';
 
 import { useForm } from 'react-hook-form';
 import ConnectButton from '@app/containers/Airdrop/components/ConnectButton/ConnectButton.tsx';
@@ -44,6 +44,7 @@ import { ResetSettingsButton } from '@app/containers/SideBar/components/Settings
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import { useGPUStatusStore } from '@app/store/useGPUStatusStore.ts';
 import { SeedWords } from './SeedWords';
+import { CardComponent } from './Card.component';
 
 enum FormFields {
     MONERO_ADDRESS = 'moneroAddress',
@@ -56,12 +57,34 @@ interface FormState {
 export default function Settings() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const moneroAddress = useAppStatusStore((state) => state.monero_address);
+    const walletAddress = useAppStatusStore((state) => state.tari_address);
+
+    // p2pool
     const isP2poolEnabled = useAppStatusStore((state) => state.p2pool_enabled);
+    const p2poolStats = useAppStatusStore((state) => state.p2pool_stats);
+    const p2poolSha3Stats = p2poolStats?.sha3;
+    const p2poolRandomXStats = p2poolStats?.randomx;
+    const p2poolTribe = p2poolSha3Stats?.tribe?.name;
+    const p2poolSha3MinersCount = p2poolSha3Stats?.num_of_miners;
+    const p2poolRandomxMinersCount = p2poolRandomXStats?.num_of_miners;
+    const p2poolSha3HashRate = p2poolSha3Stats?.pool_hash_rate;
+    const p2poolRandomxHashRate = p2poolRandomXStats?.pool_hash_rate;
+    const p2poolSha3TotalEarnings = p2poolSha3Stats?.pool_total_earnings;
+    const p2poolRandomxTotalEarnings = p2poolRandomXStats?.pool_total_earnings;
+    const p2poolSha3ChainTip = p2poolSha3Stats?.share_chain_height;
+    const p2poolRandomxChainTip = p2poolRandomXStats?.share_chain_height;
+    const p2poolSha3UserTotalEarnings = walletAddress ? p2poolSha3Stats?.total_earnings[walletAddress] : 0;
+    const p2poolRandomxUserTotalEarnings = walletAddress ? p2poolRandomXStats?.total_earnings[walletAddress] : 0;
+    const p2poolUserTotalEarnings = (p2poolSha3UserTotalEarnings && p2poolRandomxUserTotalEarnings)
+        ? p2poolSha3UserTotalEarnings + p2poolRandomxUserTotalEarnings
+        : 0;
+
     const isCpuMiningEnabled = useAppStatusStore((state) => state.cpu_mining_enabled);
     const isGpuMiningEnabled = useAppStatusStore((state) => state.gpu_mining_enabled);
     const [open, setOpen] = useState(false);
     const [showSeedWords, setShowSeedWords] = useState(false);
     const [isCopyTooltipHidden, setIsCopyTooltipHidden] = useState(true);
+    const [isCopyTooltipHiddenWalletAddress, setIsCopyTooltipHiddenWalletAddress] = useState(true);
     const { reset, handleSubmit, control } = useForm<FormState>({
         defaultValues: { moneroAddress },
         mode: 'onSubmit',
@@ -95,6 +118,12 @@ export default function Settings() {
         setTimeout(() => setIsCopyTooltipHidden(true), 1000);
     };
 
+    const copyWalletAddress = async () => {
+        setIsCopyTooltipHiddenWalletAddress(false);
+        await navigator.clipboard.writeText(walletAddress + '');
+        setTimeout(() => setIsCopyTooltipHiddenWalletAddress(true), 1000);
+    };
+
     const handleCancel = () => {
         reset({ moneroAddress });
     };
@@ -110,9 +139,26 @@ export default function Settings() {
             },
             (error) => {
                 console.error(error);
-            }
+            },
         )();
     };
+
+    const walletAddressMarkup = walletAddress ? (
+        <>
+            <Divider />
+            <Stack>
+                <Stack direction="row" justifyContent="space-between" style={{ height: 40 }}>
+                    <Typography variant="h6">Tari Wallet Address</Typography>
+                </Stack>
+                <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="p">{walletAddress}</Typography>
+                    <IconButton onClick={copyWalletAddress}>
+                        {isCopyTooltipHiddenWalletAddress ? <IoCopyOutline /> : <IoCheckmarkOutline />}
+                    </IconButton>
+                </Stack>
+            </Stack>
+        </>
+    ) : null;
 
     const seedWordMarkup = (
         <Stack>
@@ -212,6 +258,98 @@ export default function Settings() {
         </MinerContainer>
     );
 
+    const showP2poolStats = isP2poolEnabled && p2poolTribe;
+    const p2poolStatsMarkup = showP2poolStats ? (
+        <>
+            <Divider />
+            <MinerContainer>
+                <HorisontalBox>
+                    <Typography variant="h6">{t('p2pool-stats', { ns: 'settings' })}</Typography>
+                </HorisontalBox>
+                <CardContainer>
+                    <CardComponent
+                        heading={`${t('tribe', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'Current',
+                                labelValue: p2poolTribe ? p2poolTribe : '',
+                            },
+                        ]}
+                    />
+                    <CardComponent
+                        heading={`${t('miners', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'SHA-3',
+                                labelValue: '' + p2poolSha3MinersCount,
+                            },
+                            {
+                                labelText: 'RandomX',
+                                labelValue: '' + p2poolRandomxMinersCount,
+                            },
+                        ]}
+                    />
+                    <CardComponent
+                        heading={`${t('p2pool-hash-rate', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'SHA-3',
+                                labelValue: (p2poolSha3HashRate ? p2poolSha3HashRate : 0) + ' H/s',
+                            },
+                            {
+                                labelText: 'RandomX',
+                                labelValue: (p2poolRandomxHashRate ? p2poolRandomxHashRate : 0) + ' H/s',
+                            },
+                        ]}
+                    />
+                    <CardComponent
+                        heading={`${t('p2pool-total-earnings', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'SHA-3',
+                                labelValue: (p2poolSha3TotalEarnings ? p2poolSha3TotalEarnings : 0) + ' tXTM',
+                            },
+                            {
+                                labelText: 'RandomX',
+                                labelValue: (p2poolRandomxTotalEarnings ? p2poolRandomxTotalEarnings : 0) + ' tXTM',
+                            },
+                        ]}
+                    />
+                    <CardComponent
+                        heading={`${t('p2pool-chain-tip', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'SHA-3',
+                                labelValue: '#' + p2poolSha3ChainTip,
+                            },
+                            {
+                                labelText: 'RandomX',
+                                labelValue: '#' + p2poolRandomxChainTip,
+                            },
+                        ]}
+                    />
+                    <CardComponent
+                        heading={`${t('p2pool-user-total-earnings', { ns: 'settings' })}`}
+                        labels={[
+                            {
+                                labelText: 'SHA-3',
+                                labelValue: (p2poolSha3UserTotalEarnings ? p2poolSha3UserTotalEarnings : 0) + ' tXTM',
+                            },
+                            {
+                                labelText: 'RandomX',
+                                labelValue: (p2poolRandomxUserTotalEarnings ? p2poolRandomxUserTotalEarnings : 0) + ' tXTM',
+                            },
+                            {
+                                labelText: 'Total',
+                                labelValue: p2poolUserTotalEarnings + ' tXTM',
+                            },
+                        ]}
+                    />
+                </CardContainer>
+            </MinerContainer>
+        </>
+    ) : null;
+
     return (
         <>
             <IconButton onClick={handleClickOpen}>
@@ -225,6 +363,7 @@ export default function Settings() {
                             <IoClose size={20} />
                         </IconButton>
                     </Stack>
+                    {walletAddressMarkup}
                     <Divider />
                     {seedWordMarkup}
                     <Divider />
@@ -240,6 +379,7 @@ export default function Settings() {
                     <LanguageSettings />
                     <Divider />
                     <DebugSettings />
+                    {p2poolStatsMarkup}
                     <Divider />
                     <HardwareStatus />
                     <Divider />

--- a/src/types/app-status.ts
+++ b/src/types/app-status.ts
@@ -13,6 +13,7 @@ export interface AppStatus {
     mode: modeType;
     auto_mining: boolean;
     monero_address?: string;
+    tari_address?: string;
     p2pool_enabled: boolean;
     p2pool_stats?: P2poolStatsResult;
     cpu_mining_enabled: boolean;
@@ -34,7 +35,7 @@ export interface P2poolStats {
     pool_hash_rate: bigint;
     pool_total_earnings: number;
     pool_total_estimated_earnings: P2poolEstimatedEarnings;
-    total_earnings: Map<string, number>;
+    total_earnings: Record<string, number>;
     estimated_earnings: Map<string, P2poolEstimatedEarnings>;
     miner_block_stats: P2poolBlockStats;
     p2pool_block_stats: P2poolBlockStats;


### PR DESCRIPTION
Description
---
P2pool stats should be shown in the settings.

Motivation and Context
---

How Has This Been Tested?
---

Start Universe and open settings.

Example:
![image](https://github.com/user-attachments/assets/e7e11032-7b37-4774-bfa5-eaa9d56aa2b8)

Also added Tari wallet address of the user:
![image](https://github.com/user-attachments/assets/f53c4bb5-e9d2-4395-98c0-42ffaaeac713)

What process can a PR reviewer use to test or verify this change?
---
See test.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
