### PR TITLE
fix: airdrop token refresh

### DIFF
--- a/src/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts
+++ b/src/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts
@@ -35,7 +35,7 @@ export function useAirdropTokensRefresh() {
 
     useEffect(() => {
         if (!backendInMemoryConfig?.airdropApiUrl) return;
-        const interval = setInterval(handleRefresh, 1000 * 60 * 60, backendInMemoryConfig?.airdropApiUrl);
+        const interval = setInterval(() => handleRefresh(backendInMemoryConfig?.airdropApiUrl), 1000 * 60 * 60);
         return () => clearInterval(interval);
     }, [handleRefresh, backendInMemoryConfig?.airdropApiUrl]);
 

--- a/src/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts
+++ b/src/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts
@@ -1,13 +1,11 @@
 import { useAirdropStore } from '@app/store/useAirdropStore';
-// import { useInterval } from "../useInterval";
 import { useCallback, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
 
-export function useAirdropTokensRefresh() {
-    const { airdropTokens, setAirdropTokens, backendInMemoryConfig } = useAirdropStore();
+export function useHandleAirdropTokensRefresh() {
+    const { airdropTokens, setAirdropTokens } = useAirdropStore();
 
-    // Handle refreshing the access token
-    const handleRefresh = useCallback(
+    return useCallback(
         (airdropApiUrl: string) => {
             // 5 hours from now
             const expirationLimit = new Date(new Date().getTime() + 1000 * 60 * 60 * 5);
@@ -32,6 +30,12 @@ export function useAirdropTokensRefresh() {
         },
         [airdropTokens, setAirdropTokens]
     );
+}
+export function useAirdropTokensRefresh() {
+    const { airdropTokens, backendInMemoryConfig } = useAirdropStore();
+
+    // Handle refreshing the access token
+    const handleRefresh = useHandleAirdropTokensRefresh();
 
     useEffect(() => {
         if (!backendInMemoryConfig?.airdropApiUrl) return;

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -101,7 +101,7 @@ export function useSetUp() {
         settingUpFinished,
         setCriticalError,
         setSeenPermissions,
-        backendInMemoryConfig.airdropApiUrl,
+        backendInMemoryConfig?.airdropApiUrl,
         handleRefreshAirdropTokens,
     ]);
 }

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -43,13 +43,17 @@ export function useSetUp() {
     useEffect(() => {
         async function initialize() {
             await fetchAppConfig();
-            if (backendInMemoryConfig?.airdropApiUrl) {
-                handleRefreshAirdropTokens(backendInMemoryConfig.airdropApiUrl);
-            }
         }
         initialize();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        if (backendInMemoryConfig?.airdropApiUrl) {
+            handleRefreshAirdropTokens(backendInMemoryConfig.airdropApiUrl);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [backendInMemoryConfig?.airdropApiUrl]);
 
     const clearStorage = useCallback(() => {
         // clear all storage except airdrop data

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -10,6 +10,7 @@ import { setAnimationState } from '@app/visuals.ts';
 import useWalletDetailsUpdater from './useWalletUpdater.ts';
 import { useAirdropStore } from '@app/store/useAirdropStore.ts';
 import { ExternalDependency } from '@app/types/app-status.ts';
+import { useHandleAirdropTokensRefresh } from '@app/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts';
 
 export function useSetUp() {
     const setView = useUIStore((s) => s.setView);
@@ -22,6 +23,8 @@ export function useSetUp() {
     const settingUpFinished = useAppStateStore((s) => s.settingUpFinished);
     const setSeenPermissions = useAirdropStore((s) => s.setSeenPermissions);
     const setCriticalError = useAppStateStore((s) => s.setCriticalError);
+    const { backendInMemoryConfig } = useAirdropStore();
+    const handleRefreshAirdropTokens = useHandleAirdropTokensRefresh();
 
     const { loadExternalDependencies } = useAppStateStore();
 
@@ -83,6 +86,9 @@ export function useSetUp() {
             });
         }
         return () => {
+            if (backendInMemoryConfig?.airdropApiUrl) {
+                handleRefreshAirdropTokens(backendInMemoryConfig.airdropApiUrl);
+            }
             unlistenPromise.then((unlisten) => unlisten());
         };
     }, [
@@ -95,5 +101,7 @@ export function useSetUp() {
         settingUpFinished,
         setCriticalError,
         setSeenPermissions,
+        backendInMemoryConfig.airdropApiUrl,
+        handleRefreshAirdropTokens,
     ]);
 }

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -43,6 +43,9 @@ export function useSetUp() {
     useEffect(() => {
         async function initialize() {
             await fetchAppConfig();
+            if (backendInMemoryConfig?.airdropApiUrl) {
+                handleRefreshAirdropTokens(backendInMemoryConfig.airdropApiUrl);
+            }
         }
         initialize();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -86,9 +89,6 @@ export function useSetUp() {
             });
         }
         return () => {
-            if (backendInMemoryConfig?.airdropApiUrl) {
-                handleRefreshAirdropTokens(backendInMemoryConfig.airdropApiUrl);
-            }
             unlistenPromise.then((unlisten) => unlisten());
         };
     }, [


### PR DESCRIPTION
Description
---

- fixed airdrop token refresh interval
- moved out the handle refresh fn to its own hook so it can be called in `useSetup`

Motivation and Context
---

- lots of errors around fetching the last mined block - after checking it could be that jwts are expired, and the interval in `useAirdropTokensRefresh` wasn't working 

