### PR TITLE
feat(ui): added connection indicator to version chip

### DIFF
--- a/src/containers/SideBar/components/Heading.tsx
+++ b/src/containers/SideBar/components/Heading.tsx
@@ -1,9 +1,9 @@
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { Stack } from '@app/components/elements/Stack.tsx';
-import { Chip } from '@app/components/elements/Chip.tsx';
 import { useTranslation } from 'react-i18next';
 import packageInfo from '../../../../package.json';
 import OpenSettingsButton from '@app/containers/Settings/components/OpenSettingsButton.tsx';
+import VersionChip from './VersionChip/VersionChip';
 
 const appVersion = packageInfo.version;
 const versionString = `v${appVersion}`;
@@ -13,9 +13,7 @@ function Heading() {
         <Stack direction="row" justifyContent="space-between">
             <Stack direction="row" alignItems="center" gap={10}>
                 <Typography variant="h3">{t('tari-universe')}</Typography>
-                <Chip>
-                    {t('testnet')} {versionString}
-                </Chip>
+                <VersionChip version={versionString} />
             </Stack>
             <OpenSettingsButton />
         </Stack>

--- a/src/containers/SideBar/components/VersionChip/ConnectedPulse/ConnectedPulse.tsx
+++ b/src/containers/SideBar/components/VersionChip/ConnectedPulse/ConnectedPulse.tsx
@@ -1,0 +1,14 @@
+import { Dot, Pulse, Wrapper } from './styles';
+
+interface Props {
+    isConnected: boolean;
+}
+
+export default function ConnectedPulse({ isConnected }: Props) {
+    return (
+        <Wrapper>
+            <Dot $isConnected={isConnected} />
+            <Pulse $isConnected={isConnected} />
+        </Wrapper>
+    );
+}

--- a/src/containers/SideBar/components/VersionChip/ConnectedPulse/styles.ts
+++ b/src/containers/SideBar/components/VersionChip/ConnectedPulse/styles.ts
@@ -1,0 +1,51 @@
+import styled, { css, keyframes } from 'styled-components';
+
+const pulse = keyframes`
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+`;
+
+export const Wrapper = styled('div')`
+    position: relative;
+    width: 9px;
+    height: 9px;
+`;
+
+export const Dot = styled('div')<{ $isConnected: boolean }>`
+    width: 5px;
+    height: 5px;
+    background-color: #31eeaa;
+    border-radius: 50%;
+
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    ${({ $isConnected }) =>
+        !$isConnected &&
+        css`
+            background-color: #f3c11c;
+        `}
+`;
+
+export const Pulse = styled('div')<{ $isConnected: boolean }>`
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: #31eeaa;
+    animation: ${pulse} 2s infinite;
+
+    ${({ $isConnected }) =>
+        !$isConnected &&
+        css`
+            background-color: #f3c11c;
+        `}
+`;

--- a/src/containers/SideBar/components/VersionChip/VersionChip.tsx
+++ b/src/containers/SideBar/components/VersionChip/VersionChip.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+import ConnectedPulse from './ConnectedPulse/ConnectedPulse';
+import { Divider, Wrapper } from './styles';
+import { useAppStateStore } from '@app/store/appStateStore';
+
+interface Props {
+    version: string;
+}
+
+export default function VersionChip({ version }: Props) {
+    const { t } = useTranslation('common', { useSuspense: false });
+
+    const isAppSettingUp = useAppStateStore((s) => s.isSettingUp);
+
+    const isConnected = !isAppSettingUp;
+
+    return (
+        <Wrapper>
+            <ConnectedPulse isConnected={isConnected} />
+            <Divider />
+            {t('testnet')} <span>{version}</span>
+        </Wrapper>
+    );
+}

--- a/src/containers/SideBar/components/VersionChip/VersionChip.tsx
+++ b/src/containers/SideBar/components/VersionChip/VersionChip.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import ConnectedPulse from './ConnectedPulse/ConnectedPulse';
 import { Divider, Wrapper } from './styles';
-import { useAppStateStore } from '@app/store/appStateStore';
+import { useMiningStore } from '@app/store/useMiningStore';
 
 interface Props {
     version: string;
@@ -10,13 +10,11 @@ interface Props {
 export default function VersionChip({ version }: Props) {
     const { t } = useTranslation('common', { useSuspense: false });
 
-    const isAppSettingUp = useAppStateStore((s) => s.isSettingUp);
-
-    const isConnected = !isAppSettingUp;
+    const isConnectedToTariNetwork = useMiningStore((s) => s.base_node?.is_connected);
 
     return (
         <Wrapper>
-            <ConnectedPulse isConnected={isConnected} />
+            <ConnectedPulse isConnected={isConnectedToTariNetwork} />
             <Divider />
             {t('testnet')} <span>{version}</span>
         </Wrapper>

--- a/src/containers/SideBar/components/VersionChip/styles.ts
+++ b/src/containers/SideBar/components/VersionChip/styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled('div')`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+
+    height: 21px;
+    padding: 0px 10px 0 8px;
+
+    border-radius: 20px;
+    background: #000;
+
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 100%;
+    white-space: nowrap;
+
+    transform: translateY(1px);
+
+    span {
+        color: #afafaf;
+    }
+`;
+
+export const Divider = styled('div')`
+    width: 1px;
+    height: 12px;
+
+    background: rgba(255, 255, 255, 0.2);
+`;


### PR DESCRIPTION
- Moved the chip in the sidebar header into it's own `VersionChip` component.
- Added a `ConnectedPulse` indicator component that shows yellow while connecting and green once connected.
- Updated version number to grey to match designs.

Question: Im using the `isSettingUp` value from `useAppStateStore` to check the status of the connection, are there other / different checks that should be made for proper integration? 

![CleanShot 2024-10-08 at 15 48 08](https://github.com/user-attachments/assets/cade90d6-93c4-482f-aaea-1ba0d03d4812)
