### PR TITLE
fix: bring back 2022 vc version requirement

### DIFF
--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -75,13 +75,14 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
+                        "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
                         "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -92,12 +93,13 @@ impl ExternalDependencies {
                 },
                 minimum_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string()
+                        "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -111,13 +113,14 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
+                        "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
                         "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -128,12 +131,13 @@ impl ExternalDependencies {
                 },
                 minimum_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string()
+                        "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),

--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -75,14 +75,13 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
-                        "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string()
                     ],
                     display_name: "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -93,13 +92,12 @@ impl ExternalDependencies {
                 },
                 minimum_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string(),
-                        "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string()
                     ],
                     display_name: "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -113,14 +111,13 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
-                        "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string()
                     ],
                     display_name: "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -131,13 +128,12 @@ impl ExternalDependencies {
                 },
                 minimum_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string(),
-                        "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
+                        "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string()
                     ],
                     display_name: "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),

--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -77,7 +77,7 @@ impl ExternalDependencies {
                     required_version_names: vec![
                         "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
@@ -94,7 +94,7 @@ impl ExternalDependencies {
                     required_version_names: vec![
                         "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string()
                     ],
-                    display_name: "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2019 x86 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
                     download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
@@ -113,7 +113,7 @@ impl ExternalDependencies {
                     required_version_names: vec![
                         "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
                     ],
-                    display_name: "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
@@ -130,7 +130,7 @@ impl ExternalDependencies {
                     required_version_names: vec![
                         "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string()
                     ],
-                    display_name: "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
+                    display_name: "Microsoft Visual C++ 2019 x64 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
                     download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),

--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -120,7 +120,7 @@ impl ExternalDependencies {
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -137,7 +137,7 @@ impl ExternalDependencies {
                     display_name: "Microsoft Visual C++ 2022 x64 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x64.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x64.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),

--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -82,7 +82,7 @@ impl ExternalDependencies {
                     display_description:
                         "This is the additional runtime required to run Tari applications."
                             .to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),
@@ -99,7 +99,7 @@ impl ExternalDependencies {
                     display_name: "Microsoft Visual C++ 2022 x86 Minimum Runtime".to_string(),
                     display_description:
                         "This is the minimum runtime required to run Tari applications.".to_string(),
-                    download_url: "https://aka.ms/vs/16/release/vc_redist.x86.exe".to_string(),
+                    download_url: "https://aka.ms/vs/17/release/vc_redist.x86.exe".to_string(),
                     manufacturer: Manufacturer::new(
                         "Microsoft".to_string(),
                         "https://www.microsoft.com".to_string(),

--- a/src-tauri/src/external_dependencies.rs
+++ b/src-tauri/src/external_dependencies.rs
@@ -75,7 +75,7 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string()
+                        "Microsoft Visual C++ 2019 x86 Additional Runtime".to_string(),
                     ],
                     display_name: "Microsoft Visual C++ 2022 x86 Additional Runtime".to_string(),
                     display_description:
@@ -111,7 +111,7 @@ impl ExternalDependencies {
             RequiredExternalDependency {
                 additional_runtime: ExternalDependency {
                     required_version_names: vec![
-                        "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string()
+                        "Microsoft Visual C++ 2019 x64 Additional Runtime".to_string(),
                     ],
                     display_name: "Microsoft Visual C++ 2022 x64 Additional Runtime".to_string(),
                     display_description:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -458,7 +458,7 @@ async fn setup_inner(
         .expect("Could not get log dir");
 
     #[cfg(target_os = "windows")]
-    if cfg!(target_os = "windows") && !cfg!("dev") {
+    if cfg!(target_os = "windows") && !cfg!(dev) {
         ExternalDependencies::current()
             .read_registry_installed_applications()
             .await?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -458,7 +458,7 @@ async fn setup_inner(
         .expect("Could not get log dir");
 
     #[cfg(target_os = "windows")]
-    if cfg!(target_os = "windows") {
+    if cfg!(target_os = "windows") && !cfg!("dev") {
         ExternalDependencies::current()
             .read_registry_installed_applications()
             .await?;


### PR DESCRIPTION
### [ Features ]
- Bring back version 2022 to allowed list
- Make adjustment do `display_name` and `download_url`
- Remove this check for vc version in `dev mode`