### PR TITLE
fix: sidebar layout | hidden airdrop ui

### DIFF
--- a/src/containers/Airdrop/AirdropGiftTracker/AirdropGiftTracker.tsx
+++ b/src/containers/Airdrop/AirdropGiftTracker/AirdropGiftTracker.tsx
@@ -18,7 +18,7 @@ export default function AirdropGiftTracker() {
     const isLoggedIn = !!airdropTokens;
 
     return (
-        <Wrapper>
+        <Wrapper layout>
             <TitleWrapper>
                 <Title>{t('airdropGame')}</Title>
                 <InfoTooltip title={t('topTooltipTitle')} text={t('topTooltipText')} />

--- a/src/containers/Airdrop/AirdropGiftTracker/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { m } from 'framer-motion';
 
-export const Wrapper = styled('div')`
+export const Wrapper = styled(m.div)`
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -10,9 +11,10 @@ export const Wrapper = styled('div')`
 
     border-radius: 10px;
     background: #fff;
-    box-shadow: 0px 4px 45px 0px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 45px 0 rgba(0, 0, 0, 0.08);
 
     position: relative;
+    height: auto;
 `;
 
 export const TitleWrapper = styled('div')`

--- a/src/containers/SideBar/components/Wallet/Wallet.styles.ts
+++ b/src/containers/SideBar/components/Wallet/Wallet.styles.ts
@@ -10,8 +10,6 @@ import { sidebarWidth } from '@app/theme/styles.ts';
 export const WalletContainer = styled(m.div)`
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
     background-image: url(${cardBg});
     background-size: cover;
     background-repeat: no-repeat;
@@ -27,6 +25,7 @@ export const WalletContainer = styled(m.div)`
     min-height: 178px;
     z-index: 2;
     overflow: hidden;
+    justify-content: space-between;
 `;
 
 export const WalletBalance = styled.div`
@@ -36,14 +35,16 @@ export const WalletBalance = styled.div`
     width: 100%;
 `;
 
-export const WalletBalanceContainer = styled.div`
+export const WalletBalanceContainer = styled(m.div)`
     display: flex;
     flex-direction: column;
-    justify-content: flex-start;
+    position: relative;
+    justify-content: flex-end;
     align-items: flex-start;
     width: 100%;
     color: ${({ theme }) => theme.palette.text.secondary};
-    padding: 60px 5px 5px;
+    padding: 10px 5px 5px;
+    height: 140px;
 `;
 
 export const BalanceVisibilityButton = styled(IconButton)`

--- a/src/containers/SideBar/components/Wallet/Wallet.tsx
+++ b/src/containers/SideBar/components/Wallet/Wallet.tsx
@@ -29,7 +29,7 @@ export default function Wallet() {
     const displayValue = balance === null ? '-' : showBalance ? formatted : '*****';
 
     const balanceMarkup = (
-        <WalletBalanceContainer>
+        <WalletBalanceContainer layout>
             <Stack direction="row" alignItems="center">
                 <Typography variant="span" style={{ fontSize: '15px' }}>
                     {t('wallet-balance')}
@@ -49,7 +49,11 @@ export default function Wallet() {
     );
 
     return (
-        <WalletContainer layout style={{ height: showHistory ? 'auto' : 178 }} transition={{ duration: 0.2 }}>
+        <WalletContainer
+            layout
+            style={{ height: showHistory ? 'auto' : 178 }}
+            transition={{ duration: 0.1, ease: 'linear' }}
+        >
             {balance ? (
                 <ShowHistoryButton onClick={() => setShowHistory((c) => !c)} style={{ minWidth: 80 }}>
                     {!showHistory ? 'Show' : 'Hide'} history

--- a/src/containers/SideBar/styles.ts
+++ b/src/containers/SideBar/styles.ts
@@ -71,4 +71,5 @@ export const Bottom = styled(m.div)`
     display: flex;
     flex-direction: column;
     gap: 12px;
+    padding-bottom: 188px; // to cater for wallet card
 `;


### PR DESCRIPTION
Description
---

- adjust wrappers so we can use `layout` prop & adjusted the expanding animation slightly
- set height on wallet balance section
- set bottom padding in bottom sidebar section to cater for the fixed wallet card so airdrop UI is above

How Has This Been Tested?
---

- locally



https://github.com/user-attachments/assets/fbeb702b-d20c-4110-b339-81c17ac92c9c

