### PR TITLE
chore: npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tari-universe",
-    "version": "0.3.10",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "0.3.10",
+            "version": "0.4.3",
             "dependencies": {
                 "@floating-ui/react": "^0.26.24",
                 "@tauri-apps/api": "^1",
@@ -1258,9 +1258,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
-            "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
+            "integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
             "cpu": [
                 "arm"
             ],
@@ -1271,9 +1271,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
-            "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
+            "integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
             "cpu": [
                 "arm64"
             ],
@@ -1284,9 +1284,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
-            "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
+            "integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1297,9 +1297,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
-            "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
+            "integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
             "cpu": [
                 "x64"
             ],
@@ -1310,9 +1310,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
-            "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
+            "integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
             "cpu": [
                 "arm"
             ],
@@ -1323,9 +1323,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
-            "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
+            "integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
             "cpu": [
                 "arm"
             ],
@@ -1336,9 +1336,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
-            "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
+            "integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
             "cpu": [
                 "arm64"
             ],
@@ -1349,9 +1349,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
-            "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
+            "integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
             "cpu": [
                 "arm64"
             ],
@@ -1362,9 +1362,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
-            "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
+            "integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1375,9 +1375,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
-            "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
+            "integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1388,9 +1388,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
-            "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
+            "integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
             "cpu": [
                 "s390x"
             ],
@@ -1401,9 +1401,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
-            "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
+            "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
             "cpu": [
                 "x64"
             ],
@@ -1414,9 +1414,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
-            "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
+            "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
             "cpu": [
                 "x64"
             ],
@@ -1427,9 +1427,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
-            "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
+            "integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
             "cpu": [
                 "arm64"
             ],
@@ -1440,9 +1440,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
-            "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
+            "integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
             "cpu": [
                 "ia32"
             ],
@@ -1453,9 +1453,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
-            "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
+            "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
             "cpu": [
                 "x64"
             ],
@@ -5366,9 +5366,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
-            "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
+            "version": "4.22.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
+            "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
             "devOptional": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -5381,22 +5381,22 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.21.2",
-                "@rollup/rollup-android-arm64": "4.21.2",
-                "@rollup/rollup-darwin-arm64": "4.21.2",
-                "@rollup/rollup-darwin-x64": "4.21.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.21.2",
-                "@rollup/rollup-linux-arm64-musl": "4.21.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-gnu": "4.21.2",
-                "@rollup/rollup-linux-x64-musl": "4.21.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.21.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.21.2",
-                "@rollup/rollup-win32-x64-msvc": "4.21.2",
+                "@rollup/rollup-android-arm-eabi": "4.22.4",
+                "@rollup/rollup-android-arm64": "4.22.4",
+                "@rollup/rollup-darwin-arm64": "4.22.4",
+                "@rollup/rollup-darwin-x64": "4.22.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.22.4",
+                "@rollup/rollup-linux-arm64-musl": "4.22.4",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.22.4",
+                "@rollup/rollup-linux-x64-gnu": "4.22.4",
+                "@rollup/rollup-linux-x64-musl": "4.22.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.22.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.22.4",
+                "@rollup/rollup-win32-x64-msvc": "4.22.4",
                 "fsevents": "~2.3.2"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@floating-ui/react": "^0.26.24",
                 "@tauri-apps/api": "^1",
                 "emoji-regex": "^10.4.0",
-                "framer-motion": "^11.5.5",
+                "framer-motion": "^11.5.6",
                 "globals": "^15.9.0",
                 "i18next": "^23.15.1",
                 "i18next-browser-languagedetector": "^8.0.0",
@@ -32,14 +32,14 @@
                 "@nabla/vite-plugin-eslint": "^2.0.4",
                 "@tauri-apps/cli": "^1.6.2",
                 "@types/eslint__js": "^8.42.3",
-                "@types/node": "^22.5.5",
-                "@types/react": "^18.3.8",
+                "@types/node": "^22.7.0",
+                "@types/react": "^18.3.9",
                 "@types/react-dom": "^18.2.7",
                 "@types/uuid": "^10.0.0",
                 "@typescript-eslint/parser": "^8.3.0",
                 "@vitejs/plugin-react": "^4.2.1",
                 "babel-plugin-styled-components": "^2.1.4",
-                "eslint": "^9.10.0",
+                "eslint": "^9.11.1",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "eslint-plugin-react": "^7.36.1",
@@ -47,8 +47,8 @@
                 "prettier": "3.3.3",
                 "prettier-eslint": "^16.3.0",
                 "typescript": "^5.6.2",
-                "typescript-eslint": "^8.6.0",
-                "vite": "^5.4.6"
+                "typescript-eslint": "^8.7.0",
+                "vite": "^5.4.8"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -928,6 +928,15 @@
                 "node": "*"
             }
         },
+        "node_modules/@eslint/core": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+            "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -986,11 +995,10 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.10.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-            "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+            "version": "9.11.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+            "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -1005,11 +1013,10 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-            "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+            "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "levn": "^0.4.1"
             },
@@ -1066,13 +1073,13 @@
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.14",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.2",
+                "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
@@ -1746,9 +1753,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.5.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-            "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+            "version": "22.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
+            "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -1761,9 +1768,9 @@
             "devOptional": true
         },
         "node_modules/@types/react": {
-            "version": "18.3.8",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.8.tgz",
-            "integrity": "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==",
+            "version": "18.3.9",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.9.tgz",
+            "integrity": "sha512-+BpAVyTpJkNWWSSnaLBk6ePpHLOGJKnEQNbINNovPWzvEUyAe3e+/d494QdEh71RekM/qV7lw6jzf1HGrJyAtQ==",
             "devOptional": true,
             "dependencies": {
                 "@types/prop-types": "*",
@@ -1791,16 +1798,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
-            "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+            "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.6.0",
-                "@typescript-eslint/type-utils": "8.6.0",
-                "@typescript-eslint/utils": "8.6.0",
-                "@typescript-eslint/visitor-keys": "8.6.0",
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/type-utils": "8.7.0",
+                "@typescript-eslint/utils": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1824,15 +1831,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
-            "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+            "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.6.0",
-                "@typescript-eslint/types": "8.6.0",
-                "@typescript-eslint/typescript-estree": "8.6.0",
-                "@typescript-eslint/visitor-keys": "8.6.0",
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1852,13 +1859,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-            "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+            "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.6.0",
-                "@typescript-eslint/visitor-keys": "8.6.0"
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1869,13 +1876,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
-            "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+            "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.6.0",
-                "@typescript-eslint/utils": "8.6.0",
+                "@typescript-eslint/typescript-estree": "8.7.0",
+                "@typescript-eslint/utils": "8.7.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -1893,9 +1900,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-            "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+            "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1906,13 +1913,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-            "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+            "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.6.0",
-                "@typescript-eslint/visitor-keys": "8.6.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/visitor-keys": "8.7.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1934,15 +1941,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
-            "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+            "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.6.0",
-                "@typescript-eslint/types": "8.6.0",
-                "@typescript-eslint/typescript-estree": "8.6.0"
+                "@typescript-eslint/scope-manager": "8.7.0",
+                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.7.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1956,12 +1963,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-            "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+            "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.6.0",
+                "@typescript-eslint/types": "8.7.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -2816,21 +2823,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.10.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
-            "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
+            "version": "9.11.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+            "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.11.0",
                 "@eslint/config-array": "^0.18.0",
+                "@eslint/core": "^0.6.0",
                 "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.10.0",
-                "@eslint/plugin-kit": "^0.1.0",
+                "@eslint/js": "9.11.1",
+                "@eslint/plugin-kit": "^0.2.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.3.0",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -3019,6 +3028,12 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/eslint/node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true
         },
         "node_modules/eslint/node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -3255,9 +3270,9 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "11.5.5",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.5.5.tgz",
-            "integrity": "sha512-4srkT940jYA3bdQRglxod0KoqDvcghYri1A6bTjT02IXvq/EAd6A0tgUnJc5Q2ahhf8n959aLD3yO+XmLmE8OQ==",
+            "version": "11.5.6",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.5.6.tgz",
+            "integrity": "sha512-JMwUpAxv/DWgul9vPgX0ElKn0G66sUc6O9tOXsYwn3zxwvhxFljSXC0XT2QCzuTYBshwC8nyDAa1SYcV0Ldbhw==",
             "dependencies": {
                 "tslib": "^2.4.0"
             },
@@ -4808,9 +4823,9 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/@eslint/js": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4932,16 +4947,16 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/eslint": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.0",
-                "@humanwhocodes/config-array": "^0.11.14",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -5942,14 +5957,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
-            "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+            "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.6.0",
-                "@typescript-eslint/parser": "8.6.0",
-                "@typescript-eslint/utils": "8.6.0"
+                "@typescript-eslint/eslint-plugin": "8.7.0",
+                "@typescript-eslint/parser": "8.7.0",
+                "@typescript-eslint/utils": "8.7.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6045,9 +6060,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-            "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+            "version": "5.4.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+            "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
             "devOptional": true,
             "dependencies": {
                 "esbuild": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@floating-ui/react": "^0.26.24",
         "@tauri-apps/api": "^1",
         "emoji-regex": "^10.4.0",
-        "framer-motion": "^11.5.5",
+        "framer-motion": "^11.5.6",
         "globals": "^15.9.0",
         "i18next": "^23.15.1",
         "i18next-browser-languagedetector": "^8.0.0",
@@ -36,14 +36,14 @@
         "@nabla/vite-plugin-eslint": "^2.0.4",
         "@tauri-apps/cli": "^1.6.2",
         "@types/eslint__js": "^8.42.3",
-        "@types/node": "^22.5.5",
-        "@types/react": "^18.3.8",
+        "@types/node": "^22.7.0",
+        "@types/react": "^18.3.9",
         "@types/react-dom": "^18.2.7",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/parser": "^8.3.0",
         "@vitejs/plugin-react": "^4.2.1",
         "babel-plugin-styled-components": "^2.1.4",
-        "eslint": "^9.10.0",
+        "eslint": "^9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.36.1",
@@ -51,7 +51,7 @@
         "prettier": "3.3.3",
         "prettier-eslint": "^16.3.0",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.6.0",
-        "vite": "^5.4.6"
+        "typescript-eslint": "^8.7.0",
+        "vite": "^5.4.8"
     }
 }


### PR DESCRIPTION
Description
---
- ran `npm audit fix` to address `rollup` vulnerability
- bumped outdated deps (only ones not on `wanted` version)

Motivation and Context
---

- vulnerability: 

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/409563ff-171a-408f-a1d1-3ebd12238ba9">

```
# npm audit report

rollup  4.0.0 - 4.22.3
Severity: high
DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS - https://github.com/advisories/GHSA-gcx4-mw62-g8wm
fix available via `npm audit fix`
node_modules/rollup
```

- outdated:

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/da723b3e-70ae-4878-8eb9-5adde2bb1106">


How has this been tested 
---

- locally & checked changelogs