### PR TITLE
fix: fix duplicated p2pool enabled checkbox and added p2pool stats

### DIFF
--- a/src/containers/SideBar/components/Settings/Markups/P2pMarkup.tsx
+++ b/src/containers/SideBar/components/Settings/Markups/P2pMarkup.tsx
@@ -38,7 +38,10 @@ const P2pMarkup = () => {
     return (
         <MinerContainer>
             <Stack>
-                <Typography variant="h6">{t('pool-mining', { ns: 'settings' })}</Typography>
+                <Typography variant="h6">
+                    {t('pool-mining', { ns: 'settings' })}
+                    <b>&nbsp;(APP RESTART REQUIRED)</b>
+                </Typography>
                 <Stack direction="row" justifyContent="space-between">
                     <Typography variant="p">{t('pool-mining-description', { ns: 'settings' })}</Typography>
                     <ToggleSwitch

--- a/src/containers/SideBar/components/Settings/Markups/P2poolStatsMarkup.tsx
+++ b/src/containers/SideBar/components/Settings/Markups/P2poolStatsMarkup.tsx
@@ -17,6 +17,12 @@ const P2PoolStats = () => {
         }))
     );
 
+    const { isP2poolEnabled } = useAppStatusStore(
+        useShallow((s) => ({
+            isP2poolEnabled: s.p2pool_enabled,
+        }))
+    );
+
     const p2poolSha3Stats = p2poolStats?.sha3;
     const p2poolRandomXStats = p2poolStats?.randomx;
     const p2poolTribe = p2poolSha3Stats?.tribe?.name;
@@ -35,7 +41,7 @@ const P2PoolStats = () => {
             ? p2poolSha3UserTotalEarnings + p2poolRandomxUserTotalEarnings
             : 0;
 
-    return (
+    return isP2poolEnabled ? (
         <MinerContainer>
             <Stack>
                 <Typography variant="h6">{t('p2pool-stats', { ns: 'settings' })}</Typography>
@@ -122,7 +128,7 @@ const P2PoolStats = () => {
                 </CardContainer>
             </Stack>
         </MinerContainer>
-    );
+    ) : null;
 };
 
 export default P2PoolStats;

--- a/src/containers/SideBar/components/Settings/Settings.tsx
+++ b/src/containers/SideBar/components/Settings/Settings.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
-import { IoSettingsOutline, IoClose } from 'react-icons/io5';
+import { IoClose, IoSettingsOutline } from 'react-icons/io5';
 
 import VisualMode from '../../../Dashboard/components/VisualMode';
-import { HorisontalBox, HeadingContainer } from './Settings.styles';
+import { HeadingContainer, HorisontalBox } from './Settings.styles';
 
 import AirdropPermissionSettings from '@app/containers/Airdrop/AirdropPermissionSettings/AirdropPermissionSettings.tsx';
 import LogsSettings from './LogsSettings';
@@ -27,6 +27,7 @@ import MoneroAddressMarkup from './Markups/MoneroAddressMarkup';
 import WalletAddressMarkup from './Markups/WalletAddressMarkup';
 import CpuMiningMarkup from './Markups/CpuMiningMarkup';
 import P2pMarkup from './Markups/P2pMarkup';
+import P2poolStatsMarkup from './Markups/P2poolStatsMarkup';
 import GpuMiningMarkup from './Markups/GpuMiningMarkup';
 import SeedWordsMarkup from './Markups/SeedWordsMarkup';
 
@@ -59,9 +60,10 @@ const ExperimentalTab = () => (
         <Divider />
         <P2pMarkup />
         <Divider />
+        <P2poolStatsMarkup />
+        <Divider />
         <DebugSettings />
         <Divider />
-        <P2pMarkup />
         <Divider />
         <HardwareStatus />
         <Divider />


### PR DESCRIPTION
Description
---
In experimental tab in settings modal, p2pool enabled/disabled checkbox was duplicated, it was fixed and added p2pool stats when p2pool is enabled in experimental tab.

Motivation and Context
---

How Has This Been Tested?
---
- Start Universe
- Check settings

![image](https://github.com/user-attachments/assets/fe7823e1-25f8-468c-9d88-f98620ed380d)
![image](https://github.com/user-attachments/assets/a3a6930b-f767-4b96-bf1b-c0c5bbc47c70)


What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
