### PR TITLE
fix(ui): removed a bad import from the airdrop login modal

### DIFF
--- a/src/containers/Airdrop/AirdropGiftTracker/components/Claimmodal/ClaimModal.tsx
+++ b/src/containers/Airdrop/AirdropGiftTracker/components/Claimmodal/ClaimModal.tsx
@@ -14,7 +14,6 @@ import {
     InputWrapper,
     StyledInput,
     Text,
-    TextButton,
     TextWrapper,
     Title,
     Wrapper,


### PR DESCRIPTION
This is just a lint fix, removing an unused import from the ClaimModal component. 
