### PR TITLE
feat(ui): added loading state to mining button + minor ui polish

### DIFF
--- a/src/components/svgs/LoadingSvg.tsx
+++ b/src/components/svgs/LoadingSvg.tsx
@@ -1,0 +1,72 @@
+const LoadingSvg = () => (
+    <svg width="120" height="30" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+        <circle cx="15" cy="15" r="15">
+            <animate
+                attributeName="r"
+                from="15"
+                to="15"
+                begin="0s"
+                dur="0.8s"
+                values="15;9;15"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+            <animate
+                attributeName="fill-opacity"
+                from="1"
+                to="1"
+                begin="0s"
+                dur="0.8s"
+                values="1;.5;1"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+        </circle>
+        <circle cx="60" cy="15" r="9" fillOpacity="0.3">
+            <animate
+                attributeName="r"
+                from="9"
+                to="9"
+                begin="0s"
+                dur="0.8s"
+                values="9;15;9"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+            <animate
+                attributeName="fill-opacity"
+                from="0.5"
+                to="0.5"
+                begin="0s"
+                dur="0.8s"
+                values=".5;1;.5"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+        </circle>
+        <circle cx="105" cy="15" r="15">
+            <animate
+                attributeName="r"
+                from="15"
+                to="15"
+                begin="0s"
+                dur="0.8s"
+                values="15;9;15"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+            <animate
+                attributeName="fill-opacity"
+                from="1"
+                to="1"
+                begin="0s"
+                dur="0.8s"
+                values="1;.5;1"
+                calcMode="linear"
+                repeatCount="indefinite"
+            />
+        </circle>
+    </svg>
+);
+
+export default LoadingSvg;

--- a/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
@@ -1,5 +1,5 @@
 import { ImSpinner3 } from 'react-icons/im';
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { Button } from '@app/components/elements/Button.tsx';
 import { m } from 'framer-motion';
 export const spin = keyframes`
@@ -39,18 +39,21 @@ export const ButtonWrapper = styled(m.div)`
     width: 100%;
 `;
 
-export const StyledButton = styled(Button)<{ $hasStarted: boolean }>`
+export const StyledButton = styled(Button)<{ $hasStarted: boolean; $isLoading?: boolean }>`
     width: 100%;
     position: relative;
     cursor: pointer;
     overflow: hidden;
+
     background: ${({ $hasStarted }) =>
         $hasStarted
             ? 'linear-gradient(90deg, #929292 0%, rgba(0,0,0,0.7) 99.49%)'
             : 'linear-gradient(90deg, #046937 0%, #188750 92.49%)'};
+
     color: ${({ theme }) => theme.palette.base};
     box-shadow: 0 0 3px 0 rgba(255, 255, 255, 0.58) inset;
     transition: opacity 0.4s ease-in-out background 0.4s ease-in-out;
+
     &:hover {
         background: ${({ $hasStarted }) =>
             $hasStarted
@@ -68,4 +71,24 @@ export const StyledButton = styled(Button)<{ $hasStarted: boolean }>`
                     : 'linear-gradient(90deg, #046937 0%, #188750 92.49%)'};
         }
     }
+
+    ${({ $isLoading }) =>
+        $isLoading &&
+        css`
+            background: linear-gradient(90deg, #929292 0%, rgba(0, 0, 0, 0.7) 99.49%);
+            color: transparent;
+            box-shadow: none;
+            pointer-events: none;
+            opacity: 1;
+            cursor: wait;
+
+            svg {
+                color: #fff;
+                width: 36px;
+            }
+
+            &:disabled {
+                opacity: 0.6;
+            }
+        `}
 `;

--- a/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.styles.ts
@@ -13,6 +13,7 @@ export const spin = keyframes`
 export const StyledIcon = styled(ImSpinner3)`
     animation: ${spin} 2s infinite;
     animation-timing-function: cubic-bezier(0.76, 0.89, 0.95, 0.85);
+    height: 16px;
 `;
 
 export const IconWrapper = styled.div`

--- a/src/containers/Dashboard/MiningView/components/MiningButton.tsx
+++ b/src/containers/Dashboard/MiningView/components/MiningButton.tsx
@@ -11,6 +11,7 @@ import ButtonOrbitAnimation from '@app/containers/SideBar/Miner/components/Butto
 import { AnimatePresence } from 'framer-motion';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
 import { useAppConfigStore } from '@app/store/useAppConfigStore.ts';
+import LoadingSvg from '@app/components/svgs/LoadingSvg.tsx';
 
 enum MiningButtonStateText {
     STARTED = 'stop-mining',
@@ -33,6 +34,7 @@ export default function MiningButton() {
     const isMiningLoading = (isMining && !isMiningInitiated) || (isMiningInitiated && !isMining);
     const anyMiningEnabled = isCpuMiningEnabled || isGPUMiningEnabled;
     const isMiningButtonDisabled = isAppSettingUp || isMiningLoading || !isMiningControlsEnabled || !anyMiningEnabled;
+    const isAppLoading = isAppSettingUp || isMiningLoading;
 
     const miningButtonStateText = useMemo(() => {
         return isMining && isMiningInitiated ? MiningButtonStateText.STARTED : MiningButtonStateText.START;
@@ -47,16 +49,19 @@ export default function MiningButton() {
     }, [isMining, startMining, stopMining]);
 
     const icon = isMining ? <GiPauseButton /> : <IoChevronForwardOutline />;
+    const iconFinal = <IconWrapper>{isMiningLoading ? <StyledIcon /> : icon}</IconWrapper>;
+
     return (
         <ButtonWrapper>
             <StyledButton
                 variant="rounded"
                 $hasStarted={isMining}
                 onClick={handleClick}
-                icon={<IconWrapper>{isMiningLoading ? <StyledIcon /> : icon}</IconWrapper>}
+                icon={!isAppLoading ? iconFinal : null}
                 disabled={isMiningButtonDisabled}
+                $isLoading={isAppLoading}
             >
-                <span>{t(`mining-button-text.${miningButtonStateText}`)}</span>
+                {!isAppLoading ? <span>{t(`mining-button-text.${miningButtonStateText}`)}</span> : <LoadingSvg />}
             </StyledButton>
             <AnimatePresence>{isMining ? <ButtonOrbitAnimation /> : null}</AnimatePresence>
         </ButtonWrapper>

--- a/src/containers/SideBar/Miner/styles.ts
+++ b/src/containers/SideBar/Miner/styles.ts
@@ -39,6 +39,7 @@ export const StatWrapper = styled(m.div)<{ $useLowerCase?: boolean }>`
     justify-content: space-between;
     align-items: baseline;
     color: ${({ theme }) => theme.palette.text.primary};
+    min-height: 16px;
 `;
 export const Unit = styled(m.div)`
     line-height: 1;

--- a/src/containers/SideBar/components/Wallet/History.tsx
+++ b/src/containers/SideBar/components/Wallet/History.tsx
@@ -1,4 +1,4 @@
-import { HistoryContainer } from '@app/containers/SideBar/components/Wallet/Wallet.styles.ts';
+import { HistoryContainer, HistoryPadding } from '@app/containers/SideBar/components/Wallet/Wallet.styles.ts';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import HistoryItem from '@app/containers/SideBar/components/Wallet/HistoryItem.tsx';
 import { useWalletStore } from '@app/store/useWalletStore';
@@ -26,12 +26,14 @@ export default function History() {
 
     return (
         <HistoryContainer initial="hidden" animate="visible" exit="hidden" variants={container}>
-            <Typography variant="h6">{t('recent-wins')}</Typography>
-            {isTransactionLoading ? (
-                <CircularProgress />
-            ) : (
-                transactions.map((tx) => <HistoryItem key={tx.tx_id} item={tx} />)
-            )}
+            <HistoryPadding>
+                <Typography variant="h6">{t('recent-wins')}</Typography>
+                {isTransactionLoading ? (
+                    <CircularProgress />
+                ) : (
+                    transactions.map((tx) => <HistoryItem key={tx.tx_id} item={tx} />)
+                )}
+            </HistoryPadding>
         </HistoryContainer>
     );
 }

--- a/src/containers/SideBar/components/Wallet/Wallet.styles.ts
+++ b/src/containers/SideBar/components/Wallet/Wallet.styles.ts
@@ -83,7 +83,14 @@ export const HistoryContainer = styled(m.div)`
     overflow-y: auto;
     width: 100%;
     position: relative;
-    gap: 6px;
-    padding-bottom: 10px;
+
     color: ${({ theme }) => theme.palette.base};
+`;
+
+export const HistoryPadding = styled('div')`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+    padding: 0 5px 60px 5px;
 `;


### PR DESCRIPTION
1. Added a loading state to the Mining Button. 

![CleanShot 2024-10-10 at 17 58 46](https://github.com/user-attachments/assets/e4b533b7-7567-44e7-be81-a3117f635af2)

2. Fixed 1px layout shift when Mining Tiles switched between loading state and showing a number

![CleanShot 2024-10-10 at 18 00 12](https://github.com/user-attachments/assets/22360863-3bce-4d1e-b607-e2d4f41c3ae6)

3. Fixed padding alignment on the wallet history scroll area

![CleanShot 2024-10-10 at 18 01 01](https://github.com/user-attachments/assets/ef028dd2-9095-46e1-901b-3d10bdae91b6)
