### PR TITLE
fix(ui): circular progress wrapper

### DIFF
--- a/src/components/elements/CircularProgress.tsx
+++ b/src/components/elements/CircularProgress.tsx
@@ -2,8 +2,8 @@ import { m } from 'framer-motion';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Description
---
- fixed `CircularProgress` wrapper styling

Motivation and Context
---
noticed a previous change to `CircularProgress` borked the shut down screen

| before ☹️ | after ✨  |
| :---: | :---: |
| <img width="1412" alt="image" src="https://github.com/user-attachments/assets/6284eb65-3113-4907-bafa-41fa79d27d1d"> | <img width="1478" alt="image" src="https://github.com/user-attachments/assets/687a5630-8248-4948-85f9-4a8c70e14514"> |

also centering in buttons, etc. is still fine:

<img width="142" alt="image" src="https://github.com/user-attachments/assets/ba92fb79-535a-4cd0-8601-2e1a273e9bdc">
<img width="133" alt="image" src="https://github.com/user-attachments/assets/e41956a6-5f19-4265-859c-16178687a3fd">
