### PR TITLE
fix(setup): critical errors when setup application

### DIFF
--- a/public/locales/af/common.json
+++ b/public/locales/af/common.json
@@ -14,5 +14,8 @@
     "utilization": "Benutting",
     "mode": "Modus",
     "day": "Dag",
-    "shutting-down": "Afskakel.."
+    "shutting-down": "Afskakel..",
+    "critical-error": "Critical error",
+    "please-try-again-later": "Please try again later. If the problem persists, please contact us.",
+    "close-tari-universe": "Close Tari Universe"
 }

--- a/public/locales/cn/common.json
+++ b/public/locales/cn/common.json
@@ -16,5 +16,8 @@
     "day": "天",
     "shutting-down": "停工..",
     "tari-universe": "Tari Universe",
-    "testnet": "测试网"
+    "testnet": "测试网",
+    "critical-error": "Critical error",
+    "please-try-again-later": "Please try again later. If the problem persists, please contact us.",
+    "close-tari-universe": "Close Tari Universe"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -16,5 +16,8 @@
     "day": "Day",
     "shutting-down": "Shutting down..",
     "tari-universe": "Tari Universe",
-    "testnet": "Testnet"
+    "testnet": "Testnet",
+    "critical-error": "Critical error",
+    "please-try-again-later": "Please try again later. If the problem persists, please contact us.",
+    "close-tari-universe": "Close Tari Universe"
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -14,5 +14,8 @@
     "utilization": "Wykorzystanie",
     "mode": "Tryb",
     "day": "Dzień",
-    "shutting-down": "Wyłączanie.."
+    "shutting-down": "Wyłączanie..",
+    "critical-error": "Krytyczny błąd",
+    "please-try-again-later": "Spróbuj ponownie później. Jeśli problem będzie się powtarzał, skontaktuj się z nami.",
+    "close-tari-universe": "Zamknij Tari Universe"
 }

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -16,5 +16,8 @@
     "day": "Gün",
     "shutting-down": "Kapatılıyor..",
     "tari-universe": "Tari Universe",
-    "testnet": "Testnet"
+    "testnet": "Testnet",
+    "critical-error": "Critical error",
+    "please-try-again-later": "Please try again later. If the problem persists, please contact us.",
+    "close-tari-universe": "Close Tari Universe"
 }

--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -451,7 +451,7 @@ impl BinaryResolver {
             .write()
             .await
             .insert(binary, version.clone());
-        return Ok(version);
+        Ok(version)
     }
 
     pub async fn get_latest_version(&self, binary: Binaries) -> Version {

--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -392,27 +392,30 @@ impl BinaryResolver {
                                 Err(e) => {
                                     error!(target:LOG_TARGET, "Failed to unwrap DirEntry: {}", e);
                                     continue;
-                                },
+                                }
                             };
                             let path = entry.path();
                             if path.is_dir() {
                                 // Check for actual binary existing. It can happen that the folder is there,
                                 // for in_progress downloads or perhaps the antivirus has quarantined the file
-                                let mut executable_name = match get_binary_name(binary, path.clone()) {
+                                let mut executable_name = match get_binary_name(
+                                    binary,
+                                    path.clone(),
+                                ) {
                                     Ok(name) => name,
                                     Err(e) => {
                                         error!(target: LOG_TARGET, "Failed to get binary name: {:?}", e);
                                         continue;
                                     }
                                 };
-                
+
                                 if cfg!(target_os = "windows") {
                                     executable_name = executable_name.with_extension("exe");
                                 }
                                 if !executable_name.exists() {
                                     continue;
                                 }
-                
+
                                 let version = path.file_name().unwrap().to_str().unwrap();
                                 versions.push(Version::parse(version).unwrap());
                             }
@@ -423,21 +426,21 @@ impl BinaryResolver {
                             let cached_version = versions.pop().unwrap();
                             let current_version = self.get_latest_version(binary).await;
                             let highest_version = cached_version.max(current_version);
-                    
+
                             self.latest_versions
                                 .write()
                                 .await
                                 .insert(binary, highest_version.clone());
-                    
-                            return Ok(highest_version.clone())
+
+                            return Ok(highest_version.clone());
                         }
-                    },
+                    }
                     Err(_) => match std::fs::create_dir_all(&bin_folder) {
                         Ok(_) => info!(target:LOG_TARGET, "Created bin dir: {:?}", bin_folder),
                         Err(e) => error!(target:LOG_TARGET, "Failed to create dir: {}", e),
                     },
                 }
-            },
+            }
             None => return Err(anyhow!("No latest version adapter for this binary")),
         }
         // If no local versions were found, download the latest version

--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use regex::Regex;
 use semver::{Version, VersionReq};
 use tari_common::configuration::Network;

--- a/src-tauri/src/binary_resolver.rs
+++ b/src-tauri/src/binary_resolver.rs
@@ -379,80 +379,76 @@ impl BinaryResolver {
         binary: Binaries,
         progress_tracker: ProgressTracker,
     ) -> Result<Version, Error> {
-        let adapter = self
-            .adapters
-            .get(&binary)
-            .ok_or_else(|| anyhow!("No latest version adapter for this binary"))?;
-        let bin_folder = adapter.get_binary_folder();
-        let version_folders_list = match std::fs::read_dir(&bin_folder) {
-            Ok(list) => list,
-            Err(_) => match std::fs::create_dir_all(&bin_folder) {
-                Ok(_) => std::fs::read_dir(&bin_folder).unwrap(),
-                Err(e) => {
-                    return Err(anyhow!("Failed to create dir: {}", e));
+        match self.adapters.get(&binary) {
+            Some(adapter) => {
+                let bin_folder = adapter.get_binary_folder();
+                match std::fs::read_dir(&bin_folder) {
+                    Ok(version_folders_list) => {
+                        // Search for all valid versions of the binary
+                        let mut versions = vec![];
+                        for entry in version_folders_list {
+                            let entry = match entry {
+                                Ok(entry) => entry,
+                                Err(e) => {
+                                    error!(target:LOG_TARGET, "Failed to unwrap DirEntry: {}", e);
+                                    continue;
+                                },
+                            };
+                            let path = entry.path();
+                            if path.is_dir() {
+                                // Check for actual binary existing. It can happen that the folder is there,
+                                // for in_progress downloads or perhaps the antivirus has quarantined the file
+                                let mut executable_name = match get_binary_name(binary, path.clone()) {
+                                    Ok(name) => name,
+                                    Err(e) => {
+                                        error!(target: LOG_TARGET, "Failed to get binary name: {:?}", e);
+                                        continue;
+                                    }
+                                };
+                
+                                if cfg!(target_os = "windows") {
+                                    executable_name = executable_name.with_extension("exe");
+                                }
+                                if !executable_name.exists() {
+                                    continue;
+                                }
+                
+                                let version = path.file_name().unwrap().to_str().unwrap();
+                                versions.push(Version::parse(version).unwrap());
+                            }
+                        }
+
+                        if !versions.is_empty() {
+                            versions.sort();
+                            let cached_version = versions.pop().unwrap();
+                            let current_version = self.get_latest_version(binary).await;
+                            let highest_version = cached_version.max(current_version);
+                    
+                            self.latest_versions
+                                .write()
+                                .await
+                                .insert(binary, highest_version.clone());
+                    
+                            return Ok(highest_version.clone())
+                        }
+                    },
+                    Err(_) => match std::fs::create_dir_all(&bin_folder) {
+                        Ok(_) => info!(target:LOG_TARGET, "Created bin dir: {:?}", bin_folder),
+                        Err(e) => error!(target:LOG_TARGET, "Failed to create dir: {}", e),
+                    },
                 }
             },
-        };
-        let mut versions = vec![];
-        for entry in version_folders_list {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(_) => continue,
-            };
-            let path = entry.path();
-            if path.is_dir() {
-                // Check for actual binary existing. It can happen that the folder is there,
-                // for in_progress downloads or perhaps the antivirus has quarantined the file
-                let mut executable_name = get_binary_name(binary, path.clone())?;
-
-                if cfg!(target_os = "windows") {
-                    executable_name = executable_name.with_extension("exe");
-                }
-
-                if !executable_name.exists() {
-                    continue;
-                }
-
-                let version = path.file_name().unwrap().to_str().unwrap();
-                let version_typed = Version::parse(version).unwrap();
-                if adapter.is_version_allowed(&version_typed) {
-                    versions.push(version_typed);
-                } else {
-                    warn!(target: LOG_TARGET, "Version {} is not allowed", version);
-                }
-            }
+            None => return Err(anyhow!("No latest version adapter for this binary")),
         }
-
-        if versions.is_empty() {
-            match self
-                .ensure_latest_inner(binary, true, progress_tracker)
-                .await
-            {
-                Ok(version) => {
-                    self.latest_versions
-                        .write()
-                        .await
-                        .insert(binary, version.clone());
-                    return Ok(version);
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            }
-        }
-
-        versions.sort();
-        let cached_version = versions.pop().unwrap();
-        let current_version = self.get_latest_version(binary).await;
-
-        let highest_version = cached_version.max(current_version);
-
+        // If no local versions were found, download the latest version
+        let version = self
+            .ensure_latest_inner(binary, true, progress_tracker)
+            .await?;
         self.latest_versions
             .write()
             .await
-            .insert(binary, highest_version.clone());
-
-        Ok(highest_version.clone())
+            .insert(binary, version.clone());
+        return Ok(version);
     }
 
     pub async fn get_latest_version(&self, binary: Binaries) -> Version {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -313,10 +313,10 @@ async fn setup_inner(
     if now
         .duration_since(last_binaries_update_timestamp)
         .unwrap_or(Duration::from_secs(0))
-        > Duration::from_secs(0)
+        > Duration::from_secs(60 * 10)
     // 10 minutes
     {
-        let _ = state
+        let _unused = state
             .config
             .write()
             .await
@@ -327,7 +327,7 @@ async fn setup_inner(
         progress
             .update("checking-latest-version-node".to_string(), None, 0)
             .await;
-        let _ = BinaryResolver::current()
+        let _unused = BinaryResolver::current()
             .ensure_latest(Binaries::MinotariNode, progress.clone())
             .await;
         sleep(Duration::from_secs(1));
@@ -337,7 +337,7 @@ async fn setup_inner(
             .update("checking-latest-version-mmproxy".to_string(), None, 0)
             .await;
         sleep(Duration::from_secs(1));
-        let _ = BinaryResolver::current()
+        let _unused = BinaryResolver::current()
             .ensure_latest(Binaries::MergeMiningProxy, progress.clone())
             .await;
         progress.set_max(20).await;
@@ -345,7 +345,7 @@ async fn setup_inner(
             .update("checking-latest-version-wallet".to_string(), None, 0)
             .await;
         sleep(Duration::from_secs(1));
-        let _ = BinaryResolver::current()
+        let _unused = BinaryResolver::current()
             .ensure_latest(Binaries::Wallet, progress.clone())
             .await;
 
@@ -354,7 +354,7 @@ async fn setup_inner(
         progress
             .update("checking-latest-version-gpuminer".to_string(), None, 0)
             .await;
-        let _ = BinaryResolver::current()
+        let _unused = BinaryResolver::current()
             .ensure_latest(Binaries::GpuMiner, progress.clone())
             .await;
 
@@ -365,14 +365,14 @@ async fn setup_inner(
             .update("checking-latest-version-xmrig".to_string(), None, 0)
             .await;
         sleep(Duration::from_secs(1));
-        let _ = XmrigAdapter::ensure_latest(cache_dir, false, progress.clone()).await;
+        let _unused = XmrigAdapter::ensure_latest(cache_dir, false, progress.clone()).await;
 
         progress.set_max(35).await;
         progress
             .update("checking-latest-version-sha-p2pool".to_string(), None, 0)
             .await;
         sleep(Duration::from_secs(1));
-        let _ = BinaryResolver::current()
+        let _unused = BinaryResolver::current()
             .ensure_latest(Binaries::ShaP2pool, progress.clone())
             .await;
     }
@@ -1311,12 +1311,12 @@ fn main() {
         tauri::RunEvent::ExitRequested { api: _, .. } => {
             // api.prevent_exit();
             info!(target: LOG_TARGET, "App shutdown caught");
-            let _ = block_on(stop_all_miners(app_state.clone(), 2));
+            let _unused = block_on(stop_all_miners(app_state.clone(), 2));
             info!(target: LOG_TARGET, "App shutdown complete");
         }
         tauri::RunEvent::Exit => {
             info!(target: LOG_TARGET, "App shutdown caught");
-            let _ = block_on(stop_all_miners(app_state.clone(), 2));
+            let _unused = block_on(stop_all_miners(app_state.clone(), 2));
             info!(target: LOG_TARGET, "Tari Universe v{} shut down successfully", _app_handle.package_info().version);
         }
         RunEvent::MainEventsCleared => {

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -103,7 +103,7 @@ impl NodeManager {
         let status_monitor = status_monitor_lock
             .status_monitor
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Node not started"))?;
+            .ok_or_else(|| anyhow::anyhow!("wait_synced: Node not started"))?;
         status_monitor.wait_synced(progress_tracker).await
     }
 
@@ -163,7 +163,7 @@ impl NodeManager {
         let status_monitor = status_monitor_lock
             .status_monitor
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Node not started"))?;
+            .ok_or_else(|| anyhow::anyhow!("get_identity: Node not started"))?;
         status_monitor.get_identity().await
     }
 

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -71,6 +71,14 @@ impl Default for P2poolConfig {
     }
 }
 
+impl Clone for P2poolManager {
+    fn clone(&self) -> Self {
+        Self {
+            watcher: self.watcher.clone(),
+        }
+    }
+}
+
 pub struct P2poolManager {
     watcher: Arc<RwLock<ProcessWatcher<P2poolAdapter>>>,
 }

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -77,7 +77,7 @@ impl XmrigAdapter {
 
     pub async fn get_latest_local_version(cache_dir: PathBuf) -> Result<String, Error> {
         let mut latest_version = None;
-        let xmrig_dir = cache_dir.join("xmrig");
+        let xmrig_dir = cache_dir.join("binaries").join("xmrig");
         if !xmrig_dir.exists() {
             return Err(anyhow::anyhow!(
                 "Failed to get latest release and no local version for xmrig found"
@@ -125,6 +125,7 @@ impl XmrigAdapter {
         };
 
         let xmrig_dir = cache_dir
+            .join("binaries")
             .join("xmrig")
             .join(latest_release.version.to_string());
         if force_download && xmrig_dir.exists() {
@@ -136,14 +137,14 @@ impl XmrigAdapter {
         if !xmrig_dir.exists() {
             println!("Latest version of xmrig doesn't exist");
             println!("latest version is {}", latest_release.version);
-            let in_progress_dir = cache_dir.join("xmrig").join("in_progress");
+            let in_progress_dir = cache_dir.join("binaries").join("xmrig").join("in_progress");
             if in_progress_dir.exists() {
                 println!("Trying to delete dir {:?}", in_progress_dir);
                 match fs::remove_dir(&in_progress_dir).await {
                     Ok(_) => {}
                     Err(e) => {
                         println!("Failed to delete dir {:?}", e);
-                        // return Err(e.into());
+                        // TODO: Is this critital error?
                     }
                 }
             }
@@ -212,6 +213,7 @@ impl ProcessAdapter for XmrigAdapter {
                 handle: Some(tokio::spawn(async move {
                     let xmrig_dir = cache_dir
                         .clone()
+                        .join("binaries")
                         .join("xmrig")
                         .join(&version)
                         .join(format!("xmrig-{}", version));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import AutoUpdateDialog from './containers/AutoUpdateDialog/AutoUpdateDialog.tsx
 
 import { useMemo } from 'react';
 import SettingsDialog from './containers/SideBar/components/Settings/SettingsDialog.tsx';
+import CriticalErrorDialog from './containers/CriticalErrorDialog/CriticalErrorDialog.tsx';
 
 export default function App() {
     useSetUp();
@@ -56,6 +57,7 @@ export default function App() {
                 <MotionConfig reducedMotion="user">
                     <AutoUpdateDialog />
                     <SettingsDialog />
+                    <CriticalErrorDialog />
                     <LayoutGroup id="app-content">
                         <AirdropLogin />
                         <SplashScreen />

--- a/src/containers/CriticalErrorDialog/CriticalErrorDialog.tsx
+++ b/src/containers/CriticalErrorDialog/CriticalErrorDialog.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@app/components/elements/Button';
+import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog';
+import { Stack } from '@app/components/elements/Stack';
+import { Typography } from '@app/components/elements/Typography';
+import { IoAlertCircleOutline } from 'react-icons/io5';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { useAppStateStore } from '@app/store/appStateStore';
+import { invoke } from '@tauri-apps/api';
+import { useCallback, useState } from 'react';
+import { CircularProgress } from '@app/components/elements/CircularProgress';
+
+const StyledButton = styled(Button)(() => ({
+    marginTop: '16px',
+}));
+
+const CriticalErrorDialog = () => {
+    const { t } = useTranslation('common', { useSuspense: false });
+    const criticalError = useAppStateStore((s) => s.criticalError);
+    const [isExiting, setIsExiting] = useState(false);
+
+    const handleExit = useCallback(async () => {
+        try {
+            setIsExiting(true);
+            await invoke('exit_application');
+        } catch (e) {
+            console.error(e);
+        }
+        setIsExiting(false);
+    }, []);
+
+    return (
+        <Dialog
+            open={!!criticalError}
+            onOpenChange={() => {
+                /* void */
+            }}
+        >
+            <DialogContent>
+                <Typography variant="h1">{t('critical-error')}</Typography>
+                <Stack direction="row" alignItems="center">
+                    <IoAlertCircleOutline size={20} color="red" />
+                    <Typography variant="p" style={{ textDecoration: 'italic' }}>
+                        {criticalError}
+                    </Typography>
+                </Stack>
+                <Typography variant="p" style={{ marginTop: '8px' }}>
+                    {t('please-try-again-later')}
+                </Typography>
+                {!isExiting ? (
+                    <StyledButton color="error" onClick={handleExit}>
+                        {t('close-tari-universe')}
+                    </StyledButton>
+                ) : (
+                    <CircularProgress />
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default CriticalErrorDialog;

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -68,5 +68,6 @@ export function useSetUp() {
         setSetupDetails,
         setView,
         settingUpFinished,
+        setCriticalError,
     ]);
 }

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -15,6 +15,7 @@ export function useSetUp() {
     const fetchApplicationsVersions = useAppStateStore((s) => s.fetchApplicationsVersions);
     const fetchAppConfig = useAppConfigStore((s) => s.fetchAppConfig);
     const settingUpFinished = useAppStateStore((s) => s.settingUpFinished);
+    const setCriticalError = useAppStateStore((s) => s.setCriticalError);
 
     useEffect(() => {
         async function initialize() {
@@ -52,7 +53,7 @@ export function useSetUp() {
         if (isAfterAutoUpdate) {
             clearStorage();
             invoke('setup_application').catch((e) => {
-                setError(`Failed to setup application: ${e}`);
+                setCriticalError(`Failed to setup application: ${e}`);
                 setView('mining');
             });
         }

--- a/src/store/appStateStore.ts
+++ b/src/store/appStateStore.ts
@@ -5,12 +5,12 @@ import { invoke } from '@tauri-apps/api';
 interface AppState {
     isAfterAutoUpdate: boolean;
     setIsAfterAutoUpdate: (value: boolean) => void;
+    criticalError?: string;
+    setCriticalError: (value: string | undefined) => void;
     error?: string;
     setError: (value: string | undefined) => void;
     topStatus: string;
     setTopStatus: (value: string) => void;
-    errorOpen: boolean;
-    setErrorOpen: (value: boolean) => void;
     setupTitle: string;
     setupTitleParams: Record<string, string>;
     setupProgress: number;
@@ -27,12 +27,12 @@ interface AppState {
 export const useAppStateStore = create<AppState>()((set, getState) => ({
     isAfterAutoUpdate: false,
     setIsAfterAutoUpdate: (value: boolean) => set({ isAfterAutoUpdate: value }),
+    criticalError: undefined,
+    setCriticalError: (criticalError) => set({ criticalError }),
     error: undefined,
     setError: (error) => set({ error }),
     topStatus: 'Not mining',
     setTopStatus: (value) => set({ topStatus: value }),
-    errorOpen: false,
-    setErrorOpen: (value) => set({ errorOpen: value }),
     setupTitle: '',
     setupTitleParams: {},
     setupProgress: 0,

--- a/src/types/invoke.ts
+++ b/src/types/invoke.ts
@@ -23,6 +23,7 @@ declare module '@tauri-apps/api/tauri' {
     function invoke(param: 'get_miner_metrics'): Promise<MinerMetrics>;
     function invoke(param: 'set_gpu_mining_enabled', payload: { enabled: boolean }): Promise<void>;
     function invoke(param: 'set_cpu_mining_enabled', payload: { enabled: boolean }): Promise<void>;
+    function invoke(param: 'exit_application'): Promise<string>;
     function invoke(
         param: 'log_web_message',
         payload: { level: 'log' | 'error' | 'warn' | 'info'; message: string }


### PR DESCRIPTION
* Added `CriticalErrorDialog` for critical errors that affect the app so we have to force the exit
* Increased reliability of `setup_application`  - filtered unimportant errors so they won't be treated as critical errors
* Create common `stop_all_miners` method and use it for `tauri::RunEvent::ExitRequested`, `tauri::RunEvent::Exit` events and `reset_settings` , `exit_application` methods
* Moved xmrig binaries to the binaries directory to unify with all rest
* Small improvements: removed unused properties from appStateStore - setErrorOpen and errorOpen | implemented clone method for `P2poolManager`
![Screenshot from 2024-09-11 12-43-21](https://github.com/user-attachments/assets/aab7d23a-7be7-4171-9d8d-46d602145651)
