### PR TITLE
fix(ui): fix stats

### DIFF
--- a/src/components/elements/Chip.tsx
+++ b/src/components/elements/Chip.tsx
@@ -36,9 +36,11 @@ const Wrapper = styled.div<StyleProps>`
         switch ($size) {
             case 'small': {
                 return css`
-                    padding: 4px 6px;
+                    height: 15px;
+                    padding: 0 6px;
                     span {
                         font-size: 10px;
+                        line-height: 9px;
                     }
                 `;
             }

--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -35,6 +35,7 @@ export const Options = styled.div<{ $open?: boolean }>`
     color: ${({ theme }) => theme.palette.text.primary};
     font-weight: 500;
     letter-spacing: -1px;
+    z-index: 2;
 `;
 
 export const SelectedOption = styled.div`

--- a/src/containers/SideBar/Miner/Miner.tsx
+++ b/src/containers/SideBar/Miner/Miner.tsx
@@ -1,5 +1,5 @@
 import Tile from './components/Tile.tsx';
-import { MinerContainer, StatWrapper, TileContainer, Unit } from './styles.ts';
+import { MinerContainer, TileContainer, Unit } from './styles.ts';
 
 import ModeSelect from './components/ModeSelect.tsx';
 import { useHardwareStatus } from '../../../hooks/useHardwareStatus.ts';
@@ -8,55 +8,50 @@ import { useCPUStatusStore } from '@app/store/useCPUStatusStore.ts';
 import { useGPUStatusStore } from '@app/store/useGPUStatusStore.ts';
 
 import { formatNumber } from '@app/utils/formatNumber.ts';
-import { Divider } from '@app/components/elements/Divider.tsx';
 
-import { useTranslation } from 'react-i18next';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import { useAppStatusStore } from '@app/store/useAppStatusStore.ts';
 import { ExpandableTile } from '@app/containers/SideBar/Miner/components/ExpandableTile.tsx';
 import formatBalance from '@app/utils/formatBalance.ts';
 import { Typography } from '@app/components/elements/Typography.tsx';
-import { ExpandedContentTile } from '@app/containers/SideBar/Miner/components/ExpandableTile.styles.ts';
+import {
+    ExpandableTileItem,
+    ExpandedContentTile,
+} from '@app/containers/SideBar/Miner/components/ExpandableTile.styles.ts';
 
 export default function Miner() {
-    const { t } = useTranslation('common', { useSuspense: false });
-
     const { cpu: cpuHardwareStatus, gpu: gpuHardwareStatus } = useHardwareStatus();
 
     const miningInitiated = useMiningStore((s) => s.miningInitiated);
+    const isMiningInProgress = useMiningStore((s) => s.isMiningInProgress);
 
     const hash_rate = useCPUStatusStore((s) => s.hash_rate);
     const gpu_hash_rate = useGPUStatusStore((s) => s.hash_rate) || 0;
 
     const estimated_earnings = useCPUStatusStore((s) => s.estimated_earnings);
     const gpu_estimated_earnings = useGPUStatusStore((s) => s.estimated_earnings) || 0;
-
+    //TODO - dedup these states
     const isCpuMiningEnabled = useAppStatusStore((s) => s.cpu_mining_enabled);
     const isGpuMiningEnabled = useAppStatusStore((s) => s.gpu_mining_enabled);
-
-    const hardwareValSplit = cpuHardwareStatus?.label?.split(' ');
-    const hardwareVal = hardwareValSplit?.[0] + ' ' + hardwareValSplit?.[1];
 
     const isWaitingForCPUHashRate = miningInitiated && hash_rate <= 0;
     const isWaitingForGPUHashRate = miningInitiated && gpu_hash_rate <= 0;
 
     const totalEarnings = estimated_earnings + gpu_estimated_earnings;
-
+    const earningsLoading = totalEarnings <= 0 && (isWaitingForCPUHashRate || isWaitingForGPUHashRate);
     const tileStats = {
         cpu: {
             title: 'CPU Power',
             chipValue: cpuHardwareStatus?.usage_percentage,
-            hidden: !isCpuMiningEnabled,
-            loading: isWaitingForCPUHashRate,
-            stats: formatNumber(hash_rate),
+            loading: isCpuMiningEnabled && isWaitingForCPUHashRate,
+            stats: isCpuMiningEnabled && isMiningInProgress ? formatNumber(hash_rate) : '-',
             unit: 'H/s',
         },
         gpu: {
             title: 'GPU Power',
             chipValue: gpuHardwareStatus?.usage_percentage,
-            hidden: !isGpuMiningEnabled,
-            loading: isWaitingForGPUHashRate,
-            stats: formatNumber(gpu_hash_rate),
+            loading: isGpuMiningEnabled && isWaitingForGPUHashRate,
+            stats: isGpuMiningEnabled && isMiningInProgress ? formatNumber(gpu_hash_rate) : '-',
             unit: 'H/s',
         },
     };
@@ -64,33 +59,35 @@ export default function Miner() {
     return (
         <MinerContainer>
             <TileContainer>
+                <Tile
+                    title={tileStats.cpu.title}
+                    stats={tileStats.cpu.stats}
+                    isLoading={tileStats.cpu.loading}
+                    chipValue={tileStats.cpu.chipValue}
+                    unit={tileStats.cpu.unit}
+                    useLowerCase
+                />
+                <Tile
+                    title={tileStats.gpu.title}
+                    stats={tileStats.gpu.stats}
+                    isLoading={tileStats.gpu.loading}
+                    chipValue={tileStats.gpu.chipValue}
+                    unit={tileStats.gpu.unit}
+                    useLowerCase
+                />
                 <ModeSelect />
-                <Tile title="CHIP/GPU" stats={hardwareVal || t('unknown')} />
-                {isCpuMiningEnabled ? (
-                    <Tile
-                        title={tileStats.cpu.title}
-                        stats={tileStats.cpu.stats}
-                        isLoading={tileStats.cpu.loading}
-                        chipValue={tileStats.cpu.chipValue}
-                        unit={tileStats.cpu.unit}
-                        useLowerCase
-                    />
-                ) : null}
-                {isGpuMiningEnabled ? (
-                    <Tile
-                        title={tileStats.gpu.title}
-                        stats={tileStats.gpu.stats}
-                        isLoading={tileStats.gpu.loading}
-                        chipValue={tileStats.gpu.chipValue}
-                        unit={tileStats.gpu.unit}
-                        useLowerCase
-                    />
-                ) : null}
-                <ExpandableTile title="Est tXTM/day" stats={formatBalance(totalEarnings)}>
+                <ExpandableTile
+                    title="Est tXTM/day"
+                    stats={isMiningInProgress && totalEarnings ? formatBalance(totalEarnings) : '-'}
+                    isLoading={earningsLoading}
+                >
+                    <Typography variant="h5" style={{ color: '#000' }}>
+                        Estimated earnings
+                    </Typography>
                     <Typography>You earn rewards for mining CPU and GPU separately</Typography>
                     <ExpandedContentTile>
                         <Typography>CPU Estimated earnings</Typography>
-                        <StatWrapper>
+                        <ExpandableTileItem>
                             <Typography
                                 variant="h5"
                                 style={{
@@ -99,16 +96,16 @@ export default function Miner() {
                                     lineHeight: '1.02',
                                 }}
                             >
-                                {formatBalance(estimated_earnings)}
+                                {isMiningInProgress && isCpuMiningEnabled ? formatBalance(estimated_earnings) : '-'}
                             </Typography>
                             <Unit>
                                 <Typography>tXTM/day</Typography>
                             </Unit>
-                        </StatWrapper>
+                        </ExpandableTileItem>
                     </ExpandedContentTile>
                     <ExpandedContentTile>
                         <Typography>GPU Estimated earnings</Typography>
-                        <StatWrapper>
+                        <ExpandableTileItem>
                             <Typography
                                 variant="h5"
                                 style={{
@@ -117,12 +114,12 @@ export default function Miner() {
                                     lineHeight: '1.02',
                                 }}
                             >
-                                {formatBalance(gpu_estimated_earnings)}
+                                {isMiningInProgress && isGpuMiningEnabled ? formatBalance(gpu_estimated_earnings) : '-'}
                             </Typography>
                             <Unit>
                                 <Typography>tXTM/day</Typography>
                             </Unit>
-                        </StatWrapper>
+                        </ExpandableTileItem>
                     </ExpandedContentTile>
                 </ExpandableTile>
             </TileContainer>

--- a/src/containers/SideBar/Miner/components/ExpandableTile.styles.ts
+++ b/src/containers/SideBar/Miner/components/ExpandableTile.styles.ts
@@ -13,25 +13,21 @@ export const TriggerWrapper = styled.div`
 `;
 
 export const ExpandableTileItem = styled(motion.div)`
-    flex-grow: 1;
-    min-width: 140px;
-    padding: 10px;
-    min-height: 65px;
-    background-color: ${({ theme }) => theme.palette.background.paper};
-    border-radius: ${({ theme }) => theme.shape.borderRadius.app};
-    box-shadow: 2px 8px 8px 0 rgba(0, 0, 0, 0.04);
-    gap: 8px;
     display: flex;
-    flex-direction: column;
-    color: ${({ theme }) => theme.palette.text.secondary};
-    font-size: 12px;
-    font-weight: 500;
+    justify-content: space-between;
+    align-items: baseline;
+    color: ${({ theme }) => theme.palette.text.primary};
 `;
 export const ExpandedWrapper = styled(motion.div)`
     display: flex;
+    background-color: ${({ theme }) => theme.palette.background.paper};
+    border-radius: ${({ theme }) => theme.shape.borderRadius.app};
+    box-shadow: 2px 8px 8px 0 rgba(0, 0, 0, 0.04);
     flex-direction: column;
     gap: 8px;
-    width: 100%;
+    width: 216px;
+    padding: 20px 12px;
+    z-index: 2;
 `;
 
 export const ExpandedContentTile = styled.div`

--- a/src/containers/SideBar/Miner/components/ExpandableTile.tsx
+++ b/src/containers/SideBar/Miner/components/ExpandableTile.tsx
@@ -1,10 +1,11 @@
-import { StatWrapper, TileTop } from '../styles';
+import { StatWrapper, TileItem, TileTop } from '../styles';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { ReactNode, useState } from 'react';
 import QuestionMarkSvg from '@app/components/svgs/QuestionMarkSvg.tsx';
-import { ExpandableTileItem, ExpandedWrapper, TriggerWrapper } from './ExpandableTile.styles.ts';
+import { ExpandedWrapper, TriggerWrapper } from './ExpandableTile.styles.ts';
 import { StyledIcon } from '@app/containers/Dashboard/MiningView/components/MiningButton.styles.ts';
 import { AnimatePresence } from 'framer-motion';
+import { offset, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
 
 interface ExpandableTileProps {
     title: string;
@@ -35,21 +36,38 @@ export function ExpandableTile({
     useLowerCase = false,
 }: ExpandableTileProps) {
     const [expanded, setExpanded] = useState(false);
+    const { refs, floatingStyles, context } = useFloating({
+        open: expanded,
+        onOpenChange: setExpanded,
+        placement: 'left-start',
+        middleware: [offset(-22)],
+    });
+
+    const hover = useHover(context, {
+        move: !expanded,
+        handleClose: safePolygon(),
+    });
+    const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
 
     return (
-        <ExpandableTileItem
-            animate={{ height: expanded ? 'auto' : '65px' }}
-            transition={{ duration: 0.2, ease: 'linear' }}
-        >
+        <TileItem>
             <TileTop>
-                <Typography style={{ color: expanded ? '#000' : 'inherit' }}>{title}</Typography>
-                <TriggerWrapper onClick={() => setExpanded((c) => !c)}>
+                <Typography>{title}</Typography>
+                <TriggerWrapper ref={refs.setReference} {...getReferenceProps()}>
                     <QuestionMarkSvg />
                 </TriggerWrapper>
             </TileTop>
             <AnimatePresence>
                 {expanded && (
-                    <ExpandedWrapper variants={variants} initial="hidden" animate="visible" exit="hidden">
+                    <ExpandedWrapper
+                        ref={refs.setFloating}
+                        {...getFloatingProps()}
+                        variants={variants}
+                        initial="hidden"
+                        animate="visible"
+                        exit="hidden"
+                        style={floatingStyles}
+                    >
                         {children}
                     </ExpandedWrapper>
                 )}
@@ -72,6 +90,6 @@ export function ExpandableTile({
                         </StatWrapper>
                     ))}
             </AnimatePresence>
-        </ExpandableTileItem>
+        </TileItem>
     );
 }

--- a/src/containers/SideBar/Miner/styles.ts
+++ b/src/containers/SideBar/Miner/styles.ts
@@ -8,24 +8,10 @@ export const MinerContainer = styled.div`
     gap: 10px;
 `;
 
-export const TileContainer = styled.div`
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-    justify-content: stretch;
-    align-items: stretch;
-    width: 100%;
-    gap: 6px;
-
-    &:last-child {
-        flex-grow: 2;
-    }
-`;
-
-export const TileItem = styled.div`
+export const TileItem = styled(motion.div)`
     height: 65px;
-    min-width: 140px;
-    flex-shrink: 0;
+    width: 155px;
+    flex-shrink: 1;
     flex-grow: 1;
     padding: 10px;
     background-color: ${({ theme }) => theme.palette.background.paper};
@@ -40,11 +26,11 @@ export const TileItem = styled.div`
     color: ${({ theme }) => theme.palette.text.secondary};
     font-size: 12px;
     font-weight: 500;
+    position: relative;
 `;
 export const TileTop = styled.div`
     display: flex;
     justify-content: space-between;
-    width: 100%;
 `;
 
 export const StatWrapper = styled(motion.div)<{ $useLowerCase?: boolean }>`
@@ -56,4 +42,11 @@ export const StatWrapper = styled(motion.div)<{ $useLowerCase?: boolean }>`
 export const Unit = styled.div`
     line-height: 1;
     font-size: 10px;
+`;
+
+export const TileContainer = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    gap: 6px;
 `;


### PR DESCRIPTION
Description
---
- fix small chip vertical alignment
- remove last child expanded styling and set all stats cards the same with
- remove chip name state card
- use tooltip/popover for estimated earnings instead of just expanding it
- add `-` for stat value if not mining or cpu/gpu mining not enabled

Motivation and Context
---

- used wrong section from designs - updated per standup

How Has This Been Tested?
---


- locally 

https://github.com/user-attachments/assets/de94c6c0-e9db-42ba-8abd-8deef43ea7a8



https://github.com/user-attachments/assets/7867cf03-786b-4adf-bdc3-17dc46b865b2

