### PR TITLE
fix: gpu devices list

### DIFF
--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -96,14 +96,18 @@ impl GpuMiner {
                 );
                 status.estimated_earnings = estimated_earnings;
                 status.is_available = self.is_available;
+                dbg!(&status);
                 Ok(status)
             }
-            None => Ok(GpuMinerStatus {
-                hash_rate: 0,
-                estimated_earnings: 0,
-                is_mining: false,
-                is_available: self.is_available,
-            }),
+            None => {
+                dbg!(&self.is_available);
+                Ok(GpuMinerStatus {
+                    hash_rate: 0,
+                    estimated_earnings: 0,
+                    is_mining: false,
+                    is_available: self.is_available,
+                })
+            }
         }
     }
 

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -99,15 +99,12 @@ impl GpuMiner {
                 dbg!(&status);
                 Ok(status)
             }
-            None => {
-                dbg!(&self.is_available);
-                Ok(GpuMinerStatus {
-                    hash_rate: 0,
-                    estimated_earnings: 0,
-                    is_mining: false,
-                    is_available: self.is_available,
-                })
-            }
+            None => Ok(GpuMinerStatus {
+                hash_rate: 0,
+                estimated_earnings: 0,
+                is_mining: false,
+                is_available: self.is_available,
+            }),
         }
     }
 
@@ -121,6 +118,12 @@ impl GpuMiner {
             config_dir
                 .join("gpuminer")
                 .join("config.json")
+                .to_string_lossy()
+                .to_string(),
+            "--gpu-status-file".to_string(),
+            config_dir
+                .join("gpuminer")
+                .join("gpu_status.json")
                 .to_string_lossy()
                 .to_string(),
         ];

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -96,7 +96,6 @@ impl GpuMiner {
                 );
                 status.estimated_earnings = estimated_earnings;
                 status.is_available = self.is_available;
-                dbg!(&status);
                 Ok(status)
             }
             None => Ok(GpuMinerStatus {

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -35,6 +35,14 @@ pub(crate) struct GpuMinerAdapter {
     pub(crate) coinbase_extra: String,
 }
 
+#[derive(serde::Deserialize)]
+pub struct GpuStatusFromFile {
+    #[serde(default = "default_num_devices")]
+    num_devices: u32,
+    #[serde(default = "default_device_names")]
+    device_names: Vec<String>,
+}
+
 impl GpuMinerAdapter {
     pub fn new() -> Self {
         Self {
@@ -218,6 +226,26 @@ impl StatusMonitor for GpuMinerStatusMonitor {
 
     async fn status(&self) -> Result<Self::Status, anyhow::Error> {
         let client = reqwest::Client::new();
+        let config_path = PathBuf::from("/home/oski/.config/com.tari.universe/"); //TODO use app config path
+        let file: PathBuf = config_path.join("gpuminer").join("gpu_status.json");
+
+        println!("GPU STATUS FILE: {:?}", file);
+        if file.exists() {
+            let config = fs::read_to_string(&file).unwrap();
+            match serde_json::from_str::<GpuStatusFromFile>(&config) {
+                Ok(config) => {
+                    println!(
+                        "GPU STATUS FILE: {:?} - {:?}",
+                        config.num_devices, config.device_names
+                    );
+                }
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Failed to parse gpu status: {}", e.to_string());
+                }
+            }
+        } else {
+            println!("GPU STATUS FILE NOT FOUND {:?}", file);
+        }
         let response = match client
             .get(format!("http://127.0.0.1:{}/stats", self.http_api_port))
             .send()
@@ -244,7 +272,10 @@ impl StatusMonitor for GpuMinerStatusMonitor {
         };
         let text = response.text().await?;
         let body: XtrGpuminerHttpApiStatus = match serde_json::from_str(&text) {
-            Ok(body) => body,
+            Ok(body) => {
+                dbg!(&body);
+                body
+            }
             Err(e) => {
                 warn!(target: LOG_TARGET, "Error decoding body from  in XtrGpuMiner status: {}", e);
                 return Ok(GpuMinerStatus {
@@ -275,4 +306,12 @@ pub struct GpuMinerStatus {
     pub hash_rate: u64,
     pub estimated_earnings: u64,
     pub is_available: bool,
+}
+
+fn default_num_devices() -> u32 {
+    0
+}
+
+fn default_device_names() -> Vec<String> {
+    vec![]
 }

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -235,12 +235,12 @@ impl StatusMonitor for GpuMinerStatusMonitor {
         if file.exists() {
             let config = fs::read_to_string(&file).unwrap();
             match serde_json::from_str::<GpuStatusFile>(&config) {
-                /*
-                 * TODO if the following PR is merged
-                 * https://github.com/tari-project/universe/pull/612
-                 * use `exlcude gpu device` to not disable not available devices
-                 */
                 Ok(config) => {
+                    /*
+                     * TODO if the following PR is merged
+                     * https://github.com/tari-project/universe/pull/612
+                     * use `exlcude gpu device` to not disable not available devices
+                     */
                     println!("GPU STATUS FILE: {:?}", config.gpu_devices);
                 }
                 Err(e) => {
@@ -248,7 +248,7 @@ impl StatusMonitor for GpuMinerStatusMonitor {
                 }
             }
         } else {
-            println!("GPU STATUS FILE NOT FOUND {:?}", file);
+            warn!(target: LOG_TARGET, "Error while getting gpu status: {:?} not found", file);
         }
         let response = match client
             .get(format!("http://127.0.0.1:{}/stats", self.http_api_port))
@@ -276,10 +276,7 @@ impl StatusMonitor for GpuMinerStatusMonitor {
         };
         let text = response.text().await?;
         let body: XtrGpuminerHttpApiStatus = match serde_json::from_str(&text) {
-            Ok(body) => {
-                dbg!(&body);
-                body
-            }
+            Ok(body) => body,
             Err(e) => {
                 warn!(target: LOG_TARGET, "Error decoding body from  in XtrGpuMiner status: {}", e);
                 return Ok(GpuMinerStatus {

--- a/src-tauri/src/hardware_monitor.rs
+++ b/src-tauri/src/hardware_monitor.rs
@@ -274,6 +274,11 @@ impl HardwareMonitorImpl for LinuxHardwareMonitor {
             .filter(|c| c.label().contains("k10temp Tctl"))
             .collect();
 
+        /*
+         * TODO if the following PR is merged
+         * https://github.com/tari-project/universe/pull/612
+         * use `exlcude gpu device` to not disable not available devices
+         */
         let available_cpu_components = if amd_cpu_component.is_empty() {
             intel_cpu_component
         } else {
@@ -444,6 +449,11 @@ impl HardwareMonitorImpl for MacOSHardwareMonitor {
             / gpu_components.len() as f32;
         //TODO: Implement GPU usage for MacOS
         let usage = system.global_cpu_usage();
+        /*
+         * TODO if the following PR is merged
+         * https://github.com/tari-project/universe/pull/612
+         * use names from json file
+         */
         let label: String = system.cpus().first().unwrap().brand().to_string() + " GPU";
 
         match current_parameters {


### PR DESCRIPTION
Description
Resolves #610 

Motivation and Context
Gpu devices are not listed on macOS so the info needs to be taken from gpu_status.json file which is created while gpu device detection by gpuminer.
This solution was chosen to use `opencl3` crate which supports different os, includes macOS.

Solution will work only if https://github.com/stringhandler/tarigpuminer/pull/19 is merged.

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
