### PR TITLE
feat: validate wallet conf matches existing wallet

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3048,6 +3048,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -59,6 +59,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1572,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2260,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2246,6 +2278,15 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -3003,11 +3044,10 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4936,6 +4976,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+dependencies = [
+ "bitflags 1.3.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6099,7 +6154,6 @@ dependencies = [
  "futures-util",
  "jsonwebtoken",
  "keyring",
- "libsqlite3-sys",
  "log",
  "log4rs",
  "minotari_node_grpc_client",
@@ -6110,6 +6164,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.7",
+ "rusqlite",
  "sanitize-filename",
  "semver",
  "sentry-tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,13 +87,12 @@ zip = "2.2.0"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"
 
-# needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"
+rusqlite = "0.25.1"
 sentry-tauri = "0.3.0"
 sys-locale = "0.3.1"
 # tonic = "0.12.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,9 +30,6 @@ keyring = {version = "3.0.5", features = [
   "apple-native",
   "linux-native",
 ] }
-libsqlite3-sys = {version = "0.25.1", features = [
-  "bundled",
-] }# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -43,6 +40,7 @@ open = "5"
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
+rusqlite = { version = "0.25.2", features = ["bundled"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
 sentry-tauri = "0.3.0"
@@ -86,16 +84,6 @@ zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"
-
-chrono = "0.4.38"
-device_query = "2.1.0"
-log = "0.4.22"
-nvml-wrapper = "0.10.0"
-rand = "0.8.5"
-rusqlite = "0.25.1"
-sentry-tauri = "0.3.0"
-sys-locale = "0.3.1"
-# tonic = "0.12.0"
 
 [features]
 airdrop-env = []

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -74,11 +74,14 @@ impl InternalWallet {
                     info!(target: LOG_TARGET, "Validating wallet config matches existing wallet");
 
                     let conn = Connection::open(&wallet_db)?;
-                    let mut stmt = conn.prepare("SELECT value FROM wallet_settings WHERE key == 'WalletType'")?;
+                    let mut stmt = conn
+                        .prepare("SELECT value FROM wallet_settings WHERE key == 'WalletType'")?;
                     let value: String = stmt.query_row([], |row| row.get(0))?;
                     let wallet_settings: WalletSettings = serde_json::from_str(&value)?;
 
-                    if wallet_settings.provided_keys.public_spend_key == config.spend_public_key_hex && wallet_settings.provided_keys.view_key == config.view_key_private_hex {
+                    if wallet_settings.provided_keys.public_spend_key == config.spend_public_key_hex
+                        && wallet_settings.provided_keys.view_key == config.view_key_private_hex
+                    {
                         info!(target: LOG_TARGET, "Wallet keys matched all good");
                         return Ok(Self {
                             tari_address: TariAddress::from_base58(&config.tari_address_base58)?,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1724,7 +1724,7 @@ fn main() {
 
     let mut shutdown = Shutdown::new();
 
-    // NOTE: Nothing is started at this point, so ports are not known. You can only start settings ports
+    // NOTE: Nothing is started at this point, so ports are not known. You can only start setting ports
     // and addresses once the different services have been started.
     // A better way is to only provide the config when we start the service.
     let node_manager = NodeManager::new();
@@ -1823,7 +1823,7 @@ fn main() {
                     .expect("Could not get log dir"),
                 include_str!("../log4rs_sample.yml"),
             )
-            .expect("Could not set up logging");
+                .expect("Could not set up logging");
 
             let config_path = app
                 .path_resolver()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1823,7 +1823,7 @@ fn main() {
                     .expect("Could not get log dir"),
                 include_str!("../log4rs_sample.yml"),
             )
-                .expect("Could not set up logging");
+            .expect("Could not set up logging");
 
             let config_path = app
                 .path_resolver()


### PR DESCRIPTION
Description
---
If the config file doesn't match the wallet, then ditch them both and start fresh. This should be rare for users but happens frequently in development.

Avoid waiting for the wallet to start by reading the needed keys directly from the dir before the startup sequence occurs.

Motivation and Context
---
Prevent mismatches of the displayed settings and running wallet. If the config previously got deleted a new one would generate displaying a new address, but the running wallet wouldn't reflect that address.

How Has This Been Tested?
---
Manually


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
