### PR TITLE
fix: add logging if parsing pid file failed

### DIFF
--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -46,7 +46,7 @@ pub(crate) trait ProcessAdapter {
                 }
                 Err(e) => {
                     let error_msg =
-                        format!("Error parsing pid file: {}. Pid file name: {}", e, pid);
+                        format!("Error parsing pid file: {}. Pid file content: {}", e, pid);
                     error!(target: LOG_TARGET, "{}", error_msg);
                     sentry::capture_event(Event {
                         message: Some(error_msg),

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -1,9 +1,10 @@
-use std::fs;
-use std::path::PathBuf;
-
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
-use log::{info, warn};
+use log::{error, info, warn};
+use sentry::protocol::Event;
+use sentry_tauri::sentry;
+use std::fs;
+use std::path::PathBuf;
 use tari_shutdown::Shutdown;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -38,11 +39,23 @@ pub(crate) trait ProcessAdapter {
     fn kill_previous_instances(&self, base_folder: PathBuf) -> Result<(), Error> {
         info!(target: LOG_TARGET, "Killing previous instances of {}", self.name());
         match fs::read_to_string(base_folder.join(self.pid_file_name())) {
-            Ok(pid) => {
-                let pid = pid.trim().parse::<i32>()?;
-                warn!(target: LOG_TARGET, "{} process did not shut down cleanly: {} pid file was created", pid, self.pid_file_name());
-                kill_process(pid)?;
-            }
+            Ok(pid) => match pid.trim().parse::<i32>() {
+                Ok(pid) => {
+                    warn!(target: LOG_TARGET, "{} process did not shut down cleanly: {} pid file was created", pid, self.pid_file_name());
+                    kill_process(pid)?;
+                }
+                Err(e) => {
+                    let error_msg =
+                        format!("Error parsing pid file: {}. Pid file name: {}", e, pid);
+                    error!(target: LOG_TARGET, "{}", error_msg);
+                    sentry::capture_event(Event {
+                        message: Some(error_msg),
+                        level: sentry::Level::Error,
+                        culprit: Some("process-adapter".to_string()),
+                        ..Default::default()
+                    });
+                }
+            },
             Err(e) => {
                 if let Ok(true) = std::path::Path::new(&base_folder)
                     .join(self.pid_file_name())


### PR DESCRIPTION
Description
---
Add additional logging if parsing pid file content fails. 

Motivation and Context
---
Some users experienced error while parsing pid file content. The issue could be localization but without any logs we can't be sure. 

How Has This Been Tested?
---
Manually modified `node_pid`  file content to contain invalid pid number and close abnormally app to prevent graceful shutdown (app rebuild by saving changes in code editor or use tools like `xkill`).

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
