### PR TITLE
fix(ui): simplified sidebar wallet show/hide history animation

### DIFF
--- a/src/components/CharSpinner/CharSpinner.tsx
+++ b/src/components/CharSpinner/CharSpinner.tsx
@@ -38,7 +38,6 @@ export default function CharSpinner({ value, variant = 'large', fontSize }: Char
         if (!isNum) {
             return (
                 <Characters
-                    layout
                     $decimal={isDec}
                     key={`dec-${i}`}
                     layout-id={`dec-${i}`}
@@ -94,8 +93,8 @@ export default function CharSpinner({ value, variant = 'large', fontSize }: Char
     return (
         <Wrapper>
             <LayoutGroup id="char-spinner">
-                <SpinnerWrapper style={{ height: letterHeight }} $variant={variant} layout>
-                    <CharacterWrapper style={{ height: letterHeight * 10 }} layout>
+                <SpinnerWrapper style={{ height: letterHeight }} $variant={variant}>
+                    <CharacterWrapper style={{ height: letterHeight * 10 }}>
                         <LayoutGroup id="characters">{charMarkup}</LayoutGroup>
                     </CharacterWrapper>
                 </SpinnerWrapper>

--- a/src/containers/SideBar/components/Wallet/History.tsx
+++ b/src/containers/SideBar/components/Wallet/History.tsx
@@ -7,16 +7,10 @@ import { CircularProgress } from '@app/components/elements/CircularProgress';
 import { useTranslation } from 'react-i18next';
 
 const container = {
-    hidden: { opacity: 1 },
+    hidden: { opacity: 1, height: 0 },
     visible: {
         opacity: 1,
-        transition: {
-            delay: 0.2,
-            delayChildren: 0.1,
-            staggerChildren: 0.05,
-            ease: 'linear',
-            duration: 0.4,
-        },
+        height: 326,
     },
 };
 

--- a/src/containers/SideBar/components/Wallet/History.tsx
+++ b/src/containers/SideBar/components/Wallet/History.tsx
@@ -7,7 +7,7 @@ import { CircularProgress } from '@app/components/elements/CircularProgress';
 import { useTranslation } from 'react-i18next';
 
 const container = {
-    hidden: { opacity: 1, height: 0 },
+    hidden: { opacity: 0, height: 0 },
     visible: {
         opacity: 1,
         height: 326,

--- a/src/containers/SideBar/components/Wallet/Wallet.styles.ts
+++ b/src/containers/SideBar/components/Wallet/Wallet.styles.ts
@@ -61,6 +61,10 @@ export const ShowHistoryButton = styled(ButtonBase).attrs({
 })`
     display: flex;
     align-self: flex-end;
+
+    &:hover {
+        border-color: rgba(255, 255, 255, 0.4);
+    }
 `;
 
 export const ScrollMask = styled.div`

--- a/src/containers/SideBar/components/Wallet/Wallet.tsx
+++ b/src/containers/SideBar/components/Wallet/Wallet.tsx
@@ -29,7 +29,7 @@ export default function Wallet() {
     const displayValue = balance === null ? '-' : showBalance ? formatted : '*****';
 
     const balanceMarkup = (
-        <WalletBalanceContainer layout>
+        <WalletBalanceContainer>
             <Stack direction="row" alignItems="center">
                 <Typography variant="span" style={{ fontSize: '15px' }}>
                     {t('wallet-balance')}
@@ -49,11 +49,7 @@ export default function Wallet() {
     );
 
     return (
-        <WalletContainer
-            layout
-            style={{ height: showHistory ? 'auto' : 178 }}
-            transition={{ duration: 0.1, ease: 'linear' }}
-        >
+        <WalletContainer>
             {balance ? (
                 <ShowHistoryButton onClick={() => setShowHistory((c) => !c)} style={{ minWidth: 80 }}>
                     {!showHistory ? 'Show' : 'Hide'} history


### PR DESCRIPTION
This PR simplifies the wallet show/hide history animation. I basically removed most of the `layout` props so we have more control over the animation and there's less weirdness.

I changed it so the height of the history container is animated instead of the parent container of the wallet. The parent just adjusts to the new height of the animation automatically as it grows in height. 

I also removed some of the layout animations from the big number, just keeping it on the "tXLM" text.  Less stretching this way, and the show/hide number still looks good

https://www.loom.com/share/a9ee052711f34e429e106394cdc69f2d?sid=2c496820-66b9-4dd1-a726-3739db9d3498