### PR TITLE
fix: allow beta builds on same computer as main builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-20.04'
-            args: ''
+            args: ' --features="release-ci'
           - platform: 'windows-2019'
-            args: '--bundles msi,updater'
+            args: '--bundles msi,updater --features "release-ci"'
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin'
+            args: '--target universal-apple-darwin --features "release-ci"'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -67,7 +67,7 @@ jobs:
       - name: Set environment variables for beta builds
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         env:
-          BETA_STRING: " -beta-"
+          BETA_STRING: " -beta"
         shell: bash
         run: |
           #set -xueo pipefail
@@ -81,12 +81,22 @@ jobs:
           # Don't mess with the double quotes and inner escaped quotes
           yq eval ".package.productName += \"${{ env.BETA_STRING }}\"" -i tauri.conf.json
           yq eval ".package.version += \"-${BETA_DATE}\"" -i tauri.conf.json
+          yq eval ".tauri.bundle.identifier += \".beta\"" -i tauri.conf.json
           yq eval ".tauri.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/beta-latest.json\"]" \
             -i tauri.conf.json
           cat tauri.conf.json
           sed -i.bak -E "s/^version\s*=\s*\"([0-9]+\.[0-9]+\.[0-9]+)\"/version = \"\1-${BETA_DATE}\"/" \
             Cargo.toml
           cat Cargo.toml
+
+      - name: Set environment variables for RELEASE builds
+        if: ${{ startsWith(github.ref, 'refs/heads/release') }}
+        shell: bash
+        run: |
+          #set -xueo pipefail
+          cd "${GITHUB_WORKSPACE}/src-tauri"
+          # Don't mess with the double quotes and inner escaped quotes
+          yq eval ".tauri.bundle.identifier = \"com.tari.universe\"" -i tauri.conf.json
 
       - name: Node.js setup
         uses: actions/setup-node@v4

--- a/src-tauri/src/binaries/adapter_github.rs
+++ b/src-tauri/src/binaries/adapter_github.rs
@@ -9,6 +9,7 @@ use tauri::api::path::cache_dir;
 
 use crate::{
     download_utils::download_file_with_retries, github, progress_tracker::ProgressTracker,
+    APPLICATION_FOLDER_ID,
 };
 
 use super::binaries_resolver::{LatestVersionApiAdapter, VersionAsset, VersionDownloadInfo};
@@ -52,7 +53,7 @@ impl LatestVersionApiAdapter for GithubReleasesAdapter {
     fn get_binary_folder(&self) -> PathBuf {
         let binary_folder_path = cache_dir()
             .unwrap()
-            .join("com.tari.universe")
+            .join(APPLICATION_FOLDER_ID)
             .join("binaries")
             .join(&self.repo)
             .join(

--- a/src-tauri/src/binaries/adapter_xmrig.rs
+++ b/src-tauri/src/binaries/adapter_xmrig.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use tari_common::configuration::Network;
 use tauri::api::path::cache_dir;
 
-use crate::{github, progress_tracker::ProgressTracker};
+use crate::{github, progress_tracker::ProgressTracker, APPLICATION_FOLDER_ID};
 
 use super::binaries_resolver::{LatestVersionApiAdapter, VersionAsset, VersionDownloadInfo};
 
@@ -40,7 +40,7 @@ impl LatestVersionApiAdapter for XmrigVersionApiAdapter {
     fn get_binary_folder(&self) -> PathBuf {
         let binary_folder_path = cache_dir()
             .unwrap()
-            .join("com.tari.universe")
+            .join(APPLICATION_FOLDER_ID)
             .join("binaries")
             .join("xmrig")
             .join(

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -24,6 +24,8 @@ use tari_key_manager::mnemonic::{Mnemonic, MnemonicLanguage};
 use tari_key_manager::SeedWords;
 use tari_utilities::hex::Hex;
 
+use crate::APPLICATION_FOLDER_ID;
+
 const KEY_MANAGER_COMMS_SECRET_KEY_BRANCH_KEY: &str = "comms";
 const LOG_TARGET: &str = "tari::universe::internal_wallet";
 
@@ -76,7 +78,7 @@ impl InternalWallet {
             passphrase: None,
         };
 
-        let passphrase = match Entry::new("com.tari.universe", "internal_wallet") {
+        let passphrase = match Entry::new(APPLICATION_FOLDER_ID, "internal_wallet") {
             Ok(entry) => match entry.get_password() {
                 Ok(pass) => SafePassword::from(pass),
                 Err(_err @ KeyringError::PlatformFailure(_))
@@ -147,7 +149,7 @@ impl InternalWallet {
         let passphrase = match &self.config.passphrase {
             Some(passphrase) => passphrase.clone(),
             None => {
-                let entry = Entry::new("com.tari.universe", "internal_wallet")?;
+                let entry = Entry::new(APPLICATION_FOLDER_ID, "internal_wallet")?;
                 SafePassword::from(entry.get_password()?)
             }
         };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,6 +83,11 @@ const MAX_ACCEPTABLE_COMMAND_TIME: Duration = Duration::from_secs(1);
 const LOG_TARGET: &str = "tari::universe::main";
 const LOG_TARGET_WEB: &str = "tari::universe::web";
 
+#[cfg(feature = "release-ci")]
+const APPLICATION_FOLDER_ID: &str = "com.tari.universe";
+#[cfg(not(feature = "release-ci"))]
+const APPLICATION_FOLDER_ID: &str = "com.tari.universe.beta";
+
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct UpdateProgressRustEvent {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,7 +67,7 @@
         "bundle": {
             "active": true,
             "targets": "all",
-            "identifier": "com.tari.universe",
+            "identifier": "com.tari.universe.beta",
             "icon": [
                 "icons/icon.icns",
                 "icons/icon.ico",


### PR DESCRIPTION
Stores data in `<data>/com.tari.universe.beta` instead of `com.tari.universe` for development and beta builds, allowing developers to run both without confusion. 

Seed words are also stored in a different keychain location for beta and release.

Note: requires release builds to be built with `feature = "release-ci"`
