### PR TITLE
fix: add default values for p2pool during initialization

### DIFF
--- a/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
@@ -69,11 +69,11 @@ const P2PoolStats = () => {
                         labels={[
                             {
                                 labelText: 'SHA-3',
-                                labelValue: '' + p2poolSha3MinersCount,
+                                labelValue: '' + (p2poolSha3MinersCount ?? 0),
                             },
                             {
                                 labelText: 'RandomX',
-                                labelValue: '' + p2poolRandomxMinersCount,
+                                labelValue: '' + (p2poolRandomxMinersCount ?? 0),
                             },
                         ]}
                     />
@@ -111,11 +111,11 @@ const P2PoolStats = () => {
                         labels={[
                             {
                                 labelText: 'SHA-3',
-                                labelValue: '#' + p2poolSha3ChainTip,
+                                labelValue: '#' + (p2poolSha3ChainTip ?? 0),
                             },
                             {
                                 labelText: 'RandomX',
-                                labelValue: '#' + p2poolRandomxChainTip,
+                                labelValue: '#' + (p2poolRandomxChainTip ?? 0),
                             },
                         ]}
                     />


### PR DESCRIPTION
Description
---
Add default values for p2pool stats.

Motivation and Context
---
Fix `undefined` displayed in experimental setting during initialization.

How Has This Been Tested?
---
Run app and check if there is any `undefined` in experimental settings.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
