### PR TITLE
fix: handle overflowing updater numbers

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1565,7 +1565,6 @@ fn main() {
             }
             UpdaterEvent::DownloadProgress { chunk_length, content_length } => {
                 downloaded += chunk_length as u64;
-                
                 let content_length = content_length.unwrap_or_else(|| {
                     warn!(target: LOG_TARGET, "Unable to determine content length");
                     downloaded

--- a/src/containers/AutoUpdateDialog/UpdatedStatus.tsx
+++ b/src/containers/AutoUpdateDialog/UpdatedStatus.tsx
@@ -16,12 +16,16 @@ export function UpdatedStatus({ contentLength, downloaded }: UpdatedStatusProps)
         return `${parseFloat((bytes / Math.pow(1024, i)).toFixed(2))} ${sizes[i]}`;
     };
 
+    const shouldShowProgress = contentLength > 0;
+
     return (
         <Stack alignItems="center">
             <ProgressWrapper>
                 <LinearProgress value={(downloaded / contentLength) * 100} variant="secondary" />
             </ProgressWrapper>
-            <Typography variant="p">{`${formatSize(downloaded)} / ${formatSize(contentLength)}`}</Typography>
+            {shouldShowProgress && (
+                <Typography variant="p">{`${formatSize(downloaded)} / ${formatSize(contentLength)}`}</Typography>
+            )}
         </Stack>
     );
 }


### PR DESCRIPTION
### [ Features ]
- Limit `downloaded` value to not exceed `content_length` value
- Prevent displaying progress bar when `content_length` is zero
- Add `info!` log with `chunk_length`, `content_length` and `downloaded` values for future debugging 