### PR TITLE
fix(ui): global font and font faces

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           time = performance.now() / 1000;
           window.addEventListener('resize', onResize);
 
-          glApp.properties.bgColor2 = '#E5E5E5';
+          glApp.properties.bgColor2 = '#d5d5d5';
 
           onResize();
           animate();

--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
           time = performance.now() / 1000;
           window.addEventListener('resize', onResize);
 
-          glApp.properties.bgColor2 = '#d5d5d5';
+          glApp.properties.bgColor1 = '#F6F6F6';
+          glApp.properties.bgColor2 = '#EEEEEE';
 
           onResize();
           animate();

--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -63,6 +63,7 @@ export const SelectedOption = styled.div<{ $isBordered?: boolean }>`
     font-weight: 500;
     height: 36px;
     width: 100%;
+    letter-spacing: -0.2px;
     img {
         width: 14px;
         display: flex;
@@ -73,7 +74,7 @@ export const OptionLabelWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 9px;
+    gap: 6px;
     img {
         width: 18px;
         display: flex;

--- a/src/containers/Airdrop/AirdropGiftTracker/components/Claimmodal/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/components/Claimmodal/styles.ts
@@ -64,7 +64,7 @@ export const Title = styled('div')`
     font-weight: 800;
     line-height: 99.7%;
     text-transform: uppercase;
-    font-family: Druk, sans-serif;
+    font-family: DrukWide, sans-serif;
 
     span {
         color: #ff4a55;
@@ -181,7 +181,7 @@ export const ClaimButton = styled('button')`
     color: #c9eb00;
     font-size: 21px;
     text-align: center;
-    font-family: Druk, sans-serif;
+    font-family: DrukWide, sans-serif;
     width: 100%;
     border-radius: 49px;
     background: #000;

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
@@ -13,14 +13,12 @@ export default function LoggedIn() {
     const {
         userDetails,
         userPoints,
-        // flareAnimationType,
+        flareAnimationType,
         bonusTiers,
         setFlareAnimationType,
         referralQuestPoints,
         miningRewardPoints,
     } = useAirdropStore();
-
-    const flareAnimationType = 'BonusGems';
 
     useEffect(() => {
         setGems(userPoints?.base.gems || userDetails?.user?.rank?.gems || 0);
@@ -34,23 +32,23 @@ export default function LoggedIn() {
         [bonusTiers, userDetails?.user?.rank?.gems, userPoints?.base.gems]
     );
 
-    // const flareGems = useMemo(() => {
-    //     switch (flareAnimationType) {
-    //         case 'GoalComplete':
-    //             return bonusTier?.bonusGems || 0;
-    //         case 'FriendAccepted':
-    //             return referralQuestPoints?.pointsForClaimingReferral || REFERRAL_GEMS;
-    //         case 'BonusGems':
-    //             return miningRewardPoints?.reward || 0;
-    //         default:
-    //             return 0;
-    //     }
-    // }, [
-    //     flareAnimationType,
-    //     bonusTier?.bonusGems,
-    //     referralQuestPoints?.pointsForClaimingReferral,
-    //     miningRewardPoints?.reward,
-    // ]);
+    const flareGems = useMemo(() => {
+        switch (flareAnimationType) {
+            case 'GoalComplete':
+                return bonusTier?.bonusGems || 0;
+            case 'FriendAccepted':
+                return referralQuestPoints?.pointsForClaimingReferral || REFERRAL_GEMS;
+            case 'BonusGems':
+                return miningRewardPoints?.reward || 0;
+            default:
+                return 0;
+        }
+    }, [
+        flareAnimationType,
+        bonusTier?.bonusGems,
+        referralQuestPoints?.pointsForClaimingReferral,
+        miningRewardPoints?.reward,
+    ]);
 
     return (
         <Wrapper>
@@ -64,7 +62,7 @@ export default function LoggedIn() {
             <AnimatePresence>
                 {flareAnimationType && (
                     <Flare
-                        gems={100}
+                        gems={flareGems}
                         animationType={flareAnimationType}
                         onAnimationComplete={() => setFlareAnimationType()}
                         onClick={() => setFlareAnimationType()}

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
@@ -13,12 +13,14 @@ export default function LoggedIn() {
     const {
         userDetails,
         userPoints,
-        flareAnimationType,
+        // flareAnimationType,
         bonusTiers,
         setFlareAnimationType,
         referralQuestPoints,
         miningRewardPoints,
     } = useAirdropStore();
+
+    const flareAnimationType = 'BonusGems';
 
     useEffect(() => {
         setGems(userPoints?.base.gems || userDetails?.user?.rank?.gems || 0);
@@ -32,23 +34,23 @@ export default function LoggedIn() {
         [bonusTiers, userDetails?.user?.rank?.gems, userPoints?.base.gems]
     );
 
-    const flareGems = useMemo(() => {
-        switch (flareAnimationType) {
-            case 'GoalComplete':
-                return bonusTier?.bonusGems || 0;
-            case 'FriendAccepted':
-                return referralQuestPoints?.pointsForClaimingReferral || REFERRAL_GEMS;
-            case 'BonusGems':
-                return miningRewardPoints?.reward || 0;
-            default:
-                return 0;
-        }
-    }, [
-        flareAnimationType,
-        bonusTier?.bonusGems,
-        referralQuestPoints?.pointsForClaimingReferral,
-        miningRewardPoints?.reward,
-    ]);
+    // const flareGems = useMemo(() => {
+    //     switch (flareAnimationType) {
+    //         case 'GoalComplete':
+    //             return bonusTier?.bonusGems || 0;
+    //         case 'FriendAccepted':
+    //             return referralQuestPoints?.pointsForClaimingReferral || REFERRAL_GEMS;
+    //         case 'BonusGems':
+    //             return miningRewardPoints?.reward || 0;
+    //         default:
+    //             return 0;
+    //     }
+    // }, [
+    //     flareAnimationType,
+    //     bonusTier?.bonusGems,
+    //     referralQuestPoints?.pointsForClaimingReferral,
+    //     miningRewardPoints?.reward,
+    // ]);
 
     return (
         <Wrapper>
@@ -62,7 +64,7 @@ export default function LoggedIn() {
             <AnimatePresence>
                 {flareAnimationType && (
                     <Flare
-                        gems={flareGems}
+                        gems={100}
                         animationType={flareAnimationType}
                         onAnimationComplete={() => setFlareAnimationType()}
                         onClick={() => setFlareAnimationType()}

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Flare/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Flare/styles.ts
@@ -20,9 +20,9 @@ export const Wrapper = styled(m.div)`
 export const Number = styled(m.div)`
     text-align: center;
     font-family: Druk, sans-serif;
-    font-size: 38px;
+    font-size: 68px;
     font-weight: 700;
-
+    line-height: 1.1;
     position: relative;
     z-index: 2;
 `;

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/UserInfo/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/UserInfo/styles.ts
@@ -36,7 +36,7 @@ export const Name = styled('div')`
     font-size: 18px;
     font-style: normal;
     font-weight: 700;
-    line-height: 100%;
+    line-height: 1.15;
     letter-spacing: -0.36px;
 
     white-space: nowrap;

--- a/src/containers/Dashboard/MiningView/components/BlockHeightAccent.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockHeightAccent.styles.ts
@@ -13,7 +13,7 @@ export const AccentWrapper = styled(m.div)`
 
 export const AccentText = styled(m.div)`
     display: flex;
-    font-family: Druk, sans-serif;
+    font-family: DrukWide, sans-serif;
     white-space: pre;
     line-height: 1;
     opacity: 0.55;

--- a/src/containers/Dashboard/MiningView/components/BlockHeightAccent.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockHeightAccent.styles.ts
@@ -18,17 +18,16 @@ export const AccentText = styled(m.div)`
     line-height: 1;
     opacity: 0.55;
     position: relative;
-    color: ${({ theme }) => theme.palette.base};
+    color: rgba(255, 255, 255, 0.4);
     user-select: none;
     height: min-content;
-    text-shadow: -4px -4px 40px rgba(206, 206, 206, 0.25);
 `;
 
-export const SpacedNum = styled(m.span)`
+export const SpacedNum = styled(m.span)<{ $isDec?: boolean }>`
     font-variant-numeric: tabular-nums;
     display: flex;
     position: relative;
     align-items: flex-end;
     justify-content: center;
-    width: 1ch;
+    width: ${({ $isDec }) => ($isDec ? 'min-content' : '1ch')};
 `;

--- a/src/containers/Dashboard/MiningView/components/BlockHeightAccent.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockHeightAccent.tsx
@@ -9,23 +9,30 @@ import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisuali
 
 export function BlockHeightAccent() {
     const height = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
-    const heightString = height?.toString();
+    const heightString = height?.toLocaleString();
 
-    const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+    const [windowHeight, setWindowHeight] = useState(window.innerHeight - 80);
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
     const [fontSize, setFontSize] = useState(0);
     const heightStringArr = heightString?.split('') || [];
     const deferredHeight = useDeferredValue(windowHeight);
-    const deferredFontSize = useDeferredValue(fontSize || 120);
+    const deferredFontSize = useDeferredValue(fontSize || 110);
 
     useEffect(() => {
-        const height = deferredHeight - 60;
-        const dividend = (height - 100) / (heightStringArr.length >= 4 ? heightStringArr.length : 4);
-        setFontSize(Math.floor(dividend));
-    }, [heightStringArr.length, deferredHeight]);
+        let dividend = (deferredHeight - 70) / (heightStringArr.length >= 4 ? heightStringArr.length : 4);
+
+        // checking discrepancy between height to mitigate overlap a bit
+        if (Math.abs(deferredHeight - windowWidth) < 210 && deferredHeight / windowWidth >= 0.65) {
+            dividend = dividend * 0.6;
+        }
+        const font = Math.floor(dividend);
+        setFontSize(font);
+    }, [heightStringArr.length, deferredHeight, windowWidth]);
 
     useLayoutEffect(() => {
         function handleResize() {
-            setWindowHeight(window.innerHeight);
+            setWindowHeight(window.innerHeight - 80);
+            setWindowWidth(window.innerWidth);
         }
         window.addEventListener('resize', handleResize);
         handleResize();
@@ -35,7 +42,7 @@ export function BlockHeightAccent() {
     }, []);
 
     return (
-        <AccentWrapper layoutId="accent-wrapper" style={{ width: deferredFontSize, top: 0, right: `-20px` }}>
+        <AccentWrapper layoutId="accent-wrapper" style={{ width: deferredFontSize, top: 0, right: `-25px` }}>
             <AnimatePresence>
                 {height && height > 0 ? (
                     <LayoutGroup id="accent-content">
@@ -48,7 +55,7 @@ export function BlockHeightAccent() {
                             }}
                         >
                             {heightStringArr?.map((c, i) => (
-                                <SpacedNum layout key={`spaced-char-${c}-${i}`}>
+                                <SpacedNum layout key={`spaced-char-${c}-${i}`} $isDec={isNaN(Number(c))}>
                                     {c}
                                 </SpacedNum>
                             ))}

--- a/src/containers/Dashboard/MiningView/components/BlockTime.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/BlockTime.styles.ts
@@ -19,7 +19,7 @@ export const TimerWrapper = styled.div`
     box-shadow: 80px -20px 60px 20px rgba(255, 255, 255, 0.6);
 `;
 export const TimerTypography = styled.div`
-    font-family: Druk, sans-serif;
+    font-family: DrukWide, sans-serif;
     font-variant-numeric: tabular-nums;
     font-size: 18px;
     font-weight: 700;

--- a/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/Earnings.styles.ts
@@ -16,7 +16,7 @@ export const EarningsWrapper = styled(m.div)`
     justify-content: center;
     span {
         display: flex;
-        font-family: Druk, sans-serif;
+        font-family: DrukWide, sans-serif;
         font-weight: 700;
         font-size: 14px;
         letter-spacing: -0.1px;

--- a/src/containers/Dashboard/MiningView/components/Ruler.tsx
+++ b/src/containers/Dashboard/MiningView/components/Ruler.tsx
@@ -66,7 +66,7 @@ export function Ruler() {
                                 data-before={height?.toString()}
                                 animate={{
                                     fontSize: '25px',
-                                    fontFamily: 'Druk, sans-serif',
+                                    fontFamily: 'DrukWide, sans-serif',
                                     color: theme.palette.text.primary,
                                 }}
                             />

--- a/src/containers/Dashboard/MiningView/components/Ruler.tsx
+++ b/src/containers/Dashboard/MiningView/components/Ruler.tsx
@@ -1,12 +1,13 @@
 import { Column, MarkGroup, RulerMark, RulerMarkGroup, Wrapper } from './Ruler.styles.ts';
 import { useTheme } from 'styled-components';
-import { useRef } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore.ts';
 
 export function Ruler() {
     const theme = useTheme();
     const height = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     const columnRef = useRef<HTMLDivElement>(null);
 
@@ -54,6 +55,17 @@ export function Ruler() {
         );
     });
 
+    useLayoutEffect(() => {
+        function handleResize() {
+            setWindowWidth(window.innerWidth);
+        }
+        window.addEventListener('resize', handleResize);
+        handleResize();
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, []);
+
     return (
         <Wrapper layout layoutId="ruler-wrapper">
             <AnimatePresence>
@@ -63,9 +75,9 @@ export function Ruler() {
                         <RulerMarkGroup layout>
                             <RulerMark
                                 $opacity={1}
-                                data-before={height?.toString()}
+                                data-before={height?.toLocaleString()}
                                 animate={{
-                                    fontSize: '25px',
+                                    fontSize: windowWidth < 1200 ? '18px' : '25px',
                                     fontFamily: 'DrukWide, sans-serif',
                                     color: theme.palette.text.primary,
                                 }}

--- a/src/containers/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
+++ b/src/containers/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
@@ -20,7 +20,7 @@ export const ExternalDependenciesDialog = () => {
     const setCriticalError = useAppStateStore((s) => s.setCriticalError);
     const [isRestarting, setIsRestarting] = useState(false);
 
-    const [instalationSlot, setInstalationSlot] = useState<number | null>(null);
+    const [installationSlot, setInstallationSlot] = useState<number | null>(null);
 
     const handleRestart = useCallback(async () => {
         try {
@@ -38,7 +38,7 @@ export const ExternalDependenciesDialog = () => {
             setCriticalError(`Failed to setup application: ${e}`);
             setView('mining');
         });
-    }, []);
+    }, [setCriticalError, setShowExternalDependenciesDialog, setView]);
 
     const shouldAllowContinue = Object.values(externalDependencies).every(
         (missingDependency) => missingDependency.status === ExternalDependencyStatus.Installed
@@ -58,10 +58,10 @@ export const ExternalDependenciesDialog = () => {
                             <ExternalDependencyCard
                                 key={missingDependency.display_name}
                                 missingDependency={missingDependency}
-                                freeInstallationSlot={() => setInstalationSlot(null)}
-                                isInInstallationSlot={instalationSlot === index}
-                                isInstallationSlotOccupied={instalationSlot !== null}
-                                occupyInstallationSlot={() => setInstalationSlot(index)}
+                                freeInstallationSlot={() => setInstallationSlot(null)}
+                                isInInstallationSlot={installationSlot === index}
+                                isInstallationSlotOccupied={installationSlot !== null}
+                                occupyInstallationSlot={() => setInstallationSlot(index)}
                             />
                             {index === array.length - 1 ? null : <Divider />}
                         </>

--- a/src/containers/ExternalDependenciesDialog/ExternalDependenciesDialog.utils.ts
+++ b/src/containers/ExternalDependenciesDialog/ExternalDependenciesDialog.utils.ts
@@ -1,7 +1,6 @@
 import { ExternalDependencyStatus } from '@app/types/app-status';
 
 export const mapStatusToText = (status: ExternalDependencyStatus) => {
-    console.log('status', status);
     switch (status) {
         case ExternalDependencyStatus.Installed:
             return 'Installed';

--- a/src/containers/ExternalDependenciesDialog/ExternalDependencyCard.tsx
+++ b/src/containers/ExternalDependenciesDialog/ExternalDependencyCard.tsx
@@ -27,7 +27,7 @@ export const ExternalDependencyCard = ({
     const { t } = useTranslation('external-dependency-dialog', { useSuspense: false });
     const fetchExternalDependencies = useAppStateStore((s) => s.fetchExternalDependencies);
     const setError = useAppStateStore((s) => s.setError);
-    const { display_description, display_name, download_url, manufacturer, status, version } = missingDependency;
+    const { display_description, display_name, manufacturer, status, version } = missingDependency;
 
     const handleDownload = useCallback(async () => {
         try {
@@ -44,7 +44,7 @@ export const ExternalDependencyCard = ({
         }
 
         freeInstallationSlot();
-    }, [download_url]);
+    }, [fetchExternalDependencies, freeInstallationSlot, missingDependency, occupyInstallationSlot, setError]);
 
     return (
         <Stack direction="row" alignItems="flex-start" gap={16} style={{ width: '100%' }}>

--- a/src/containers/SideBar/Miner/components/ModeSelect.tsx
+++ b/src/containers/SideBar/Miner/components/ModeSelect.tsx
@@ -26,7 +26,7 @@ function ModeSelect() {
 
     const handleChange = useCallback(
         async (mode: string) => {
-            changeMiningMode(mode as modeType);
+            await changeMiningMode(mode as modeType);
         },
         [changeMiningMode]
     );

--- a/src/containers/SideBar/Miner/styles.ts
+++ b/src/containers/SideBar/Miner/styles.ts
@@ -24,6 +24,7 @@ export const TileItem = styled(m.div)`
     justify-content: space-between;
 
     color: ${({ theme }) => theme.palette.text.secondary};
+    font-family: Poppins, sans-serif;
     font-size: 12px;
     font-weight: 500;
     position: relative;

--- a/src/containers/SideBar/components/Heading.tsx
+++ b/src/containers/SideBar/components/Heading.tsx
@@ -11,7 +11,7 @@ function Heading() {
     const { t } = useTranslation('common', { useSuspense: false });
     return (
         <Stack direction="row" justifyContent="space-between">
-            <Stack direction="row" alignItems="center" gap={10}>
+            <Stack direction="row" alignItems="center" gap={6}>
                 <Typography variant="h3">{t('tari-universe')}</Typography>
                 <VersionChip version={versionString} />
             </Stack>

--- a/src/containers/SideBar/components/VersionChip/styles.ts
+++ b/src/containers/SideBar/components/VersionChip/styles.ts
@@ -4,10 +4,10 @@ export const Wrapper = styled('div')`
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 5px;
+    gap: 4px;
 
     height: 21px;
-    padding: 0px 10px 0 8px;
+    padding: 0 10px 0 8px;
 
     border-radius: 20px;
     background: #000;

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -35,7 +35,7 @@ export function useSetUp() {
         return () => {
             unlistenPromise.then((unlisten) => unlisten());
         };
-    }, [loadExternalDependencies]);
+    }, [loadExternalDependencies, setShowExternalDependenciesDialog]);
 
     useEffect(() => {
         async function initialize() {

--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -61,7 +61,7 @@ export const GlobalStyle = createGlobalStyle`
 
         -ms-overflow-style: none; /* IE and Edge */
         scrollbar-width: none; /* Firefox */
-        line-height: 1.1;
+        letter-spacing: -0.02px;
         font-weight: 400;
 
         * {
@@ -79,6 +79,7 @@ export const GlobalStyle = createGlobalStyle`
     #canvas {
         z-index: 0;
         pointer-events: auto;
+        width: 100vw;
     }
 
     #root {

--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -45,7 +45,7 @@ export const GlobalStyle = createGlobalStyle`
     #root {
         margin: 0;
         padding: 0;
-        font-family: "PoppinsMedium", sans-serif;
+        font-family: Poppins, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         height: 100%;

--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -61,7 +61,7 @@ export const GlobalStyle = createGlobalStyle`
 
         -ms-overflow-style: none; /* IE and Edge */
         scrollbar-width: none; /* Firefox */
-        letter-spacing: -0.02px;
+        line-height: 1.1;
         font-weight: 400;
 
         * {

--- a/src/theme/fonts/druk.ts
+++ b/src/theme/fonts/druk.ts
@@ -1,7 +1,19 @@
 export const druk_fonts = `
     @font-face {
       font-family: "Druk";
-      src: url("/assets/fonts/Druk/DrukWideLCG-Bold.ttf") format("truetype");
+      src:
+        url("/assets/fonts/Druk/DrukLCG-Medium.ttf"),
+        url("/assets/fonts/Druk/DrukLCG-MediumItalic.ttf") format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: fallback;
+    }
+    
+    @font-face {
+      font-family: "Druk";
+      src:
+        url("/assets/fonts/Druk/DrukLCG-Bold.ttf"),
+        url("/assets/fonts/Druk/DrukLCG-BoldItalic.ttf") format("truetype");
       font-weight: 700;
       font-style: normal;
       font-display: fallback;
@@ -9,10 +21,41 @@ export const druk_fonts = `
     
     @font-face {
       font-family: "Druk";
-      src: url("/assets/fonts/Druk/DrukWideLCG-Heavy.ttf") format("truetype");
+      src:
+        url("/assets/fonts/Druk/DrukLCG-Heavy.ttf"),
+        url("/assets/fonts/Druk/DrukLCG-HeavyItalic.ttf") format("truetype");
       font-weight: 900;
       font-style: normal;
       font-display: fallback;
     }
-
+    
+    @font-face {
+      font-family: "DrukWide";
+      src:
+        url("/assets/fonts/Druk/DrukWideLCG-Medium.ttf"),
+        url("/assets/fonts/Druk/DrukWideLCG-MediumItalic.ttf") format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: fallback;
+    }
+    
+    @font-face {
+      font-family: "DrukWide";
+      src:
+        url("/assets/fonts/Druk/DrukWideLCG-Bold.ttf"),
+        url("/assets/fonts/Druk/DrukWideLCG-BoldItalic.ttf") format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: fallback;
+    }
+    
+    @font-face {
+      font-family: "DrukWide";
+      src:
+        url("/assets/fonts/Druk/DrukWideLCG-Heavy.ttf"),
+        url("/assets/fonts/Druk/DrukWideLCG-HeavyItalic.ttf") format("truetype");
+      font-weight: 900;
+      font-style: normal;
+      font-display: fallback;
+    }
 `;

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -200,9 +200,9 @@ export const componentSettings = {
         },
         h3: {
             fontSize: '24px',
-            lineHeight: '32px',
+            lineHeight: '28px',
             fontFamily: '"Poppins", sans-serif',
-            letterSpacing: '-0.4px',
+            letterSpacing: '-0.5px',
             fontWeight: 600,
         },
         h4: {


### PR DESCRIPTION
Description
---

- update Tower Animation canvas background gradient colours
- fix global fonts:
  - specify Druk _Wide_ and use narrow Druk for the gem earnings animation
  - use correct font family name set in font-fae for `Poppins` in the GlobalStyles
- adjust `BlockHeightAccent`  `Ruler` styling to suit comments from the UI QA runthrough:
  - adjusted sizing to it's not spread out as far to the top and bottom of the screen
  - tried to mitigate the overlap on narrower screen sizes by lowering the size if the window height is high, but width lower (though this is more an issue of the tower not scaling down more in these cases, which needs to be fixed/adjusted in the webgl)
  - bring down the font-size for the main ruler mark number on lower resolutions 
  - format numbers
- fixed some typos and lints 


Motivation and Context
---
- resolves some issues from the [UI QA runthrough](https://www.loom.com/share/21de95c230fc4951b349c387f09a6882?sid=6faf86d6-c57c-456b-a197-f4543feec757)
- resolves #772 

How Has This Been Tested?
---
- locally:


<img width="538" alt="image" src="https://github.com/user-attachments/assets/e84d8920-b90e-4533-80d9-827c97e7fee6">

<img width="443" alt="image" src="https://github.com/user-attachments/assets/2c72df3c-5424-44fe-94fc-f3cb1198b9b1">

<img width="311" alt="image" src="https://github.com/user-attachments/assets/5d0c8720-239f-4b80-a133-9d8320f2728a">

