### PR TITLE
fix: lock tauri-cli version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: CI
   push:
     branches:
       - "ci-*"
-      - fix/CI-tauri-cli-version-lock
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
   push:
     branches:
       - "ci-*"
+      - fix/CI-tauri-cli-version-lock
   pull_request:
     types:
       - opened
@@ -235,6 +236,6 @@ jobs:
       - name: cargo tauri build
         working-directory: ./src-tauri
         run: |
-          cargo install tauri-cli
+          cargo install tauri-cli --version "1.6.2"
           cargo tauri --version
           cargo tauri build --ci --bundles deb


### PR DESCRIPTION
Description
---
After release of stable tauri 2.0 the new default version for tauri-cli is 2.0 which brakes build on CI.

Motivation and Context
---
Fix failing builds due invalid version.

How Has This Been Tested?
---
Force CI run by changing rules of triggering worklfow.

What process can a PR reviewer use to test or verify this change?
---
Check action history.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
