### PR TITLE
fix(ui): canvas BG and initial wallet

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
           time = performance.now() / 1000;
           window.addEventListener('resize', onResize);
 
+          glApp.properties.bgColor2 = '#E5E5E5';
+
           onResize();
           animate();
         }

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -39,7 +39,7 @@ export const useWalletStore = create<WalletStoreState>()((set) => ({
                 ...tari_wallet_details.wallet_balance,
                 tari_address_base58: tari_wallet_details.tari_address_base58,
                 tari_address_emoji: tari_wallet_details.tari_address_emoji,
-                balance: newBalance,
+                balance: tari_wallet_details.wallet_balance ? newBalance : null,
             });
         } catch (error) {
             console.error('Could not get tari wallet details: ', error);


### PR DESCRIPTION
Description
---
- changed canvas BG gradient colour to better suit designs
- only update wallet balance in stoore if there is a value from BE (not default to 0)

Motivation and Context
---
- resolves #687 
- fixes #671 properly after BE update


How Has This Been Tested?
---
locally: 


<img width="1291" alt="image" src="https://github.com/user-attachments/assets/57fdc288-bee8-4e34-91a7-7442fb512c79">

https://github.com/user-attachments/assets/013e3e41-13cf-483f-b7d2-1ef8852ad1a6

