### PR TITLE
feat(binaries): prioritize github releases over mirror cdn

### DIFF
--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -22,7 +22,10 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
         let mut dist_responded = false;
 
         for _ in 0..3 {
-            let response = reqwest::get(dist_tor_bundle_url).await;
+            let response = reqwest::Client::new()
+                .head(dist_tor_bundle_url)
+                .send()
+                .await;
             if let Ok(resp) = response {
                 if resp.status().is_success() {
                     dist_responded = true;

--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -17,37 +17,37 @@ pub(crate) struct TorReleaseAdapter {}
 #[async_trait]
 impl LatestVersionApiAdapter for TorReleaseAdapter {
     async fn fetch_releases_list(&self) -> Result<Vec<VersionDownloadInfo>, Error> {
+        let dist_tor_bundle_url = "https://dist.torproject.org/torbrowser/13.5.6/tor-expert-bundle-windows-x86_64-13.5.6.tar.gz";
         let cdn_tor_bundle_url = "https://cdn-universe.tari.com/torbrowser/13.5.6/tor-expert-bundle-windows-x86_64-13.5.6.tar.gz";
-        let mut cdn_responded = false;
+        let mut dist_responded = false;
 
         for _ in 0..3 {
-            let response = reqwest::get(cdn_tor_bundle_url).await;
+            let response = reqwest::get(dist_tor_bundle_url).await;
             if let Ok(resp) = response {
                 if resp.status().is_success() {
-                    cdn_responded = true;
+                    dist_responded = true;
                     break;
                 }
             }
         }
 
-        if cdn_responded {
+        if dist_responded {
             let version = VersionDownloadInfo {
                 version: "13.5.6".parse().expect("Bad tor version"),
                 assets: vec![VersionAsset {
-                    url: cdn_tor_bundle_url.to_string(),
+                    url: dist_tor_bundle_url.to_string(),
                     name: "tor-expert-bundle-windows-x86_64-13.5.6.tar.gz".to_string(),
                 }],
             };
             return Ok(vec![version]);
         }
 
-        // Tor doesn't have a nice API for this so just return specific ones
         let version = VersionDownloadInfo {
             version: "13.5.6".parse().expect("Bad tor version"),
             assets: vec![VersionAsset {
-                url: "https://dist.torproject.org/torbrowser/13.5.6/tor-expert-bundle-windows-x86_64-13.5.6.tar.gz".to_string(),
+                url: cdn_tor_bundle_url.to_string(),
                 name: "tor-expert-bundle-windows-x86_64-13.5.6.tar.gz".to_string(),
-            }]
+            }],
         };
         Ok(vec![version])
     }

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -61,14 +61,14 @@ pub async fn list_releases(
 ) -> Result<Vec<VersionDownloadInfo>, anyhow::Error> {
     let mut attempts = 0;
     let releases = loop {
-        let result = list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await;
+        let result = list_releases_from(ReleaseSource::Github, repo_owner, repo_name).await;
         if result.as_ref().map_or(false, |r| !r.is_empty()) || attempts >= 3 {
             break result;
         }
         attempts += 1;
         warn!(
             target: LOG_TARGET,
-            "Failed to fetch releases from mirror, attempt {}",
+            "Failed to fetch releases from github, attempt {}",
             attempts
         );
     };
@@ -76,7 +76,7 @@ pub async fn list_releases(
     if releases.as_ref().map_or(false, |r| !r.is_empty()) {
         releases
     } else {
-        list_releases_from(ReleaseSource::Github, repo_owner, repo_name).await
+        list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await
     }
 }
 


### PR DESCRIPTION
Description
---
Reverse the order of choosing releases source of binaries.

Motivation and Context
---
CDN is being overwhelmed with downloads requests so we can just first try github releases to minimize traffic on CDN.

How Has This Been Tested?
---
Deleted all binaries and checked from which source we are downloading binaries.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

