### PR TITLE
fix(gpu): clean up gpu status minitor after stopping gpu mining

### DIFF
--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -63,6 +63,7 @@ impl GpuMiner {
     pub async fn stop(&self) -> Result<(), anyhow::Error> {
         info!(target: LOG_TARGET, "Stopping xtrgpuminer");
         let mut process_watcher = self.watcher.write().await;
+        process_watcher.status_monitor = None;
         process_watcher.stop().await?;
         info!(target: LOG_TARGET, "xtrgpuminer stopped");
         Ok(())


### PR DESCRIPTION
Description
---
fixes: #740 
Remove status monitor after stopping gpu mining.

Motivation and Context
---
Stop spamming error in console `Error in getting response from XtrGpuMiner status ...`

How Has This Been Tested?
---
Disabled gpu mining in mining settings and checked if there are still warnings in console.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
