### PR TITLE
chore(ci): add local builds as alpha, ci for beta and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ concurrency:
 
 permissions: {}
 
+env:
+  TS_FEATURES: release-ci
+
 jobs:
   builds:
     name: Building ${{ matrix.platform }}
@@ -32,11 +35,11 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-20.04'
-            args: ' --features "release-ci"'
+            args: ''
           - platform: 'windows-2019'
-            args: '--bundles msi,updater --features "release-ci"'
+            args: '--bundles msi,updater'
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin --features "release-ci"'
+            args: '--target universal-apple-darwin'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -44,12 +47,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: beta builds - Install dependencies (windows) [yq]
-        if: ${{  startsWith(runner.os,'Windows')  }}
+        if: ${{ startsWith(runner.os,'Windows') }}
         run: |
           choco upgrade yq -y
 
       - name: beta builds - Install dependencies (linux) [yq]
-        if: ${{  startsWith(runner.os,'Linux')  }}
+        if: ${{ startsWith(runner.os,'Linux') }}
         shell: bash
         run: |
           sudo bash ./scripts/check-get-yq.sh
@@ -57,7 +60,7 @@ jobs:
       - name: Set environment variables for beta builds
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         env:
-          BETA_STRING: "-beta"
+          BETA_STRING: "(Beta)"
           AIRDROP_BASE_URL: ${{ secrets.BETA_AIRDROP_BASE_URL }}
           AIRDROP_API_BASE_URL: ${{ secrets.BETA_AIRDROP_API_BASE_URL }}
           AIRDROP_TWITTER_AUTH_URL: ${{ secrets.BETA_AIRDROP_TWITTER_AUTH_URL }}
@@ -69,15 +72,17 @@ jobs:
           echo "AIRDROP_BASE_URL=${{ env.AIRDROP_BASE_URL }}" >> $GITHUB_ENV
           echo "AIRDROP_API_BASE_URL=${{ env.AIRDROP_API_BASE_URL }}" >> $GITHUB_ENV
           echo "AIRDROP_TWITTER_AUTH_URL=${{ env.AIRDROP_TWITTER_AUTH_URL }}" >> $GITHUB_ENV
+          echo "TS_FEATURES=release-ci-beta, airdrop-env" >> $GITHUB_ENV
           #export BETA_DATE=$(date +%Y-%m-%d)
           # numeric-only and cannot be greater than 65535 for msi target
           export BETA_DATE=4$(date +%m%d)
           cd "${GITHUB_WORKSPACE}/src-tauri"
-          echo "releaseName=Tari Universe${{ env.BETA_STRING }} v__VERSION__-${BETA_DATE}" >> $GITHUB_ENV
+          echo "releaseName=Tari Universe ${{ env.BETA_STRING }} v__VERSION__-${BETA_DATE}" >> $GITHUB_ENV
           # Don't mess with the double quotes and inner escaped quotes
-          yq eval ".package.productName += \"${{ env.BETA_STRING }}\"" -i tauri.conf.json
+          yq eval ".package.productName = \"Tari Universe ${{ env.BETA_STRING }}\"" -i tauri.conf.json
           yq eval ".package.version += \"-${BETA_DATE}\"" -i tauri.conf.json
-          #yq eval ".tauri.bundle.identifier += \".beta\"" -i tauri.conf.json
+          yq eval ".tauri.windows[0].title = \"Tari Universe ${{ env.BETA_STRING }} | Testnet\"" -i tauri.conf.json
+          yq eval ".tauri.bundle.identifier = \"com.tari.universe.beta\"" -i tauri.conf.json
           yq eval ".tauri.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/beta-latest.json\"]" \
             -i tauri.conf.json
           cat tauri.conf.json
@@ -98,7 +103,11 @@ jobs:
           echo "TARI_TARGET_NETWORK=nextnet" >> $GITHUB_ENV
           cd "${GITHUB_WORKSPACE}/src-tauri"
           # Don't mess with the double quotes and inner escaped quotes
+          yq eval ".package.productName = \"Tari Universe\"" -i tauri.conf.json
+          yq eval ".tauri.windows[0].title = \"Tari Universe | Testnet\"" -i tauri.conf.json
           yq eval ".tauri.bundle.identifier = \"com.tari.universe\"" -i tauri.conf.json
+          yq eval ".tauri.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\"]" \
+            -i tauri.conf.json
 
       - name: Node.js setup
         uses: actions/setup-node@v4
@@ -208,11 +217,19 @@ jobs:
           prerelease: true
           includeDebug: false
           includeRelease: true
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
+
+      - name: Debug step {artifactPaths}
+        if: ${{ false }}
+        continue-on-error: true
+        env:
+          artifactPaths: ${{ steps.build.outputs.artifactPaths }}
+        shell: bash
+        run: echo "Artifact ID from previous job is $artifactPaths"
 
       - name: Upload none releases
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         uses: actions/upload-artifact@v4
         with:
-          name: tari-universe_${{ steps.build.outputs.appVersion }}_${{ matrix.platform }}
+          name: tari-universe-beta_${{ steps.build.outputs.appVersion }}_${{ matrix.platform }}
           path: "${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tari-universe",
-    "version": "0.4.6",
+    "version": "0.5.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "0.4.6",
+            "version": "0.5.6",
             "dependencies": {
                 "@floating-ui/react": "^0.26.24",
                 "@tauri-apps/api": "^1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,6 +91,7 @@ custom-protocol = ["tauri/custom-protocol"]
 airdrop-local = []
 airdrop-env = []
 release-ci = ["tauri/custom-protocol"]
+release-ci-beta = ["tauri/custom-protocol"]
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -85,8 +85,10 @@ const LOG_TARGET_WEB: &str = "tari::universe::web";
 
 #[cfg(feature = "release-ci")]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe";
-#[cfg(not(feature = "release-ci"))]
+#[cfg(feature = "release-ci-beta")]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe.beta";
+#[cfg(not(any(feature = "release-ci", feature = "release-ci-beta")))]
+const APPLICATION_FOLDER_ID: &str = "com.tari.universe.alpha";
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,9 +83,9 @@ const MAX_ACCEPTABLE_COMMAND_TIME: Duration = Duration::from_secs(1);
 const LOG_TARGET: &str = "tari::universe::main";
 const LOG_TARGET_WEB: &str = "tari::universe::web";
 
-#[cfg(feature = "release-ci")]
+#[cfg(all(feature = "release-ci", not(feature="release-ci-beta")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe";
-#[cfg(feature = "release-ci-beta")]
+#[cfg(all(feature = "release-ci-beta", not(feature = "release-ci")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe.beta";
 #[cfg(not(any(feature = "release-ci", feature = "release-ci-beta")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe.alpha";

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,12 +83,14 @@ const MAX_ACCEPTABLE_COMMAND_TIME: Duration = Duration::from_secs(1);
 const LOG_TARGET: &str = "tari::universe::main";
 const LOG_TARGET_WEB: &str = "tari::universe::web";
 
+#[cfg(not(any(feature = "release-ci", feature = "release-ci-beta")))]
+const APPLICATION_FOLDER_ID: &str = "com.tari.universe.alpha";
+#[cfg(all(feature = "release-ci", feature = "release-ci-beta"))]
+const APPLICATION_FOLDER_ID: &str = "com.tari.universe.other";
 #[cfg(all(feature = "release-ci", not(feature = "release-ci-beta")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe";
 #[cfg(all(feature = "release-ci-beta", not(feature = "release-ci")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe.beta";
-#[cfg(not(any(feature = "release-ci", feature = "release-ci-beta")))]
-const APPLICATION_FOLDER_ID: &str = "com.tari.universe.alpha";
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,7 +83,7 @@ const MAX_ACCEPTABLE_COMMAND_TIME: Duration = Duration::from_secs(1);
 const LOG_TARGET: &str = "tari::universe::main";
 const LOG_TARGET_WEB: &str = "tari::universe::web";
 
-#[cfg(all(feature = "release-ci", not(feature="release-ci-beta")))]
+#[cfg(all(feature = "release-ci", not(feature = "release-ci-beta")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe";
 #[cfg(all(feature = "release-ci-beta", not(feature = "release-ci")))]
 const APPLICATION_FOLDER_ID: &str = "com.tari.universe.beta";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
         "distDir": "../dist"
     },
     "package": {
-        "productName": "Tari Universe",
+        "productName": "Tari Universe (Alpha)",
         "version": "0.5.6"
     },
     "tauri": {
@@ -17,7 +17,7 @@
         "updater": {
             "active": true,
             "endpoints": [
-                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json"
+                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/alpha-latest.json"
             ],
             "dialog": false,
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK"
@@ -49,7 +49,7 @@
         },
         "windows": [
             {
-                "title": "Tari Universe | Testnet",
+                "title": "Tari Universe (Alpha) | Testnet",
                 "label": "main",
                 "width": 1380,
                 "height": 780,
@@ -67,7 +67,7 @@
         "bundle": {
             "active": true,
             "targets": "all",
-            "identifier": "com.tari.universe.beta",
+            "identifier": "com.tari.universe.alpha",
             "icon": [
                 "icons/icon.icns",
                 "icons/icon.ico",


### PR DESCRIPTION
Description
Add local defulat builds as alpha, ci for beta and release

Motivation and Context
Give users that fork the repo and build local an build labeled alpha
Ci none release builds as beta ... found that we can use [], nor ## nor dashes

How Has This Been Tested?
Builds locally and in local fork with CI and uploads assets as expected for all OS (Windows/OSX/Linux)
