### PR TITLE
fix(ui): add restart modal | remove disabling

### DIFF
--- a/src/components/elements/ToggleSwitch.tsx
+++ b/src/components/elements/ToggleSwitch.tsx
@@ -16,10 +16,8 @@ const Label = styled.label`
     cursor: pointer;
 
     border-radius: 40px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    background: rgba(255, 255, 255, 0.2);
-    box-shadow: 20px 20px 65px 0 rgba(0, 0, 0, 0.15);
-    backdrop-filter: blur(7px);
+    background: ${({ theme }) => theme.palette.background.paper};
+    box-shadow: 10px 10px 25px 3px rgba(0, 0, 0, 0.05);
 
     display: flex;
     justify-content: space-between;
@@ -64,7 +62,7 @@ const Input = styled.input<{ $isSolid?: boolean }>`
     display: none;
     &:disabled + ${Switch} {
         pointer-events: none;
-        background: ${({ theme }) => theme.palette.colors.grey[200]};
+        background: ${({ theme }) => theme.palette.colors.success[100]};
     }
     &:checked + ${Switch} {
         &:before {

--- a/src/components/elements/buttons/ButtonBase.styles.ts
+++ b/src/components/elements/buttons/ButtonBase.styles.ts
@@ -29,6 +29,9 @@ export const StyledButtonBase = styled.button<Props>`
         opacity: 0.5;
         cursor: inherit;
     }
+    &:hover {
+        opacity: 0.85;
+    }
 
     ${({ $variant, $color }) => {
         switch ($variant) {
@@ -36,18 +39,21 @@ export const StyledButtonBase = styled.button<Props>`
                 return css`
                     border: 1px solid ${({ theme }) => theme.palette[$color || 'primary'].light};
                     color: ${({ theme }) => theme.palette.base};
-                    background: ${({ theme }) => theme.palette[$color || 'primary'].dark};
+                    background: ${({ theme }) => theme.palette[$color || 'primary'].main};
                 `;
             case 'gradient':
                 return css`
                     background: linear-gradient(86deg, #780eff -4.33%, #bf28ff 102.27%);
                     color: ${({ theme }) => theme.palette.text.contrast};
+                    &:hover {
+                        background: linear-gradient(86deg, #780eff -24.33%, #bf28ff 78.27%);
+                    }
                 `;
             case 'secondary':
                 return css`
-                    box-shadow: 0 2px 20px -10px rgba(0, 0, 0, 0.06);
-                    color: ${({ theme }) => theme.palette.primary.main};
-                    background: ${({ theme }) => theme.palette.background.paper};
+                    box-shadow: 0 2px 20px -10px rgba(0, 0, 0, 0.076);
+                    color: ${({ theme }) => theme.palette[$color || 'primary'].main};
+                    background: ${({ theme }) => theme.palette[$color || 'background'].paper};
                 `;
             case 'primary':
             default:
@@ -62,10 +68,15 @@ export const StyledButtonBase = styled.button<Props>`
 
     ${({ $size }) => {
         switch ($size) {
-            case 'small':
+            case 'xs':
                 return css`
                     padding: 0 8px;
                     font-size: 10px;
+                `;
+            case 'small':
+                return css`
+                    padding: 6px 12px;
+                    font-size: 14px;
                 `;
             case 'large':
                 return css`

--- a/src/components/elements/buttons/ButtonBase.tsx
+++ b/src/components/elements/buttons/ButtonBase.tsx
@@ -3,7 +3,7 @@ import { StyledButtonBase } from './ButtonBase.styles.ts';
 
 type ButtonBaseVariant = 'primary' | 'secondary' | 'outlined' | 'gradient';
 type ButtonBaseColor = 'primary' | 'secondary' | 'gradient';
-type ButtonBaseSize = 'small' | 'medium' | 'large';
+type ButtonBaseSize = 'xs' | 'small' | 'medium' | 'large';
 
 export interface ButtonBaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     variant?: ButtonBaseVariant;

--- a/src/containers/Settings/sections/experimental/P2pMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/P2pMarkup.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
-import { useMiningStore } from '@app/store/useMiningStore.ts';
 
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { ToggleSwitch } from '@app/components/elements/ToggleSwitch.tsx';
@@ -14,42 +13,73 @@ import {
     SettingsGroupTitle,
     SettingsGroupWrapper,
 } from '@app/containers/Settings/components/SettingsGroup.styles.ts';
+import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog.tsx';
+import { ButtonBase } from '@app/components/elements/buttons/ButtonBase.tsx';
+import { Stack } from '@app/components/elements/Stack.tsx';
+import { invoke } from '@tauri-apps/api/tauri';
 
 const P2pMarkup = () => {
+    const [showRestartModal, setShowRestartModal] = useState(false);
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const isP2poolEnabled = useAppConfigStore((state) => state.p2pool_enabled);
     const setP2poolEnabled = useAppConfigStore((state) => state.setP2poolEnabled);
     const miningAllowed = useAppStateStore((s) => s.setupProgress >= 1);
-    const isCPUMining = useMiningStore((s) => s.cpu.mining.is_mining);
-    const isGPUMining = useMiningStore((s) => s.gpu.mining.is_mining);
-    const miningInitiated = useMiningStore((s) => s.miningInitiated);
-    const isMiningInProgress = isCPUMining || isGPUMining;
-    const isDisabled = isMiningInProgress || miningInitiated || !miningAllowed;
+    const isDisabled = !miningAllowed;
 
     const handleP2poolEnabled = useCallback(
         async (event: React.ChangeEvent<HTMLInputElement>) => {
             await setP2poolEnabled(event.target.checked);
+            setShowRestartModal((c) => !c);
         },
         [setP2poolEnabled]
     );
 
+    const handleRestart = useCallback(async () => {
+        try {
+            console.info('Restarting application.');
+            await invoke('restart_application');
+        } catch (error) {
+            console.error('Restart error: ', error);
+        }
+    }, []);
+
     return (
-        <SettingsGroupWrapper>
-            <SettingsGroup>
-                <SettingsGroupContent>
-                    <SettingsGroupTitle>
-                        <Typography variant="h6">
-                            {t('pool-mining', { ns: 'settings' })}
-                            <b>&nbsp;(APP RESTART REQUIRED)</b>
-                        </Typography>
-                    </SettingsGroupTitle>
-                    <Typography>{t('pool-mining-description', { ns: 'settings' })}</Typography>
-                </SettingsGroupContent>
-                <SettingsGroupAction>
-                    <ToggleSwitch checked={isP2poolEnabled} disabled={isDisabled} onChange={handleP2poolEnabled} />
-                </SettingsGroupAction>
-            </SettingsGroup>
-        </SettingsGroupWrapper>
+        <Dialog open={showRestartModal} onOpenChange={setShowRestartModal}>
+            <SettingsGroupWrapper>
+                <SettingsGroup>
+                    <SettingsGroupContent>
+                        <SettingsGroupTitle>
+                            <Typography variant="h6">
+                                {t('pool-mining', { ns: 'settings' })}
+                                <b>&nbsp;(APP RESTART REQUIRED)</b>
+                            </Typography>
+                        </SettingsGroupTitle>
+                        <Typography>{t('pool-mining-description', { ns: 'settings' })}</Typography>
+                    </SettingsGroupContent>
+                    <SettingsGroupAction>
+                        <ToggleSwitch checked={isP2poolEnabled} disabled={isDisabled} onChange={handleP2poolEnabled} />
+                    </SettingsGroupAction>
+                </SettingsGroup>
+            </SettingsGroupWrapper>
+            <DialogContent>
+                {/*TODO: move to own component*/}
+                <Stack direction="column" alignItems="center" justifyContent="space-between" style={{ height: 120 }}>
+                    <Stack>
+                        <Typography variant="h3">Restart Tari Universe?</Typography>
+                        <Typography variant="p">An app restart is required for changes to take effect.</Typography>
+                    </Stack>
+
+                    <Stack direction="row" gap={8}>
+                        <ButtonBase size="small" onClick={() => setShowRestartModal(false)}>
+                            Cancel
+                        </ButtonBase>
+                        <ButtonBase size="small" variant="outlined" onClick={handleRestart}>
+                            Restart Now
+                        </ButtonBase>
+                    </Stack>
+                </Stack>
+            </DialogContent>
+        </Dialog>
     );
 };
 

--- a/src/containers/SideBar/components/Wallet/Wallet.styles.ts
+++ b/src/containers/SideBar/components/Wallet/Wallet.styles.ts
@@ -55,7 +55,7 @@ export const BalanceVisibilityButton = styled(IconButton)`
 `;
 
 export const ShowHistoryButton = styled(ButtonBase).attrs({
-    size: 'small',
+    size: 'xs',
     variant: 'outlined',
     color: 'secondary',
 })`

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -21,7 +21,8 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 const success = {
-    100: '#E6FAF6',
+    50: '#E6FAF6',
+    100: '#a1d2c1',
     200: '#06C983',
     300: '#094E41',
 };

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -67,7 +67,7 @@ export const light = {
         success: {
             main: success[200],
             dark: success[300],
-            light: success[100],
+            light: success[50],
             contrastText: success[300],
         },
         warning: {
@@ -128,9 +128,9 @@ export const dark = {
         },
         success: {
             main: success[200],
-            dark: success[100],
+            dark: success[50],
             light: success[300],
-            contrastText: success[100],
+            contrastText: success[50],
         },
         warning: {
             main: warning[200],

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -42,14 +42,14 @@ export const light = {
         contrast: '#000000',
         primary: {
             main: tariPurple[600],
-            dark: tariPurple[800],
+            dark: tariPurple[700],
             light: tariPurple[500],
             shadow: tariPurpleAlpha[10],
             wisp: tariPurpleAlpha[5],
         },
         secondary: {
-            main: grey[600],
-            dark: grey[700],
+            main: grey[700],
+            dark: grey[800],
             light: grey[500],
             wisp: tariPurpleAlpha[5],
         },


### PR DESCRIPTION
Description
---
- change toggle switch disabled styling to still be green but much lighter, instead of grey
- only disable when mining is setting up, allow for it to be toggled, but prompt an app restart

How Has This Been Tested?
---
- locally:

https://github.com/user-attachments/assets/334dce98-b574-4c2e-9c81-2f4b1e442e28

