### PR TITLE
fix(p2pool): set timeout for p2pool list-tribes command

### DIFF
--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -82,7 +82,13 @@ impl ProcessAdapter for P2poolAdapter {
 
                     let output = process_utils::launch_and_get_outputs(
                         &file_path,
-                        vec!["list-tribes".to_string()],
+                        vec![
+                            "list-tribes".to_string(),
+                            "--timeout".to_string(),
+                            "5".to_string(),
+                        ],
+                        // TODO: Change or remove (to use default 30 seconds)
+                        // TODO: when more than 1 tribe will be in place.
                     )
                     .await?;
                     let tribes: Vec<String> = serde_json::from_slice(&output)?;


### PR DESCRIPTION
Description
---
Now when p2pool is about to start, it will only last 5 seconds maximum to try to find squads instead of the previous 30 seconds. This decreases startup time of p2pool in universe.
