### PR TITLE
feat(ui): experimental settings switch

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -40,5 +40,7 @@
   "yes": "Yes",
   "cancel": "Cancel",
   "reset-settings": "Reset Settings",
-  "reset-permanently": "Are you sure you want to reset all settings permanently?"
+  "reset-permanently": "Are you sure you want to reset all settings permanently?",
+  "experimental-title": "Experimental Features",
+  "experimental-warning": "⚠️ Warning: These features are under active development and could behave unpredictably. Please proceed carefully."
 }

--- a/src/containers/SideBar/components/Settings/ExperimentalWarning.tsx
+++ b/src/containers/SideBar/components/Settings/ExperimentalWarning.tsx
@@ -1,0 +1,34 @@
+import { Typography } from '@app/components/elements/Typography.tsx';
+import { ToggleSwitch } from '@app/components/elements/ToggleSwitch';
+import { Stack } from '@app/components/elements/Stack';
+import { useTranslation } from 'react-i18next';
+import { useUIStore } from '@app/store/useUIStore';
+import styled from 'styled-components';
+
+const ExperimentalContainer = styled.div`
+    padding: 15px;
+    border-radius: 5px;
+    box-shadow: 0 4px 45px 0 rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+export default function ExperimentalWarning() {
+    const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
+
+    const { showExperimental, setShowExperimental } = useUIStore((s) => ({
+        showExperimental: s.showExperimental,
+        setShowExperimental: s.setShowExperimental,
+    }));
+
+    return (
+        <ExperimentalContainer>
+            <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <Typography variant="h6">{t('experimental-title', { ns: 'settings' })}</Typography>
+                <ToggleSwitch checked={showExperimental} onChange={() => setShowExperimental(!showExperimental)} />
+            </Stack>
+            <Typography variant="p">{t('experimental-warning', { ns: 'settings' })}</Typography>
+        </ExperimentalContainer>
+    );
+}

--- a/src/containers/SideBar/components/Settings/Markups/SeedWordsMarkup/SeedWords.tsx
+++ b/src/containers/SideBar/components/Settings/Markups/SeedWordsMarkup/SeedWords.tsx
@@ -2,39 +2,70 @@ import { Typography } from '@app/components/elements/Typography.tsx';
 import { Stack } from '@app/components/elements/Stack.tsx';
 import styled from 'styled-components';
 
+import { IconButton } from '@app/components/elements/Button.tsx';
+import { IoCopyOutline, IoCheckmarkOutline } from 'react-icons/io5';
+import { useState, useCallback } from 'react';
+import { useGetSeedWords } from './useGetSeedWords';
+
 export interface SeedWordsProps {
     showSeedWords: boolean;
     seedWords: string[];
 }
 
 export const SeedWordsContainer = styled.div`
+    position: relative;
     display: grid;
+    grid-template-rows: repeat(6, 1fr);
     grid-auto-flow: column;
-    grid-template-rows: repeat(12, 1fr);
-    gap: 10px;
+    gap: 15px;
+    background-color: ${({ theme }) => theme.palette.background.default};
+    width: 100%;
+    border-radius: 10px;
+    padding: 20px;
+`;
+
+export const CopyIconContainer = styled.div`
+    position: absolute;
+    top: 10px;
+    right: 10px;
 `;
 
 export const SeedWords = ({ showSeedWords, seedWords }: SeedWordsProps) => {
+    const [isCopyTooltipHidden, setIsCopyTooltipHidden] = useState(true);
+    const { getSeedWords, seedWordsFetched } = useGetSeedWords();
+
+    const copySeedWords = useCallback(async () => {
+        if (!seedWordsFetched) {
+            await getSeedWords();
+        }
+        setIsCopyTooltipHidden(false);
+        await navigator.clipboard.writeText(seedWords.join(' '));
+        setTimeout(() => setIsCopyTooltipHidden(true), 1000);
+    }, [seedWords, seedWordsFetched, getSeedWords]);
+
     return (
-        <Stack direction="column" justifyContent="space-between">
-            <Typography variant="p">
-                {showSeedWords ? (
-                    <SeedWordsContainer>
-                        {seedWords.map((word, index) => (
-                            <Stack key={word} direction="row" justifyContent="flex-start" alignItems="center">
-                                <Typography key={index} style={{ color: '#000' }} variant="h6">
-                                    {index + 1}.
-                                </Typography>
-                                <Typography variant="p" key={word}>
-                                    {word}
-                                </Typography>
-                            </Stack>
-                        ))}
-                    </SeedWordsContainer>
-                ) : (
-                    '****************************************************'
-                )}
-            </Typography>
-        </Stack>
+        <>
+            {showSeedWords ? (
+                <SeedWordsContainer>
+                    {seedWords.map((word, index) => (
+                        <Stack key={word} direction="row" justifyContent="flex-start">
+                            <Typography key={index} variant="p" style={{ minWidth: 15 }}>
+                                {index + 1}.
+                            </Typography>
+                            <Typography variant="p" key={word}>
+                                {word}
+                            </Typography>
+                        </Stack>
+                    ))}
+                    <CopyIconContainer>
+                        <IconButton onClick={copySeedWords}>
+                            {isCopyTooltipHidden ? <IoCopyOutline /> : <IoCheckmarkOutline />}
+                        </IconButton>
+                    </CopyIconContainer>
+                </SeedWordsContainer>
+            ) : (
+                <Typography variant="p">****************************************************</Typography>
+            )}
+        </>
     );
 };

--- a/src/containers/SideBar/components/Settings/Markups/SeedWordsMarkup/SeedWordsMarkup.tsx
+++ b/src/containers/SideBar/components/Settings/Markups/SeedWordsMarkup/SeedWordsMarkup.tsx
@@ -4,12 +4,11 @@ import { Stack } from '@app/components/elements/Stack.tsx';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { IconButton } from '@app/components/elements/Button.tsx';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
-import { IoCopyOutline, IoEyeOutline, IoEyeOffOutline, IoCheckmarkOutline } from 'react-icons/io5';
+import { IoEyeOutline, IoEyeOffOutline } from 'react-icons/io5';
 import { SeedWords } from './SeedWords';
 
 const SeedWordsMarkup = () => {
     const [showSeedWords, setShowSeedWords] = useState(false);
-    const [isCopyTooltipHidden, setIsCopyTooltipHidden] = useState(true);
     const { seedWords, getSeedWords, seedWordsFetched, seedWordsFetching } = useGetSeedWords();
 
     const toggleSeedWordsVisibility = useCallback(async () => {
@@ -19,27 +18,10 @@ const SeedWordsMarkup = () => {
         setShowSeedWords((prev) => !prev);
     }, [seedWordsFetched, getSeedWords]);
 
-    const copySeedWords = useCallback(async () => {
-        if (!seedWordsFetched) {
-            await getSeedWords();
-        }
-        setIsCopyTooltipHidden(false);
-        await navigator.clipboard.writeText(seedWords.join(' '));
-        setTimeout(() => setIsCopyTooltipHidden(true), 1000);
-    }, [seedWords, seedWordsFetched, getSeedWords]);
-
     return (
         <Stack>
-            <Stack direction="row" justifyContent="space-between" style={{ height: 40 }}>
+            <Stack direction="row" style={{ height: 40 }} justifyContent="flex-start" alignItems="center">
                 <Typography variant="h6">Seed Words</Typography>
-                {showSeedWords && seedWordsFetched && (
-                    <IconButton onClick={copySeedWords}>
-                        {isCopyTooltipHidden ? <IoCopyOutline /> : <IoCheckmarkOutline />}
-                    </IconButton>
-                )}
-            </Stack>
-            <Stack direction="row" justifyContent="space-between">
-                <SeedWords showSeedWords={showSeedWords} seedWords={seedWords} />
                 <IconButton onClick={toggleSeedWordsVisibility} disabled={seedWordsFetching}>
                     {seedWordsFetching ? (
                         <CircularProgress />
@@ -50,6 +32,7 @@ const SeedWordsMarkup = () => {
                     )}
                 </IconButton>
             </Stack>
+            <SeedWords showSeedWords={showSeedWords} seedWords={seedWords} />
         </Stack>
     );
 };

--- a/src/containers/SideBar/components/Settings/Settings.tsx
+++ b/src/containers/SideBar/components/Settings/Settings.tsx
@@ -29,58 +29,65 @@ import CpuMiningMarkup from './Markups/CpuMiningMarkup';
 import P2pMarkup from './Markups/P2pMarkup';
 import GpuMiningMarkup from './Markups/GpuMiningMarkup';
 import SeedWordsMarkup from './Markups/SeedWordsMarkup';
-
-const GeneralTab = () => (
-    <Stack gap={10}>
-        <MoneroAddressMarkup />
-        <Divider />
-        <SeedWordsMarkup />
-        <Divider />
-        <HorisontalBox>
-            <CpuMiningMarkup />
-            <GpuMiningMarkup />
-        </HorisontalBox>
-        <Divider />
-        <LogsSettings />
-        <Divider />
-        <LanguageSettings />
-        <Divider />
-        <AirdropPermissionSettings />
-        <Divider />
-        <HorisontalBox>
-            <ResetSettingsButton />
-        </HorisontalBox>
-    </Stack>
-);
-
-const ExperimentalTab = () => (
-    <Stack gap={10}>
-        <WalletAddressMarkup />
-        <Divider />
-        <P2pMarkup />
-        <Divider />
-        <DebugSettings />
-        <Divider />
-        <P2pMarkup />
-        <Divider />
-        <HardwareStatus />
-        <Divider />
-        <AppVersions />
-        <Divider />
-        <Stack direction="row" justifyContent="space-between">
-            <VisualMode />
-        </Stack>
-    </Stack>
-);
-
-const tabs = [
-    { label: 'General', content: <GeneralTab /> },
-    { label: 'Experimental', content: <ExperimentalTab /> },
-];
+import ExperimentalWarning from './ExperimentalWarning';
+import { useUIStore } from '@app/store/useUIStore';
 
 export default function Settings() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const [open, setOpen] = useState(false);
+    const showExperimental = useUIStore((s) => s.showExperimental);
+
+    const GeneralTab = () => (
+        <Stack gap={10}>
+            <MoneroAddressMarkup />
+            <Divider />
+            <SeedWordsMarkup />
+            <Divider />
+            <HorisontalBox>
+                <CpuMiningMarkup />
+                <GpuMiningMarkup />
+            </HorisontalBox>
+            <Divider />
+            <LogsSettings />
+            <Divider />
+            <LanguageSettings />
+            <Divider />
+            <AirdropPermissionSettings />
+            <Divider />
+            <HorisontalBox>
+                <ResetSettingsButton />
+            </HorisontalBox>
+        </Stack>
+    );
+
+    const ExperimentalTab = () => (
+        <Stack gap={10}>
+            <ExperimentalWarning />
+            {showExperimental && (
+                <>
+                    <Divider />
+                    <WalletAddressMarkup />
+                    <Divider />
+                    <P2pMarkup />
+                    <Divider />
+                    <DebugSettings />
+                    <Divider />
+                    <HardwareStatus />
+                    <Divider />
+                    <AppVersions />
+                    <Divider />
+                    <Stack direction="row" justifyContent="space-between">
+                        <VisualMode />
+                    </Stack>
+                </>
+            )}
+        </Stack>
+    );
+
+    const tabs = [
+        { label: t('tabs.general', { ns: 'settings' }), content: <GeneralTab /> },
+        { label: t('tabs.experimental', { ns: 'settings' }), content: <ExperimentalTab /> },
+    ];
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -7,6 +7,7 @@ interface State {
     view: viewType;
     visualMode: boolean;
     sidebarOpen: boolean;
+    showExperimental: boolean;
 }
 interface Actions {
     setShowSplash: (showSplash: boolean) => void;
@@ -14,6 +15,7 @@ interface Actions {
     setView: (view: State['view']) => void;
     toggleVisualMode: () => void;
     setSidebarOpen: (sidebarOpen: State['sidebarOpen']) => void;
+    setShowExperimental: (showExperimental: boolean) => void;
 }
 
 type UIStoreState = State & Actions;
@@ -24,6 +26,7 @@ const initialState: State = {
     view: 'setup',
     visualMode: true,
     sidebarOpen: false,
+    showExperimental: false,
 };
 
 export const useUIStore = create<UIStoreState>()((set) => ({
@@ -33,4 +36,5 @@ export const useUIStore = create<UIStoreState>()((set) => ({
     setView: (view) => set({ view }),
     toggleVisualMode: () => set((state) => ({ visualMode: !state.visualMode })),
     setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
+    setShowExperimental: (showExperimental) => set({ showExperimental }),
 }));


### PR DESCRIPTION
Description
---
Add a switch to show or hide experimental settings
Updated the layout of seed words

Motivation and Context
---
Users were using the experimental settings that are still under development and experiencing bugs

How Has This Been Tested?
---
Manually

![Screenshot 2024-09-11 at 15 42 38](https://github.com/user-attachments/assets/6709e2c4-25a9-47f3-a747-2c89083a71d5)

![Screenshot 2024-09-11 at 15 43 39](https://github.com/user-attachments/assets/28104f19-5bbf-4731-a4e2-a56efc71736b)

What process can a PR reviewer use to test or verify this change?
---
Go to settings / experimental and switch them on or off

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
