### PR TITLE
fix: balance check for success animation

### DIFF
--- a/src/hooks/mining/useBalanceChanges.ts
+++ b/src/hooks/mining/useBalanceChanges.ts
@@ -23,6 +23,9 @@ export function useBalanceChanges() {
     const block_height = useBaseNodeStatusStore(useShallow((s) => s.block_height));
     const balance = useWalletStore(useShallow((s) => s.balance));
 
+    const balanceRef = useRef(balance);
+    const blockHeightRef = useRef(block_height);
+
     const {
         setDisplayBlockHeight,
         setEarnings,
@@ -45,12 +48,10 @@ export function useBalanceChanges() {
     const isGPUMining = useGPUStatusStore(useShallow((s) => s.is_mining));
     const isMining = isCPUMining || isGPUMining;
 
-    const balanceRef = useRef(balance);
-    const blockHeightRef = useRef(block_height);
-
     const handleBalanceChange = useCallback(() => {
         setTimerPaused(true);
-        const balanceHasChanges = balanceRef.current > 0 && balance > 0 && balanceRef.current != balance;
+
+        const balanceHasChanges = balance > 0 && balanceRef.current != balance;
         if (balanceHasChanges) {
             const diff = balance - balanceRef.current;
             logBalanceChanges({ balance, prevBalance: balanceRef.current, balanceDiff: diff });
@@ -76,7 +77,7 @@ export function useBalanceChanges() {
     }, [block_height, balance, isMining, setDisplayBlockHeight]);
 
     useEffect(() => {
-        if (balanceRef.current !== balance) {
+        if (balance > 0 && balanceRef.current !== balance) {
             setBalanceChangeBlock(block_height);
         }
     }, [block_height, balance]);

--- a/src/hooks/mining/useBalanceChanges.ts
+++ b/src/hooks/mining/useBalanceChanges.ts
@@ -55,12 +55,12 @@ export function useBalanceChanges() {
         if (balanceHasChanges) {
             const diff = balance - balanceRef.current;
             logBalanceChanges({ balance, prevBalance: balanceRef.current, balanceDiff: diff });
-            const hasEarnings = Boolean(balanceRef.current > 0 && balance > 0 && diff && diff > 0);
+            const hasEarnings = Boolean(balance > 0 && diff > 0 && diff !== balance);
             if (hasEarnings) {
                 setEarnings(diff);
                 handleWin();
-                balanceRef.current = balance;
             }
+            balanceRef.current = balance;
         } else {
             handleFail();
         }


### PR DESCRIPTION
Description
---
previously changed the balanceRef check (to check for 0) so it wouldn't show success/earnings when changing from 0 to balance, but that broke the flow since it never registered any changes in balance because the initial value was 0, and ref was only updated after balance change, so fixed the logic: 

- removed check for 0 on the ref from `balanceHasChanges`
- changed `hasEarnings` to just check that balance isn't 0, but diff != balance (fixes original issue

