### PR TITLE
fix(binaries): add failsafe mirror to the tor binaries

### DIFF
--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -17,6 +17,30 @@ pub(crate) struct TorReleaseAdapter {}
 #[async_trait]
 impl LatestVersionApiAdapter for TorReleaseAdapter {
     async fn fetch_releases_list(&self) -> Result<Vec<VersionDownloadInfo>, Error> {
+        let cdn_tor_bundle_url = "https://cdn-universe.tari.com/torbrowser/13.5.6/tor-expert-bundle-windows-x86_64-13.5.6.tar.gz";
+        let mut cdn_responded = false;
+
+        for _ in 0..3 {
+            let response = reqwest::get(cdn_tor_bundle_url).await;
+            if let Ok(resp) = response {
+                if resp.status().is_success() {
+                    cdn_responded = true;
+                    break;
+                }
+            }
+        }
+
+        if cdn_responded {
+            let version = VersionDownloadInfo {
+                version: "13.5.6".parse().expect("Bad tor version"),
+                assets: vec![VersionAsset {
+                    url: cdn_tor_bundle_url.to_string(),
+                    name: "tor-expert-bundle-windows-x86_64-13.5.6.tar.gz".to_string(),
+                }],
+            };
+            return Ok(vec![version]);
+        }
+
         // Tor doesn't have a nice API for this so just return specific ones
         let version = VersionDownloadInfo {
             version: "13.5.6".parse().expect("Bad tor version"),


### PR DESCRIPTION
Description
---
Tor was missing a failsafe mirror like other binaries.

Motivation and Context
---
Tor was blocked on 0.5.9 and needed a mirror CDN.

How Has This Been Tested?
---
On windows machine remove tor binaries and run again to check if works.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
