### PR TITLE
feat: add low hash rate warning

### DIFF
--- a/public/locales/af/settings.json
+++ b/public/locales/af/settings.json
@@ -59,5 +59,6 @@
   "use-tor": "Gebruik Tor",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/cn/settings.json
+++ b/public/locales/cn/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "使用Tor",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/de/Einstellungen.json
+++ b/public/locales/de/Einstellungen.json
@@ -59,5 +59,6 @@
     "connected-peers": "Verbundenen Peers",
     "should-use-system-language": "Systemsprache verwenden",
     "use-tor": "Tor verwenden",
+    "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
     "report-issue": "Ein Problem melden"
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -62,5 +62,6 @@
     "report-issue": "Report an issue",
     "importing-wallet": "Importing wallet",
     "action-requires-restart": "This action requires restart to apply changes",
+    "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
     "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/fr/settings.json
+++ b/public/locales/fr/settings.json
@@ -56,5 +56,6 @@
   "pool-mining-description": "Lorsqu\"il est activé, vous minerez dans un pool et rejoindrez un groupe de mineurs.",
   "seed-words": "Mots de récupération",
   "feedback-required": "Les commentaires sont requis",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "reset-permanently": "Êtes-vous sûr de vouloir réinitialiser tous les paramètres de manière permanente ?"
 }

--- a/public/locales/hi/settings.json
+++ b/public/locales/hi/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "टोर का उपयोग करें",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/id/settings.json
+++ b/public/locales/id/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "Gunakan Tor",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/ja/settings.json
+++ b/public/locales/ja/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "Torを使用する",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/ko/settings.json
+++ b/public/locales/ko/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "Tor 사용하기",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/pl/settings.json
+++ b/public/locales/pl/settings.json
@@ -63,5 +63,6 @@
   "use-tor": "Używaj Tor",
   "importing-wallet": "Importowanie portfela",
   "action-requires-restart": "Ta akcja wymaga ponownego uruchomienia, aby wprowadzić zmiany",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Wprowadź 24 słowa oddzielone spacjami"
 }

--- a/public/locales/ru/settings.json
+++ b/public/locales/ru/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "Использовать Tor",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/public/locales/tr/settings.json
+++ b/public/locales/tr/settings.json
@@ -61,5 +61,6 @@
   "use-tor": "Tor Kullan",
   "importing-wallet": "Importing wallet",
   "action-requires-restart": "This action requires restart to apply changes",
+  "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "invalid-seed-words": "Enter 24 words separated by spaces"
 }

--- a/src/containers/SideBar/SideBar.tsx
+++ b/src/containers/SideBar/SideBar.tsx
@@ -6,6 +6,7 @@ import { Bottom, Scroll, SideBarContainer, SidebarTop, Top } from './styles';
 import MiningButton from '@app/containers/Dashboard/MiningView/components/MiningButton.tsx';
 import AirdropGiftTracker from '@app/containers/Airdrop/AirdropGiftTracker/AirdropGiftTracker';
 import LostConnectionAlert from './components/LostConnectionAlert';
+import { LowHashRateWarning } from './components/LowHashRateWarning/LowHashRateWarning.tsx';
 
 function SideBar() {
     return (
@@ -14,6 +15,7 @@ function SideBar() {
                 <Heading />
                 <MiningButton />
                 <LostConnectionAlert />
+                <LowHashRateWarning />
             </SidebarTop>
             <Scroll>
                 <Top>

--- a/src/containers/SideBar/components/LowHashRateWarning/LowHashRateWarning.tsx
+++ b/src/containers/SideBar/components/LowHashRateWarning/LowHashRateWarning.tsx
@@ -1,0 +1,26 @@
+import { IoWarningSharp } from 'react-icons/io5';
+import { Stack } from '@app/components/elements/Stack';
+import { Typography } from '@app/components/elements/Typography';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import { useMiningStore } from '@app/store/useMiningStore';
+
+const LowHashRateIcon = styled(IoWarningSharp)(({ theme }) => ({
+    color: theme.palette.warning.main,
+}));
+
+export const LowHashRateWarning = () => {
+    const { t } = useTranslation('settings', { useSuspense: false });
+    const { hash_rate, is_mining } = useMiningStore((s) => s.cpu.mining);
+
+    const showHashRateWarning = is_mining && hash_rate > 0 && hash_rate < 250;
+
+    return showHashRateWarning ? (
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <LowHashRateIcon size={20} />
+            <Typography variant="p">{t('low-hash-rate-warning')}</Typography>
+        </Stack>
+    ) : (
+        <></>
+    );
+};


### PR DESCRIPTION
Description
---
implements: #742 
Adds warning under the mine button about low hash rate.
![Screenshot from 2024-10-10 15-45-40](https://github.com/user-attachments/assets/cd75ae97-0049-462a-a96c-cc7d3ad4f878)


Motivation and Context
---
Miner may enter into very slow mining mode if there is not enough free RAM. 

How Has This Been Tested?
---
Increased hash rate above my CPU capability to trigger warning.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

