### PR TITLE
fix(gpu): prevent app crash if gpu detect fails

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -358,7 +358,15 @@ async fn setup_inner(
             .ensure_latest(Binaries::GpuMiner, progress.clone())
             .await;
 
-        state.gpu_miner.write().await.detect().await?;
+        drop(
+            state
+                .gpu_miner
+                .write()
+                .await
+                .detect()
+                .await
+                .inspect_err(|e| error!(target: LOG_TARGET, "Could not detect gpu miner: {:?}", e)),
+        );
 
         progress.set_max(30).await;
         progress


### PR DESCRIPTION
Description
---
On my integrated intel gpu the gpu miner would fail to detect the gpu causing crash of the entire application. This PR only makes it log error and continue working as gpu mining will be disabled.

Motivation and Context
---
Stop crashing app with unsupported GPUs.

How Has This Been Tested?
---
Tested manually on my machine (Ubuntu with integrated intel gpu)

What process can a PR reviewer use to test or verify this change?
---
same as above


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
