### PR TITLE
fix(ui): wallet spacing | copy update | button ani update

### DIFF
--- a/public/locales/af/mining-view.json
+++ b/public/locales/af/mining-view.json
@@ -6,7 +6,7 @@
     "mining-button-text": {
         "starting-mining": "Myn begin",
         "start-mining": "Begin myn",
-        "pause-mining": "Onderbreek myn",
+        "stop-mining": "Stop myn",
         "changing-mode": "Verander modus",
         "cancel-mining": "Kanselleer myn",
         "waiting-for-idle": "Wag tot onaktief",

--- a/public/locales/cn/mining-view.json
+++ b/public/locales/cn/mining-view.json
@@ -6,7 +6,7 @@
   "mining-button-text": {
     "starting-mining": "开始挖矿",
     "start-mining": "开始挖矿",
-    "pause-mining": "暂停挖矿",
+    "stop-mining": "停止挖矿",
     "changing-mode": "更改模式",
     "cancel-mining": "取消挖矿",
     "waiting-for-idle": "等待空闲",

--- a/public/locales/en/mining-view.json
+++ b/public/locales/en/mining-view.json
@@ -1,15 +1,15 @@
 {
-  "floor": "Floor",
-  "current-block-time": "Current block time",
-  "your-reward-is": "Your reward is",
-  "connection-to-node-lost": "Connection to miner lost. Please wait for the miner to reconnect or restart the miner.",
-  "mining-button-text": {
-    "starting-mining": "Starting Mining",
-    "start-mining": "Start Mining",
-    "pause-mining": "Pause Mining",
-    "changing-mode": "Changing mode",
-    "cancel-mining": "Cancel Mining",
-    "waiting-for-idle": "Waiting for Idle",
-    "started-auto-mining": "Auto Mining Started"
-  }
+    "floor": "Floor",
+    "current-block-time": "Current block time",
+    "your-reward-is": "Your reward is",
+    "connection-to-node-lost": "Connection to miner lost. Please wait for the miner to reconnect or restart the miner.",
+    "mining-button-text": {
+        "starting-mining": "Starting Mining",
+        "start-mining": "Start Mining",
+        "stop-mining": "Stop Mining",
+        "changing-mode": "Changing mode",
+        "cancel-mining": "Cancel Mining",
+        "waiting-for-idle": "Waiting for Idle",
+        "started-auto-mining": "Auto Mining Started"
+    }
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -1,7 +1,7 @@
 {
   "settings": "Settings",
   "seed-words": "Seed words",
-  "send-logs": "Send logs",
+  "send-logs": "Submit an Issue & Logs",
   "your-feedback": "Please describe your issue",
   "feedback-required": "Feedback is required",
   "your-reference": "Your reference",

--- a/public/locales/pl/mining-view.json
+++ b/public/locales/pl/mining-view.json
@@ -6,7 +6,7 @@
   "mining-button-text": {
     "starting-mining": "Uruchamianie kopania",
     "start-mining": "Uruchom kopanie",
-    "pause-mining": "Wstrzymaj kopanie",
+    "stop-mining": "Wstrzymaj kopanie",
     "changing-mode": "Zmiana trybu",
     "cancel-mining": "Anuluj kopanie",
     "waiting-for-idle": "Oczekiwanie na bezczynność",

--- a/public/locales/tr/mining-view.json
+++ b/public/locales/tr/mining-view.json
@@ -6,7 +6,7 @@
     "mining-button-text": {
         "starting-mining": "Madenci Başlatılıyor",
         "start-mining": "Madenciyi Başlat",
-        "pause-mining": "Madenciyi Durdur",
+        "stop-mining": "Madenciyi Durdur",
         "changing-mode": "Mod değiştirme",
         "cancel-mining": "Madenciyi İptal Et",
         "waiting-for-idle": "Boşta Bekliyor",

--- a/src/components/CharSpinner/CharSpinner.styles.ts
+++ b/src/components/CharSpinner/CharSpinner.styles.ts
@@ -43,7 +43,6 @@ export const Characters = styled(m.div)<Props>`
     display: flex;
     flex-direction: column;
     align-items: center;
-    letter-spacing: -4px;
     font-weight: ${({ $variant }) => ($variant == 'simple' ? 600 : 700)};
     font-family: ${({ $variant }) => ($variant == 'simple' ? 'Poppins' : 'Druk')}, sans-serif;
     font-size: ${({ $fontSize }) => `${$fontSize}px`};
@@ -52,8 +51,13 @@ export const Characters = styled(m.div)<Props>`
 
 export const Character = styled(m.div)<Props>`
     display: flex;
-    justify-self: center;
+    justify-self: flex-start;
     font-size: ${({ $fontSize }) => `${$fontSize}px`};
-    letter-spacing: -0.02ch;
+    letter-spacing: -4px;
     text-transform: lowercase;
+    width: min-content;
+    &:last-child {
+        // for the unit
+        width: ${({ $decimal }) => ($decimal ? 'min-content' : '1ch')};
+    }
 `;

--- a/src/components/CharSpinner/CharSpinner.styles.ts
+++ b/src/components/CharSpinner/CharSpinner.styles.ts
@@ -51,13 +51,15 @@ export const Characters = styled(m.div)<Props>`
 
 export const Character = styled(m.div)<Props>`
     display: flex;
-    justify-self: flex-start;
+    justify-self: center;
     font-size: ${({ $fontSize }) => `${$fontSize}px`};
     letter-spacing: -4px;
     text-transform: lowercase;
     width: min-content;
+    // for the unit & decimal
     &:last-child {
-        // for the unit
         width: ${({ $decimal }) => ($decimal ? 'min-content' : '1ch')};
+        margin-left: 1px;
+        margin-right: -1px;
     }
 `;

--- a/src/containers/Dashboard/MiningView/components/MiningButton.tsx
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.tsx
@@ -13,7 +13,7 @@ import { useAppStateStore } from '@app/store/appStateStore.ts';
 import { useAppConfigStore } from '@app/store/useAppConfigStore.ts';
 
 enum MiningButtonStateText {
-    STARTED = 'pause-mining',
+    STARTED = 'stop-mining',
     START = 'start-mining',
 }
 

--- a/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.styles.ts
+++ b/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.styles.ts
@@ -14,8 +14,8 @@ export const OrbitWrapper = styled(m.div)`
 export const Orbit = styled(m.div)`
     border-radius: 100%;
     border-width: 1px;
-    border-color: rgba(255, 255, 255, 0.15);
-    color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.13);
+    color: rgba(255, 255, 255, 0.09);
     position: absolute;
     width: 100%;
     height: 100%;

--- a/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.styles.ts
+++ b/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.styles.ts
@@ -14,8 +14,8 @@ export const OrbitWrapper = styled(m.div)`
 export const Orbit = styled(m.div)`
     border-radius: 100%;
     border-width: 1px;
-    border-color: rgba(255, 255, 255, 0.175);
-    color: rgba(255, 255, 255, 0.095);
+    border-color: rgba(255, 255, 255, 0.15);
+    color: rgba(255, 255, 255, 0.1);
     position: absolute;
     width: 100%;
     height: 100%;

--- a/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
+++ b/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
@@ -5,29 +5,32 @@ import { Transition, useAnimationFrame, Variants } from 'framer-motion';
 
 const orbitTracks = [{ size: 200 }, { size: 230 }, { size: 260 }, { size: 160 }];
 
+const opacityTransition = {
+    duration: 15,
+    ease: 'easeInOut',
+    repeat: Infinity,
+    delay: i * 2,
+};
 const cube = {
     animate: (i) => ({
         opacity: [0.75, 1, 0.9],
         scale: [0.8, 0.75],
-        transition: {
-            duration: 15,
-            ease: 'easeInOut',
-            repeat: Infinity,
-            delay: i * 2,
-        },
+        transition: opacityTransition,
     }),
 };
 
 const track: Variants = {
     animate: (i) => ({
-        rotate: i % 2 !== 0 ? 360 : -360,
+        rotate: i % 3 !== 0 ? 360 : -360,
+        opacity: [0.75, 8.2, 0.69],
         transition: {
-            duration: 30 - (i + 2) * 3.5,
+            duration: 40 + (i + 1) * 1.5,
             ease: 'linear',
             repeat: Infinity,
             repeatType: 'mirror' as Transition['repeatType'],
             staggerChildren: 1.5,
             delay: i * 1.75,
+            opacity: opacityTransition,
         },
     }),
 };
@@ -40,13 +43,13 @@ function OrbitCube({ isEven, custom, x, y }: { isEven?: boolean; custom: number;
     );
 }
 
-const baseCubes = [1, 2, 3];
+const baseCubes = [1, 2];
 
 export default function ButtonOrbitAnimation() {
     const [cubesPerTrack, setCubesPerTrack] = useState(baseCubes);
 
     useAnimationFrame((time, delta) => {
-        if (delta > 20 && cubesPerTrack.length < 15) {
+        if (delta > 20 && cubesPerTrack.length < 10) {
             setCubesPerTrack((c) => [...c, c.length + 1]);
         }
     });
@@ -60,8 +63,8 @@ export default function ButtonOrbitAnimation() {
         >
             {orbitTracks.map(({ size }, trackIndex) => {
                 const isEven = trackIndex % 2 === 0;
-                const borderStyleArr = ['dashed', 'dashed', 'dashed'];
-                borderStyleArr.splice(trackIndex, 0, 'solid');
+                const borderStyleArr = ['solid', 'solid', 'solid'];
+                borderStyleArr.splice(trackIndex, 0, 'dashed');
                 const borderStyle = borderStyleArr.join(' ');
                 const cubes = isEven
                     ? cubesPerTrack.filter((c) => c % 2 !== 0)
@@ -70,7 +73,7 @@ export default function ButtonOrbitAnimation() {
                     <Orbit
                         key={`orbit-${size}-${trackIndex}`}
                         style={{
-                            opacity: isEven ? 1 : 0.7,
+                            opacity: isEven ? 0.8 : 0.65,
                             borderStyle,
                             width: size,
                             height: size,

--- a/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
+++ b/src/containers/SideBar/Miner/components/ButtonOrbitAnimation.tsx
@@ -6,30 +6,30 @@ import { Transition, useAnimationFrame, Variants } from 'framer-motion';
 const orbitTracks = [{ size: 200 }, { size: 230 }, { size: 260 }, { size: 160 }];
 
 const opacityTransition = {
-    duration: 15,
+    duration: 10,
     ease: 'easeInOut',
     repeat: Infinity,
-    delay: i * 2,
 };
 const cube = {
     animate: (i) => ({
-        opacity: [0.75, 1, 0.9],
-        scale: [0.8, 0.75],
-        transition: opacityTransition,
+        opacity: [0.53, 0.65, 0.75, 1, 0.9, 0.6, 0.45],
+        scale: [0.8, 0.85],
+        transition: { ...opacityTransition, delay: i * 2 },
     }),
 };
 
 const track: Variants = {
     animate: (i) => ({
-        rotate: i % 3 !== 0 ? 360 : -360,
-        opacity: [0.75, 8.2, 0.69],
+        rotate: i % 2 !== 0 ? 360 : -360,
+        opacity: [0.55, 0.75, 0.6],
         transition: {
-            duration: 40 + (i + 1) * 1.5,
+            duration: 45 + (orbitTracks.length - i) * 3,
             ease: 'linear',
             repeat: Infinity,
             repeatType: 'mirror' as Transition['repeatType'],
-            staggerChildren: 1.5,
-            delay: i * 1.75,
+            staggerChildren: 2,
+            staggerDirection: -1,
+            delay: (i + 1) * 1.5,
             opacity: opacityTransition,
         },
     }),
@@ -43,13 +43,13 @@ function OrbitCube({ isEven, custom, x, y }: { isEven?: boolean; custom: number;
     );
 }
 
-const baseCubes = [1, 2];
+const baseCubes = [1, 2, 3];
 
 export default function ButtonOrbitAnimation() {
     const [cubesPerTrack, setCubesPerTrack] = useState(baseCubes);
 
     useAnimationFrame((time, delta) => {
-        if (delta > 20 && cubesPerTrack.length < 10) {
+        if (delta > 25 && cubesPerTrack.length < 12) {
             setCubesPerTrack((c) => [...c, c.length + 1]);
         }
     });
@@ -67,13 +67,13 @@ export default function ButtonOrbitAnimation() {
                 borderStyleArr.splice(trackIndex, 0, 'dashed');
                 const borderStyle = borderStyleArr.join(' ');
                 const cubes = isEven
-                    ? cubesPerTrack.filter((c) => c % 2 !== 0)
-                    : cubesPerTrack.filter((c) => c % 2 === 0);
+                    ? cubesPerTrack.filter((c) => c % 2 === 0)
+                    : cubesPerTrack.filter((c) => c % 2 !== 0);
                 return (
                     <Orbit
                         key={`orbit-${size}-${trackIndex}`}
                         style={{
-                            opacity: isEven ? 0.8 : 0.65,
+                            opacity: isEven ? 0.7 : 0.55,
                             borderStyle,
                             width: size,
                             height: size,


### PR DESCRIPTION
Description
---
- updated mining button copy: `Pause Mining` => `Stop Mining` (please check translations)
- updated `send-logs` copy `Send logs` => `Submit an Issue & Logs`
- adjusted `CharSpinner` styling to handle kerning a bit better - tighter letter spacing to match designs, but also caters for the decimal and unit character
- adjust mining button Orbit animation:
  - brought opacities down (on tracks and cubes)
  - used less `dashed` and more `solid` borders on the track
  - brought the speed down a lot (duration up)
  - less blocks allowed per track

Motivation and Context
---
resolves:
- #460 
- #595 & #558 
- #594 

How Has This Been Tested?
---

https://github.com/user-attachments/assets/f492b62a-bec6-4c43-9c7a-05bb246acdc4



<img width="1240" alt="image" src="https://github.com/user-attachments/assets/6e9ee598-9bf5-42f0-8fa3-365462678de9">

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/6a28776d-ccee-4fa5-b88a-69fbe4f1475c">
