### PR TITLE
feat(ui): airdrop add gems animation to gems stats pill

### DIFF
--- a/src/containers/Airdrop/AirdropLogin/ConnectButton/styles.ts
+++ b/src/containers/Airdrop/AirdropLogin/ConnectButton/styles.ts
@@ -78,11 +78,16 @@ export const NumberPill = styled('div')`
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 1px;
 
     min-width: 63px;
     height: 23px;
 
     padding: 0 8px;
+
+    .StatsIcon-gems {
+        transform: translateX(-2px);
+    }
 `;
 
 export const Text = styled('div')`

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/GemsPill/GemsPill.tsx
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/GemsPill/GemsPill.tsx
@@ -1,0 +1,86 @@
+import { StatsPill, StatsNumber, StatsIcon, GemsAnimation, GemImage } from '../styles';
+import gemImage from '../images/gems.png';
+import { AnimatePresence, useSpring } from 'framer-motion';
+import { useEffect, useState } from 'react';
+
+interface Props {
+    value: number;
+}
+
+export default function GemsPill({ value }: Props) {
+    const [displayValue, setDisplayValue] = useState(0);
+    const [animate, setAnimate] = useState(false);
+
+    const getRandomX = (() => {
+        let lastValue = 20;
+        return () => {
+            lastValue = lastValue === 20 ? -20 : 20;
+            return lastValue;
+        };
+    })();
+
+    const getRandomRotation = (() => {
+        let lastValue = 40;
+        return () => {
+            lastValue = lastValue === 40 ? -40 : 40;
+            return lastValue;
+        };
+    })();
+
+    const spring = useSpring(0, { mass: 0.8, stiffness: 50, damping: 20 });
+
+    spring.on('change', (latest: number) => {
+        setDisplayValue(Math.round(latest));
+    });
+
+    useEffect(() => {
+        spring.set(value);
+    }, [spring, value]);
+
+    useEffect(() => {
+        setAnimate(true);
+        const timer = setTimeout(() => setAnimate(false), 1000);
+        return () => clearTimeout(timer);
+    }, [displayValue]);
+
+    return (
+        <StatsPill>
+            <StatsNumber>{displayValue.toLocaleString()}</StatsNumber>
+
+            <StatsIcon src={gemImage} alt="Gems" className="StatsIcon-gems" />
+
+            <AnimatePresence>
+                {animate && (
+                    <GemsAnimation>
+                        {[...Array(8)].map((_, i) => (
+                            <GemImage
+                                key={i}
+                                src={gemImage}
+                                alt=""
+                                initial={{
+                                    opacity: 0,
+                                    y: 120,
+                                    x: getRandomX(),
+                                    scale: 2.5,
+                                    rotate: getRandomRotation(),
+                                }}
+                                animate={{
+                                    opacity: 1,
+                                    y: 0,
+                                    x: 0,
+                                    scale: 0.8,
+                                    rotate: 0,
+                                    transition: {
+                                        duration: 1,
+                                        delay: i * 0.18,
+                                    },
+                                }}
+                                exit={{ opacity: 0 }}
+                            />
+                        ))}
+                    </GemsAnimation>
+                )}
+            </AnimatePresence>
+        </StatsPill>
+    );
+}

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/GemsPill/styles.ts
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/GemsPill/styles.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled('div')``;

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/UserInfo.tsx
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/UserInfo.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { AnimatePresence } from 'framer-motion';
 import DownloadReferralModal from './DownloadReferralModal/DownloadReferralModal';
 import { NumberPill } from '../ConnectButton/styles';
+import GemsPill from './GemsPill/GemsPill';
 
 export default function UserInfo() {
     const { logout, userDetails, airdropTokens, userPoints, wipUI } = useAirdropStore();
@@ -30,7 +31,6 @@ export default function UserInfo() {
     const { t } = useTranslation(['airdrop'], { useSuspense: false });
 
     const profileimageurl = userDetails?.user?.profileimageurl;
-    const gems = userPoints?.gems || userDetails?.user?.rank?.gems || 0;
 
     const handleClick = () => {
         setOpen(!open);
@@ -66,6 +66,12 @@ export default function UserInfo() {
         return () => document.removeEventListener('click', handleClickOutside);
     }, [handleClickOutside]);
 
+    const [gems, setGems] = useState(0);
+
+    useEffect(() => {
+        setGems(userPoints?.gems || userDetails?.user?.rank?.gems || 0);
+    }, [userPoints?.gems, userDetails?.user?.rank?.gems]);
+
     if (!wipUI) return null;
     if (!airdropTokens?.token) return null;
 
@@ -75,14 +81,11 @@ export default function UserInfo() {
         <>
             <Wrapper>
                 <StatsGroup>
-                    <StatsPill>
-                        <StatsNumber>{gems}</StatsNumber>
-                        <StatsIcon src={gemImage} alt="Gems" className="StatsIcon-gems" />
-                    </StatsPill>
+                    <GemsPill value={gems} />
 
                     {userDetails?.user?.rank?.rank && (
                         <StatsPill>
-                            <StatsNumber>Rank {userDetails?.user?.rank?.rank}</StatsNumber>
+                            <StatsNumber>Rank #{parseInt(userDetails?.user?.rank?.rank).toLocaleString()}</StatsNumber>
                         </StatsPill>
                     )}
                 </StatsGroup>

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/UserInfo.tsx
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/UserInfo.tsx
@@ -20,6 +20,7 @@ import { useAirdropStore } from '@app/store/useAirdropStore';
 import { useTranslation } from 'react-i18next';
 import { AnimatePresence } from 'framer-motion';
 import DownloadReferralModal from './DownloadReferralModal/DownloadReferralModal';
+import { NumberPill } from '../ConnectButton/styles';
 
 export default function UserInfo() {
     const { logout, userDetails, airdropTokens, userPoints, wipUI } = useAirdropStore();
@@ -32,7 +33,7 @@ export default function UserInfo() {
     const gems = userPoints?.gems || userDetails?.user?.rank?.gems || 0;
 
     const handleClick = () => {
-        setOpen(true);
+        setOpen(!open);
     };
     const handleClose = () => {
         setOpen(false);
@@ -78,7 +79,7 @@ export default function UserInfo() {
                         <StatsNumber>{gems}</StatsNumber>
                         <StatsIcon src={gemImage} alt="Gems" className="StatsIcon-gems" />
                     </StatsPill>
-                    <Divider />
+
                     {userDetails?.user?.rank?.rank && (
                         <StatsPill>
                             <StatsNumber>Rank {userDetails?.user?.rank?.rank}</StatsNumber>
@@ -99,9 +100,14 @@ export default function UserInfo() {
                     <StyledAvatar id="avatar-wrapper" $img={profileimageurl} onClick={handleClick} />
                     <AnimatePresence>
                         {open && (
-                            <Menu>
+                            <Menu initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}>
+                                <MenuItem onClick={handleReferral}>
+                                    {t('referral')}{' '}
+                                    <NumberPill>
+                                        <StatsIcon src={gemImage} alt="Gems" className="StatsIcon-gems" /> +1000
+                                    </NumberPill>
+                                </MenuItem>
                                 <MenuItem onClick={handleLogout}>{t('logout')}</MenuItem>
-                                <MenuItem onClick={handleReferral}>{t('referral')}</MenuItem>
                             </Menu>
                         )}
                     </AnimatePresence>

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/styles.ts
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/styles.ts
@@ -39,6 +39,8 @@ export const StatsPill = styled('div')`
 
     height: 36px;
     padding: 0 15px;
+    pointer-events: all;
+    position: relative;
 `;
 
 export const StatsNumber = styled('div')`
@@ -181,9 +183,24 @@ export const MenuItem = styled('div')`
 
     .StatsIcon-gems {
         width: 12px;
+        position: relative;
+        z-index: 2;
     }
 `;
 
 export const MenuWrapper = styled('div')`
     position: relative;
+`;
+
+export const GemsAnimation = styled(m.div)`
+    position: absolute;
+    top: 10px;
+    right: 33px;
+    z-index: 0;
+`;
+
+export const GemImage = styled(m.img)`
+    position: absolute;
+    top: 0;
+    left: 0;
 `;

--- a/src/containers/Airdrop/AirdropLogin/UserInfo/styles.ts
+++ b/src/containers/Airdrop/AirdropLogin/UserInfo/styles.ts
@@ -1,5 +1,5 @@
 import { m } from 'framer-motion';
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 const ring = keyframes`
   0%, 100% {
@@ -25,7 +25,7 @@ export const Wrapper = styled('div')`
 export const StatsGroup = styled('div')`
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
 `;
 
 export const StatsPill = styled('div')`
@@ -34,7 +34,8 @@ export const StatsPill = styled('div')`
     gap: 5px;
 
     border-radius: 20px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 
     height: 36px;
     padding: 0 15px;
@@ -118,37 +119,71 @@ export const StyledAvatar = styled('div')<{ $img?: string }>`
     user-select: none;
     pointer-events: all;
     cursor: pointer;
-    background-color: grey;
+    background-color: rgba(0, 0, 0, 0.1);
     width: 36px;
     height: 36px;
-    // fit background image
     background-size: cover;
     background-position: center;
 
-    ${({ $img }) => $img && `background-image: url(${$img})`}
+    ${({ $img }) =>
+        $img &&
+        css`
+            background-image: url(${$img});
+        `}
+
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 `;
 
 export const Menu = styled(m.div)`
-    width: 180px;
     position: absolute;
-    top: 110%;
+    top: 100%;
     right: 0;
     z-index: 2;
-    padding: 10px;
-    background-color: white;
+
     border-radius: 10px;
-`;
-export const MenuItem = styled('div')`
+    background: #fff;
+    box-shadow: 0px 14px 25px 0px rgba(0, 0, 0, 0.15);
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    min-width: 205px;
     padding: 10px;
-    border-radius: 6px;
-    width: 100%;
-    cursor: pointer;
     pointer-events: all;
+
+    margin-top: 12px;
+`;
+
+export const MenuItem = styled('div')`
+    color: #000;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    border-radius: 5px;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+
+    width: 100%;
+    padding: 10px 15px;
+    cursor: pointer;
     transition: background-color 0.2s ease;
+
+    white-space: nowrap;
+
     &:hover {
-        background-color: #f5f5f5;
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .StatsIcon-gems {
+        width: 12px;
     }
 `;
+
 export const MenuWrapper = styled('div')`
     position: relative;
 `;


### PR DESCRIPTION
This adds a "gem animation" when the user's gems value changes. This is for user's who are logged into Airdrop. 

https://www.loom.com/share/90cda46674c4434fbecc43680aaa7133?sid=9788e9e2-883d-4b1b-a3a8-dcb4fceec844

I also cleaned up the design for the stats pill and user menu. The previous contrast was difficult to read with the background. 

![CleanShot 2024-09-19 at 17 14 23](https://github.com/user-attachments/assets/b2ade333-83a6-4f4e-ab15-15649c5d875f)

Note: Right now this only triggers when the Gem value changes. It does play the animation on initial load, but it's usually covered by the splash screen so it is not visible. To fix this, we'll need to disable the UserInfo component until the splash screen is hidden. 

