### PR TITLE
fix: update deps and init start logic

### DIFF
--- a/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
+++ b/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
@@ -28,7 +28,7 @@ export default function ButtonOrbitAnimation() {
                         y: 150 - size / 2,
                         x: 150 - size / 2,
                     }}
-                    transition={{ ...orbitTransition, delay: (index + 1) * 1.5 }}
+                    transition={{ ...orbitTransition, delay: index * 1.5 }}
                     animate={{ rotate: index % 2 === 0 ? 360 : -360, opacity: [0.7, 0.5, 0.8, 1] }}
                 >
                     {index % 2 === 0 ? (


### PR DESCRIPTION
- use a ref to check the initial `handleStart` since auto-mining and cpu/gpu mining flags may not be ready yet when that initially runs (so we need the dependencies there)
- also moved `window?.glApp?.stateManager.statusIndex` into an external var so the value would make a difference to the dep array
- tiny tweak to the orbit animation initial delay


---



https://github.com/user-attachments/assets/4cf9a309-1ccc-4337-b376-39a8375893e5

