### PR TITLE
fix: wallet balance display if no tXTM

### DIFF
--- a/src/containers/SideBar/components/Wallet.tsx
+++ b/src/containers/SideBar/components/Wallet.tsx
@@ -12,12 +12,12 @@ import { useWalletStore } from '@app/store/useWalletStore.ts';
 function Wallet() {
     const { t } = useTranslation('sidebar', { useSuspense: false });
     const balance = useWalletStore((state) => state.balance);
-    const formatted = formatBalance(balance);
+    const formatted = formatBalance(balance || 0);
     const sizing = formatted.length <= 6 ? 50 : formatted.length <= 8 ? 44 : 32;
     const [showBalance, setShowBalance] = useState(true);
 
     const toggleBalanceVisibility = () => setShowBalance((prev) => !prev);
-    const displayValue = balance && balance > 0 ? (showBalance ? formatted : '*****') : '-';
+    const displayValue = balance === null ? '-' : showBalance ? formatted : '*****';
     return (
         <WalletContainer>
             <Handle />

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -50,8 +50,8 @@ export const useBlockchainVisualisationStore = create<BlockchainVisualisationSto
                 const checkEarningsInterval = setInterval(async () => {
                     await useWalletStore.getState().fetchWalletDetails();
                     const { balance: currBalance } = useWalletStore.getState();
-                    const balanceDiff = currBalance - prevBalance;
-                    const hasEarnings = currBalance > 0 && balanceDiff > 0;
+                    const balanceDiff = (currBalance || 0) - (prevBalance || 0);
+                    const hasEarnings = currBalance && currBalance > 0 && balanceDiff > 0;
 
                     if (hasEarnings) {
                         logBalanceChanges({ currBalance, prevBalance, balanceDiff });

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -5,7 +5,7 @@ import { invoke } from '@tauri-apps/api';
 interface State extends WalletBalance {
     tari_address_base58: string;
     tari_address_emoji: string;
-    balance: number;
+    balance: number | null;
 }
 
 interface Actions {
@@ -17,7 +17,7 @@ type WalletStoreState = State & Actions;
 const initialState: State = {
     tari_address_base58: '',
     tari_address_emoji: '',
-    balance: 0,
+    balance: null,
     available_balance: 0,
     timelocked_balance: 0,
     pending_incoming_balance: 0,
@@ -33,7 +33,7 @@ export const useWalletStore = create<WalletStoreState>()((set) => ({
                 timelocked_balance = 0,
                 pending_incoming_balance = 0,
             } = tari_wallet_details.wallet_balance || {};
-            // Q: Should we substract pending_outgoing_balance here?
+            // Q: Should we subtract pending_outgoing_balance here?
             const newBalance = available_balance + timelocked_balance + pending_incoming_balance; //TM
             set({
                 ...tari_wallet_details.wallet_balance,


### PR DESCRIPTION
Description
---
- set balance initial state to `null` and check specifically for `null` instead of `0` to display the `-`

Motivation and Context
---
- misunderstood the requirement for #633 and set it to always be `-` if 0

NOTE: 

- this undoes the initial fix for #633 since the BE returns 0 while it's loading anyway so the `-` hardly has time to show 😅 

