### PR TITLE
fix: prevent local dev clutter on sentry

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.16"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"]}
+tauri-build = {version = "1.5.5", features = ["isolation"] }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"]}
+async_zip = {version = "0.0.17", features = ["full"] }
 blake2 = "0.10"
 chrono = "0.4.38"
 device_query = "2.1.0"
@@ -27,23 +27,23 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-]}
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}# Required for tari_wallet
+] }
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"]}
+nix = {version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
 sentry-anyhow = {version = "0.34.0"}
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"]}
+serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -53,7 +53,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-]}
+] }
 tari_crypto = "0.20.3"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -73,12 +73,12 @@ tauri = {version = "1.8.0", features = [
   "isolation",
   "shell-open",
   "process-command-api",
-]}
+] }
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"]}
-tokio-util = {version = "0.7.11", features = ["compat"]}
-xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
+tokio = {version = "1", features = ["full"] }
+tokio-util = {version = "0.7.11", features = ["compat"] }
+xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.16"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"] }
+tauri-build = {version = "1.5.5", features = ["isolation"]}
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"] }
+async_zip = {version = "0.0.17", features = ["full"]}
 blake2 = "0.10"
 chrono = "0.4.38"
 device_query = "2.1.0"
@@ -27,23 +27,23 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-] }
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }# Required for tari_wallet
+]}
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"] }
+nix = {version = "0.29.0", features = ["signal"]}
 nvml-wrapper = "0.10.0"
 open = "5"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
 sanitize-filename = "0.5"
 semver = "1.0.23"
 sentry-anyhow = {version = "0.34.0"}
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -53,7 +53,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-] }
+]}
 tari_crypto = "0.20.3"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -73,12 +73,12 @@ tauri = {version = "1.8.0", features = [
   "isolation",
   "shell-open",
   "process-command-api",
-] }
+]}
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"] }
-tokio-util = {version = "0.7.11", features = ["compat"] }
-xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
+tokio = {version = "1", features = ["full"]}
+tokio-util = {version = "0.7.11", features = ["compat"]}
+xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/utils/shared-logger.ts
+++ b/src/utils/shared-logger.ts
@@ -35,19 +35,16 @@ const getStackTrace = function () {
 };
 
 const isDevelopment = import.meta.env.DEV || import.meta.env.MODE == 'development';
+
 const getOptions = (args, level) => {
-    if (isDevelopment) {
-        return originalConsole[level](...args);
-    } else {
-        const trace = getStackTrace();
-        const firstStackItem = trace.slice(0, 1);
-        void invoke('log_web_message', {
-            level,
-            message: [...args.map(parseArgument), firstStackItem], // in case no breadcrumbs are added
-            trace: level === 'error' ? trace : firstStackItem, // so it doesn't get too noisy
-        });
-        return originalConsole[level](...args);
-    }
+    const trace = getStackTrace();
+    const firstStackItem = trace.slice(0, 1);
+    void invoke('log_web_message', {
+        level: isDevelopment ? `info` : level, // so it isn't logged to sentry if error
+        message: args.map(parseArgument),
+        trace: level === 'error' ? trace : firstStackItem, // so it doesn't get too noisy
+    });
+    return originalConsole[level](...args);
 };
 
 export const setupLogger = () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,35 +1,42 @@
-import { defineConfig } from 'vite';
+import { defineConfig, UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import eslintPlugin from '@nabla/vite-plugin-eslint';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import * as path from 'node:path';
 
-// https://vitejs.dev/config/
+const baseConfig: UserConfig = {
+    plugins: [
+        react({
+            babel: { plugins: ['styled-components'] },
+        }),
+        tsconfigPaths(),
+        eslintPlugin({ eslintOptions: { cache: false } }),
+    ],
+    resolve: {
+        alias: {
+            '@app': path.resolve(__dirname, './src'),
+        },
+    },
+    logLevel: 'error',
+};
 
-export default defineConfig(() => {
-    return {
-        // prevent vite from obscuring rust errors
-        clearScreen: false,
-        // Tauri expects a fixed port, fail if that port is not available
-        server: {
-            port: 1420,
-            strictPort: true,
-            watch: {
-                // 3. tell vite to ignore watching `src-tauri`
-                ignored: ['**/src-tauri/**'],
+export default defineConfig(({ command }) => {
+    if (command === 'serve') {
+        return {
+            ...baseConfig,
+            // prevent vite from obscuring rust errors
+            clearScreen: false,
+            // Tauri expects a fixed port, fail if that port is not available
+            server: {
+                port: 1420,
+                strictPort: true,
+                watch: {
+                    // 3. tell vite to ignore watching `src-tauri`
+                    ignored: ['**/src-tauri/**'],
+                },
             },
-        },
-        plugins: [
-            react({
-                babel: { plugins: ['styled-components'] },
-            }),
-            tsconfigPaths(),
-            eslintPlugin({ eslintOptions: { cache: false } }),
-        ],
-        resolve: {
-            alias: {
-                '@app': path.resolve(__dirname, './src'),
-            },
-        },
-    };
+        };
+    } else {
+        return baseConfig;
+    }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,42 +1,34 @@
-import { defineConfig, UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import eslintPlugin from '@nabla/vite-plugin-eslint';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import * as path from 'node:path';
 
-const baseConfig: UserConfig = {
-    plugins: [
-        react({
-            babel: { plugins: ['styled-components'] },
-        }),
-        tsconfigPaths(),
-        eslintPlugin({ eslintOptions: { cache: false } }),
-    ],
-    resolve: {
-        alias: {
-            '@app': path.resolve(__dirname, './src'),
-        },
-    },
-    logLevel: 'error',
-};
-
-export default defineConfig(({ command }) => {
-    if (command === 'serve') {
-        return {
-            ...baseConfig,
-            // prevent vite from obscuring rust errors
-            clearScreen: false,
-            // Tauri expects a fixed port, fail if that port is not available
-            server: {
-                port: 1420,
-                strictPort: true,
-                watch: {
-                    // 3. tell vite to ignore watching `src-tauri`
-                    ignored: ['**/src-tauri/**'],
-                },
+export default defineConfig(() => {
+    return {
+        // prevent vite from obscuring rust errors
+        clearScreen: false,
+        // Tauri expects a fixed port, fail if that port is not available
+        server: {
+            port: 1420,
+            strictPort: true,
+            watch: {
+                // 3. tell vite to ignore watching `src-tauri`
+                ignored: ['**/src-tauri/**'],
             },
-        };
-    } else {
-        return baseConfig;
-    }
+        },
+        plugins: [
+            react({
+                babel: { plugins: ['styled-components'] },
+            }),
+            tsconfigPaths(),
+            eslintPlugin({ eslintOptions: { cache: false } }),
+        ],
+        resolve: {
+            alias: {
+                '@app': path.resolve(__dirname, './src'),
+            },
+        },
+        logLevel: 'error',
+    };
 });


### PR DESCRIPTION
Description
---

- update `shared-logger.ts` to pass the log level as `info` when invoking `log_web_message` in local/development because errors are logged to sentry (so this prevents that, but still writes to log files)
- only log vite errors in console

Motivation and Context
---

- sentry is getting clogged up with local development errors 😬 
