### PR TITLE
fix(ui): mining button | more obvious diabled state

### DIFF
--- a/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
@@ -59,7 +59,13 @@ export const StyledButton = styled(Button)<{ $hasStarted: boolean }>`
     }
 
     &:disabled {
-        opacity: 0.9;
-        pointer-events: none;
+        opacity: 0.45;
+        cursor: wait;
+        &:hover {
+            background: ${({ $hasStarted }) =>
+                $hasStarted
+                    ? 'linear-gradient(90deg, #929292 0%, rgba(0,0,0,0.7) 99.49%)'
+                    : 'linear-gradient(90deg, #046937 0%, #188750 92.49%)'};
+        }
     }
 `;


### PR DESCRIPTION
Description
---
- just made the disabled opacity change more obvious and added the 'wait' cursor

Motivation and Context
---
- resolves #672 

How Has This Been Tested?
---

- locally:

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/54dec595-db00-4eb1-97bf-47a2f676a42f">


https://github.com/user-attachments/assets/cd101029-b8dd-430a-ae3a-47759cf20a7a

https://github.com/user-attachments/assets/a99be3ae-b54b-42b3-91b3-ac6a11dc5224


