### PR TITLE
fix: restart services if they are not healthy

### DIFF
--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -1,9 +1,9 @@
 {
     "binaries": {
         "xmrig": "=6.22.0",
-        "mmproxy": "=1.6.0-pre.0",
-        "minotari_node": "=1.6.0-pre.0",
-        "wallet": "=1.6.0-pre.0",
+        "mmproxy": "=1.7.0-pre.0",
+        "minotari_node": "=1.7.0-pre.0",
+        "wallet": "=1.7.0-pre.0",
         "sha-p2pool": "=0.2.0",
         "xtrgpuminer": "=0.1.13",
         "tor": "=13.5.6"

--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -4,8 +4,8 @@
         "mmproxy": "=1.7.0-pre.0",
         "minotari_node": "=1.7.0-pre.0",
         "wallet": "=1.7.0-pre.0",
-        "sha-p2pool": "=0.2.0",
-        "xtrgpuminer": "=0.1.13",
+        "sha-p2pool": "=0.3.0",
+        "xtrgpuminer": "=0.1.16",
         "tor": "=13.5.6"
     }
 }

--- a/src-tauri/binaries_versions_nextnet.json
+++ b/src-tauri/binaries_versions_nextnet.json
@@ -4,8 +4,8 @@
         "mmproxy": "=1.5.1-rc.3",
         "minotari_node": "=1.5.1-rc.3",
         "wallet": "=1.5.1-rc.3",
-        "sha-p2pool": "=0.2.0",
-        "xtrgpuminer": "=0.1.13",
+        "sha-p2pool": "=0.3.0",
+        "xtrgpuminer": "=0.1.16",
         "tor": "=13.5.6"
     }
 }

--- a/src-tauri/log4rs_sample.yml
+++ b/src-tauri/log4rs_sample.yml
@@ -15,7 +15,7 @@ appenders:
   stdout:
     kind: console
     encoder:
-      pattern: "{d(%H:%M)} {h({l}):5} {m}{n}"
+      pattern: "{d(%H:%M:%S)} {h({l}):5} {m}{n}"
     filters:
       - kind: threshold
         level: info

--- a/src-tauri/src/binaries/binaries_list.rs
+++ b/src-tauri/src/binaries/binaries_list.rs
@@ -43,7 +43,7 @@ impl Binaries {
         match self {
             Binaries::Xmrig => {
                 let file_name = format!("xmrig-{}", version);
-                PathBuf::from(file_name)
+                PathBuf::from(file_name).join("xmrig")
             }
             Binaries::MergeMiningProxy => {
                 let file_name = "minotari_merge_mining_proxy";

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -175,7 +175,7 @@ impl BinaryResolver {
         &INSTANCE
     }
 
-    pub async fn resolve_path_to_binary_files(&self, binary: Binaries) -> Result<PathBuf, Error> {
+    pub fn resolve_path_to_binary_files(&self, binary: Binaries) -> Result<PathBuf, Error> {
         let manager = self
             .managers
             .get(&binary)

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -73,6 +73,7 @@ impl BinaryResolver {
             Binaries::Xmrig,
             BinaryManager::new(
                 Binaries::Xmrig.name().to_string(),
+                // Some("xmrig-6.22.0".to_string()),
                 None,
                 Box::new(XmrigVersionApiAdapter {}),
                 None,

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -1,4 +1,5 @@
 use crate::app_config::MiningMode;
+use crate::binaries::{Binaries, BinaryResolver};
 use crate::process_adapter::ProcessAdapter;
 use crate::xmrig::http_api::XmrigHttpApiClient;
 use crate::xmrig_adapter::{XmrigAdapter, XmrigNodeConnection};
@@ -81,8 +82,18 @@ impl CpuMiner {
             monero_address.clone(),
             cpu_max_percentage,
         );
-        let (mut xmrig_child, _xmrig_status_monitor) =
-            xmrig.spawn_inner(base_path.clone(), config_path.clone(), log_dir.clone())?;
+
+        let binary_path = BinaryResolver::current()
+            .read()
+            .await
+            .resolve_path_to_binary_files(Binaries::Xmrig)?;
+
+        let (mut xmrig_child, _xmrig_status_monitor) = xmrig.spawn_inner(
+            base_path.clone(),
+            config_path.clone(),
+            log_dir.clone(),
+            binary_path,
+        )?;
         self.api_client = Some(xmrig.client);
 
         self.watcher_task = Some(tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -1,35 +1,37 @@
 use crate::app_config::MiningMode;
 use crate::binaries::{Binaries, BinaryResolver};
 use crate::process_adapter::ProcessAdapter;
+use crate::process_watcher::ProcessWatcher;
 use crate::xmrig::http_api::XmrigHttpApiClient;
 use crate::xmrig_adapter::{XmrigAdapter, XmrigNodeConnection};
 use crate::{CpuMinerConfig, CpuMinerConnection, CpuMinerConnectionStatus, CpuMinerStatus};
 use log::{debug, error, info, warn};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::thread;
+use sysinfo::Process;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tauri::async_runtime::JoinHandle;
 use tokio::select;
+use tokio::sync::RwLock;
 use tokio::time::MissedTickBehavior;
 
 const RANDOMX_BLOCKS_PER_DAY: u64 = 360;
 const LOG_TARGET: &str = "tari::universe::cpu_miner";
 
 pub(crate) struct CpuMiner {
-    watcher_task: Option<JoinHandle<Result<(), anyhow::Error>>>,
+    watcher: Arc<RwLock<ProcessWatcher<XmrigAdapter>>>,
     miner_shutdown: Shutdown,
-    api_client: Option<XmrigHttpApiClient>,
-    is_mining: bool,
 }
 
 impl CpuMiner {
     pub fn new() -> Self {
+        let xmrig_adapter = XmrigAdapter::new();
+        let process_watcher = ProcessWatcher::new(xmrig_adapter);
         Self {
-            watcher_task: None,
+            watcher: Arc::new(RwLock::new(process_watcher)),
             miner_shutdown: Shutdown::new(),
-            api_client: None,
-            is_mining: false,
         }
     }
 
@@ -45,12 +47,7 @@ impl CpuMiner {
         log_dir: PathBuf,
         mode: MiningMode,
     ) -> Result<(), anyhow::Error> {
-        if self.watcher_task.is_some() {
-            warn!(target: LOG_TARGET, "Tried to start mining twice");
-            return Ok(());
-        }
-        self.miner_shutdown = Shutdown::new();
-        let mut inner_shutdown = self.miner_shutdown.to_signal();
+        let mut lock = self.watcher.write().await;
 
         let xmrig_node_connection = match cpu_miner_config.node_connection {
             CpuMinerConnection::BuiltInProxy => {
@@ -77,75 +74,25 @@ impl CpuMiner {
             MiningMode::Eco => (30 * max_cpu_available) / 100isize,
             MiningMode::Ludicrous => -1, // Use all
         };
-        let xmrig = XmrigAdapter::new(
-            xmrig_node_connection,
-            monero_address.clone(),
-            cpu_max_percentage,
-        );
 
-        let binary_path = BinaryResolver::current()
-            .read()
-            .await
-            .resolve_path_to_binary_files(Binaries::Xmrig)?;
+        lock.adapter.node_connection = Some(xmrig_node_connection);
+        lock.adapter.monero_address = Some(monero_address.clone());
+        lock.adapter.cpu_max_percentage = Some(cpu_max_percentage);
 
-        let (mut xmrig_child, _xmrig_status_monitor) = xmrig.spawn_inner(
+        lock.start(
+            app_shutdown.clone(),
             base_path.clone(),
             config_path.clone(),
             log_dir.clone(),
-            binary_path,
-        )?;
-        self.api_client = Some(xmrig.client);
-
-        self.watcher_task = Some(tauri::async_runtime::spawn(async move {
-            let mut watch_timer = tokio::time::interval(tokio::time::Duration::from_secs(1));
-            watch_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            // read events such as stdout
-            loop {
-                select! {
-                      _ = watch_timer.tick() => {
-                            if !xmrig_child.ping()
-                            {
-                               warn!(target: LOG_TARGET, "Wmrig is not running");
-                               match xmrig_child.stop().await {
-                                   Ok(_) => {
-                                      info!(target: LOG_TARGET, "Xmrig exited successfully");
-                                   }
-                                   Err(e) => {
-                                      error!(target: LOG_TARGET, "Xmrig exited with error: {}", e);
-                                      return Err(e)
-                                   }
-                               }
-                               break;
-                            }
-                      },
-                        //   event = rx.recv() => {
-
-                    _ = inner_shutdown.wait() => {
-                        xmrig_child.stop().await?;
-                        break;
-                    },
-                    _ = app_shutdown.wait() => {
-                        xmrig_child.stop().await?;
-                        break;
-                    }
-                }
-            }
-            Ok(())
-        }));
+            Binaries::Xmrig,
+        )
+        .await?;
         Ok(())
     }
 
     pub async fn stop(&mut self) -> Result<(), anyhow::Error> {
-        info!(target: LOG_TARGET, "Triggering shutdown");
-        self.miner_shutdown.trigger();
-        self.api_client = None;
-        if let Some(task) = self.watcher_task.take() {
-            task.await??;
-            info!(target: LOG_TARGET, "CPU miner shut down successfully");
-        }
-        // TODO: This doesn't seem to be called
-        self.is_mining = false;
-
+        let mut lock = self.watcher.write().await;
+        lock.stop().await?;
         Ok(())
     }
 
@@ -154,68 +101,9 @@ impl CpuMiner {
         network_hash_rate: u64,
         block_reward: MicroMinotari,
     ) -> Result<CpuMinerStatus, anyhow::Error> {
-        match &self.api_client {
-            Some(client) => {
-                let (hash_rate, _hashrate_sum, estimated_earnings, is_connected) =
-                    match client.summary().await {
-                        Ok(xmrig_status) => {
-                            let hash_rate = xmrig_status.hashrate.total[0].unwrap_or_default();
-                            let estimated_earnings = if network_hash_rate == 0 {
-                                0
-                            } else {
-                                #[allow(clippy::cast_possible_truncation)]
-                                {
-                                    ((block_reward.as_u64() as f64)
-                                        * ((hash_rate / (network_hash_rate as f64))
-                                            * (RANDOMX_BLOCKS_PER_DAY as f64)))
-                                        .floor() as u64
-                                }
-                            };
-                            // Can't be more than the max reward for a day
-                            let estimated_earnings = std::cmp::min(
-                                estimated_earnings,
-                                block_reward.as_u64() * RANDOMX_BLOCKS_PER_DAY,
-                            );
-
-                            // mining should be true if the hashrate is greater than 0
-
-                            let hasrate_sum = xmrig_status
-                                .hashrate
-                                .total
-                                .iter()
-                                .fold(0.0, |acc, x| acc + x.unwrap_or(0.0));
-                            (
-                                hash_rate,
-                                hasrate_sum,
-                                estimated_earnings,
-                                xmrig_status.connection.uptime > 0,
-                            )
-                        }
-                        Err(e) => {
-                            warn!(target: LOG_TARGET, "Failed to get xmrig summary: {}", e);
-                            (0.0, 0.0, 0, false)
-                        }
-                    };
-
-                if !self.is_mining && is_connected {
-                    self.is_mining = true;
-                }
-
-                Ok(CpuMinerStatus {
-                    is_mining: self.is_mining,
-                    hash_rate,
-                    estimated_earnings: MicroMinotari(estimated_earnings).as_u64(),
-                    connection: CpuMinerConnectionStatus {
-                        is_connected,
-                        // error: if xmrig_status.connection.error_log.is_empty() {
-                        //     None
-                        // } else {
-                        //     Some(xmrig_status.connection.error_log.join(";"))
-                        // },
-                    },
-                })
-            }
-            None => Ok(CpuMinerStatus {
+        let lock = self.watcher.read().await;
+        if !lock.is_running() {
+            return Ok(CpuMinerStatus {
                 is_mining: false,
                 hash_rate: 0.0,
                 estimated_earnings: 0,
@@ -223,7 +111,68 @@ impl CpuMiner {
                     is_connected: false,
                     // error: None,
                 },
-            }),
+            });
+        }
+
+        let client = &lock.status_monitor;
+
+        if let Some(client) = client.as_ref() {
+            let (hash_rate, _hashrate_sum, estimated_earnings, is_connected) =
+                match client.summary().await {
+                    Ok(xmrig_status) => {
+                        let hash_rate = xmrig_status.hashrate.total[0].unwrap_or_default();
+                        let estimated_earnings = if network_hash_rate == 0 {
+                            0
+                        } else {
+                            #[allow(clippy::cast_possible_truncation)]
+                            {
+                                ((block_reward.as_u64() as f64)
+                                    * ((hash_rate / (network_hash_rate as f64))
+                                        * (RANDOMX_BLOCKS_PER_DAY as f64)))
+                                    .floor() as u64
+                            }
+                        };
+                        // Can't be more than the max reward for a day
+                        let estimated_earnings = std::cmp::min(
+                            estimated_earnings,
+                            block_reward.as_u64() * RANDOMX_BLOCKS_PER_DAY,
+                        );
+
+                        // mining should be true if the hashrate is greater than 0
+
+                        let hasrate_sum = xmrig_status
+                            .hashrate
+                            .total
+                            .iter()
+                            .fold(0.0, |acc, x| acc + x.unwrap_or(0.0));
+                        (
+                            hash_rate,
+                            hasrate_sum,
+                            estimated_earnings,
+                            xmrig_status.connection.uptime > 0,
+                        )
+                    }
+                    Err(e) => {
+                        warn!(target: LOG_TARGET, "Failed to get xmrig summary: {}", e);
+                        (0.0, 0.0, 0, false)
+                    }
+                };
+            Ok(CpuMinerStatus {
+                is_mining: true,
+                hash_rate,
+                estimated_earnings: MicroMinotari(estimated_earnings).as_u64(),
+                connection: CpuMinerConnectionStatus { is_connected },
+            })
+        } else {
+            Ok(CpuMinerStatus {
+                is_mining: false,
+                hash_rate: 0.0,
+                estimated_earnings: 0,
+                connection: CpuMinerConnectionStatus {
+                    is_connected: false,
+                    // error: None,
+                },
+            })
         }
     }
 }

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -61,7 +61,7 @@ pub async fn list_releases(
 ) -> Result<Vec<VersionDownloadInfo>, anyhow::Error> {
     let mut attempts = 0;
     let mut releases = loop {
-        let result = match list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await {
+        let _result = match list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await {
             Ok(r) => break r,
             Err(e) => {
                 warn!(target: LOG_TARGET, "Failed to fetch releases from mirror: {}", e);

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -60,11 +60,13 @@ pub async fn list_releases(
     repo_name: &str,
 ) -> Result<Vec<VersionDownloadInfo>, anyhow::Error> {
     let mut attempts = 0;
-    let releases = loop {
-        let result = list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await;
-        if result.as_ref().map_or(false, |r| !r.is_empty()) || attempts >= 3 {
-            break result;
-        }
+    let mut releases = loop {
+        let result = match list_releases_from(ReleaseSource::Mirror, repo_owner, repo_name).await {
+            Ok(r) => break r,
+            Err(e) => {
+                warn!(target: LOG_TARGET, "Failed to fetch releases from mirror: {}", e);
+            }
+        };
         attempts += 1;
         warn!(
             target: LOG_TARGET,
@@ -72,12 +74,26 @@ pub async fn list_releases(
             attempts
         );
     };
+    // Add any missing releases from github
+    let github_releases = list_releases_from(ReleaseSource::Github, repo_owner, repo_name)
+        .await
+        .inspect_err(|e| {
+            warn!(target: LOG_TARGET, "Failed to fetch releases from Github: {}", e);
+        })
+        .unwrap_or_default();
 
-    if releases.as_ref().map_or(false, |r| !r.is_empty()) {
-        releases
-    } else {
-        list_releases_from(ReleaseSource::Github, repo_owner, repo_name).await
+    for release in &github_releases {
+        if !releases.iter().any(|r| r.version == release.version) {
+            releases.push(release.clone());
+        }
     }
+    Ok(releases)
+
+    // if releases.as_ref().map_or(false, |r| !r.is_empty()) {
+    //     releases
+    // } else {
+    //     list_releases_from(ReleaseSource::Github, repo_owner, repo_name).await
+    // }
 }
 
 async fn list_releases_from(

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -12,7 +12,6 @@ use crate::process_utils;
 use crate::{
     app_config::MiningMode,
     gpu_miner_adapter::{GpuMinerAdapter, GpuMinerStatus},
-    process_adapter::StatusMonitor,
     process_watcher::ProcessWatcher,
 };
 

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -58,7 +58,13 @@ impl GpuMiner {
             .set_excluded_gpu_devices(self.excluded_gpu_devices.clone());
         info!(target: LOG_TARGET, "Starting xtrgpuminer");
         process_watcher
-            .start(app_shutdown, base_path, config_path, log_path)
+            .start(
+                app_shutdown,
+                base_path,
+                config_path,
+                log_path,
+                Binaries::GpuMiner,
+            )
             .await?;
         info!(target: LOG_TARGET, "xtrgpuminer started");
 
@@ -143,8 +149,7 @@ impl GpuMiner {
         let gpuminer_bin = BinaryResolver::current()
             .read()
             .await
-            .resolve_path_to_binary_files(Binaries::GpuMiner)
-            .await?;
+            .resolve_path_to_binary_files(Binaries::GpuMiner)?;
 
         info!(target: LOG_TARGET, "Gpu miner binary file path {:?}", gpuminer_bin.clone());
         crate::download_utils::set_permissions(&gpuminer_bin).await?;

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -230,15 +230,20 @@ impl ProcessAdapter for GpuMinerAdapter {
     }
 }
 
+#[derive(Clone)]
 pub struct GpuMinerStatusMonitor {
     http_api_port: u16,
 }
 
 #[async_trait]
 impl StatusMonitor for GpuMinerStatusMonitor {
-    type Status = GpuMinerStatus;
+    async fn check_health(&self) -> bool {
+        self.status().await.is_ok()
+    }
+}
 
-    async fn status(&self) -> Result<Self::Status, anyhow::Error> {
+impl GpuMinerStatusMonitor {
+    pub async fn status(&self) -> Result<GpuMinerStatus, anyhow::Error> {
         let client = reqwest::Client::new();
         let response = match client
             .get(format!("http://127.0.0.1:{}/stats", self.http_api_port))

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -75,7 +75,6 @@ impl ProcessAdapter for GpuMinerAdapter {
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         info!(target: LOG_TARGET, "Gpu miner spawn inner");
         let inner_shutdown = Shutdown::new();
-        let shutdown_signal = inner_shutdown.to_signal();
 
         let http_api_port = get_free_port().unwrap_or(18000);
         let working_dir = data_dir.join("gpuminer");

--- a/src-tauri/src/hardware_monitor.rs
+++ b/src-tauri/src/hardware_monitor.rs
@@ -255,10 +255,14 @@ impl HardwareMonitorImpl for WindowsHardwareMonitor {
                 }
             };
 
-            let current_temperature =
-                current_gpu.temperature(TemperatureSensor::Gpu).unwrap() as f32;
-            let usage_percentage = current_gpu.utilization_rates().unwrap().gpu as f32;
-            let label = current_gpu.name().unwrap();
+            let current_temperature = current_gpu
+                .temperature(TemperatureSensor::Gpu)
+                .unwrap_or_default() as f32;
+            let usage_percentage = current_gpu
+                .utilization_rates()
+                .map(|e| e.gpu)
+                .unwrap_or_default() as f32;
+            let label = current_gpu.name().unwrap_or_else(|_e| "N/A".to_string());
 
             let max_temperature = match current_parameters.get(i as usize) {
                 Some(current_parameters) => {
@@ -281,7 +285,13 @@ impl HardwareMonitorImpl for WindowsHardwareMonitor {
         let mut gpu_devices = vec![];
 
         if let Some(file_path) = file {
-            let gpu_status_file = fs::read_to_string(file_path).unwrap();
+            let gpu_status_file = match fs::read_to_string(file_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Failed to read gpu status file: {}", e);
+                    return gpu_devices;
+                }
+            };
             match serde_json::from_str::<GpuStatusFile>(&gpu_status_file) {
                 Ok(gpu) => gpu_devices = gpu.gpu_devices,
                 Err(e) => {
@@ -417,10 +427,14 @@ impl HardwareMonitorImpl for LinuxHardwareMonitor {
                 }
             };
 
-            let current_temperature =
-                current_gpu.temperature(TemperatureSensor::Gpu).unwrap() as f32;
-            let usage_percentage = current_gpu.utilization_rates().unwrap().gpu as f32;
-            let label = current_gpu.name().unwrap();
+            let current_temperature = current_gpu
+                .temperature(TemperatureSensor::Gpu)
+                .unwrap_or_default() as f32;
+            let usage_percentage = current_gpu
+                .utilization_rates()
+                .map(|e| e.gpu)
+                .unwrap_or_default() as f32;
+            let label = current_gpu.name().unwrap_or_else(|e| "N/A".to_string());
 
             let max_temperature = match current_parameters.get(i as usize) {
                 Some(current_parameters) => {
@@ -443,7 +457,13 @@ impl HardwareMonitorImpl for LinuxHardwareMonitor {
         let mut gpu_devices = vec![];
 
         if let Some(file_path) = file {
-            let gpu_status_file = fs::read_to_string(file_path).unwrap();
+            let gpu_status_file = match fs::read_to_string(file_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Failed to read gpu status file: {}", e);
+                    return gpu_devices;
+                }
+            };
             match serde_json::from_str::<GpuStatusFile>(&gpu_status_file) {
                 Ok(gpu) => {
                     gpu_devices = gpu.gpu_devices;
@@ -595,7 +615,13 @@ impl HardwareMonitorImpl for MacOSHardwareMonitor {
         let mut gpu_devices = vec![];
 
         if let Some(file_path) = file {
-            let gpu_status_file = fs::read_to_string(file_path).unwrap();
+            let gpu_status_file = match fs::read_to_string(file_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Failed to read gpu status file: {}", e);
+                    return gpu_devices;
+                }
+            };
             match serde_json::from_str::<GpuStatusFile>(&gpu_status_file) {
                 Ok(gpu) => {
                     gpu_devices = gpu.gpu_devices;

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -2,7 +2,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::binaries::{Binaries, BinaryResolver};
-use crate::process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor};
+use crate::process_adapter::{
+    HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
+};
 use crate::process_utils;
 use crate::utils::file_utils::convert_to_string;
 use anyhow::{anyhow, Error};
@@ -147,8 +149,8 @@ pub struct MergeMiningProxyStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for MergeMiningProxyStatusMonitor {
-    async fn check_health(&self) -> bool {
+    async fn check_health(&self) -> HealthStatus {
         // TODO: Implement a call to the jsonrpc api to check the health of the mmproxy
-        true
+        HealthStatus::Healthy
     }
 }

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -175,13 +175,13 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
     }
 }
 
+#[derive(Clone)]
 pub struct MergeMiningProxyStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for MergeMiningProxyStatusMonitor {
-    type Status = ();
-
-    async fn status(&self) -> Result<Self::Status, Error> {
-        todo!()
+    async fn check_health(&self) -> bool {
+        // TODO: Implement a call to the jsonrpc api to check the health of the mmproxy
+        true
     }
 }

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -58,7 +58,6 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
         binary_verison_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
-        let shutdown_signal = inner_shutdown.to_signal();
 
         let working_dir = data_dir.join("mmproxy");
         std::fs::create_dir_all(&working_dir)?;

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -140,6 +140,7 @@ impl MmProxyManager {
                 config.base_path,
                 config.config_path,
                 config.log_path,
+                crate::binaries::Binaries::MergeMiningProxy,
             )
             .await?;
 

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -59,7 +59,6 @@ impl ProcessAdapter for MinotariNodeAdapter {
         binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
-        let shutdown_signal = inner_shutdown.to_signal();
         let status_shutdown = inner_shutdown.to_signal();
 
         info!(target: LOG_TARGET, "Starting minotari node");

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -1,7 +1,7 @@
 use crate::binaries::{Binaries, BinaryResolver};
 use crate::network_utils::get_free_port;
 use crate::node_manager::NodeIdentity;
-use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
+use crate::process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor};
 use crate::utils::file_utils::convert_to_string;
 use crate::{process_utils, ProgressTracker};
 use anyhow::{anyhow, Error};
@@ -18,6 +18,7 @@ use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_utilities::ByteArray;
+use tokio::runtime::Handle;
 use tokio::select;
 
 const LOG_TARGET: &str = "tari::universe::minotari_node_adapter";
@@ -53,6 +54,7 @@ impl ProcessAdapter for MinotariNodeAdapter {
         data_dir: PathBuf,
         _config_dir: PathBuf,
         log_dir: PathBuf,
+        binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
         let shutdown_signal = inner_shutdown.to_signal();
@@ -130,53 +132,19 @@ impl ProcessAdapter for MinotariNodeAdapter {
             // "base_node.p2p.dht.excluded_dial_addresses=/ip4/127.*.*.*/tcp/0:18188".to_string(),
             // );
         }
+
         Ok((
             ProcessInstance {
                 shutdown: inner_shutdown,
-                handle: Some(tokio::spawn(async move {
-                    let file_path = BinaryResolver::current()
-                        .read()
-                        .await
-                        .resolve_path_to_binary_files(Binaries::MinotariNode)
-                        .await?;
-
-                    crate::download_utils::set_permissions(&file_path).await?;
-                    let mut child = process_utils::launch_child_process(&file_path, None, &args)?;
-
-                    if let Some(id) = child.id() {
-                        fs::write(data_dir.join("node_pid"), id.to_string())?;
-                    }
-
-                    let exit_code;
-                    select! {
-                        _res = shutdown_signal =>{
-                            child.kill().await?;
-                            exit_code = 0;
-                            // res
-                        },
-                        res2 = child.wait() => {
-                            match res2
-                             {
-                                Ok(res) => {
-                                    exit_code = res.code().unwrap_or(0)
-                                    },
-                                Err(e) => {
-                                    warn!(target: LOG_TARGET, "Error in NodeInstance: {}", e);
-                                    return Err(e.into());
-                                }
-                            }
-
-                        },
-                    }
-
-                    match fs::remove_file(data_dir.join("node_pid")) {
-                        Ok(_) => {}
-                        Err(_e) => {
-                            debug!(target: LOG_TARGET, "Could not clear node's pid file");
-                        }
-                    }
-                    Ok(exit_code)
-                })),
+                handle: None,
+                startup_spec: ProcessStartupSpec {
+                    file_path: binary_version_path,
+                    envs: None,
+                    args,
+                    data_dir,
+                    pid_file_name: self.pid_file_name().to_string(),
+                    name: self.name().to_string(),
+                },
             },
             MinotariNodeStatusMonitor {
                 grpc_port: self.grpc_port,

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -1,7 +1,9 @@
 use crate::binaries::{Binaries, BinaryResolver};
 use crate::network_utils::get_free_port;
 use crate::node_manager::NodeIdentity;
-use crate::process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor};
+use crate::process_adapter::{
+    HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
+};
 use crate::utils::file_utils::convert_to_string;
 use crate::{process_utils, ProgressTracker};
 use anyhow::{anyhow, Error};
@@ -180,8 +182,12 @@ pub struct MinotariNodeStatusMonitor {
 
 #[async_trait]
 impl StatusMonitor for MinotariNodeStatusMonitor {
-    async fn check_health(&self) -> bool {
-        self.get_identity().await.is_ok()
+    async fn check_health(&self) -> HealthStatus {
+        if self.get_identity().await.is_ok() {
+            HealthStatus::Healthy
+        } else {
+            HealthStatus::Unhealthy
+        }
     }
 }
 

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -76,7 +76,13 @@ impl NodeManager {
             let mut process_watcher = self.watcher.write().await;
             process_watcher.adapter.use_tor = use_tor;
             process_watcher
-                .start(app_shutdown, base_path, config_path, log_path)
+                .start(
+                    app_shutdown,
+                    base_path,
+                    config_path,
+                    log_path,
+                    crate::binaries::Binaries::MinotariNode,
+                )
                 .await?;
         }
         self.wait_ready().await?;
@@ -92,7 +98,13 @@ impl NodeManager {
     ) -> Result<(), anyhow::Error> {
         let mut process_watcher = self.watcher.write().await;
         process_watcher
-            .start(app_shutdown, base_path, config_path, log_path)
+            .start(
+                app_shutdown,
+                base_path,
+                config_path,
+                log_path,
+                crate::binaries::Binaries::MinotariNode,
+            )
             .await?;
 
         Ok(())

--- a/src-tauri/src/p2pool/models.rs
+++ b/src-tauri/src/p2pool/models.rs
@@ -56,10 +56,11 @@ pub struct Stats {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChainStats {
     pub squad: SquadDetails,
-    pub num_of_miners: usize,
+    // pub num_of_miners: usize,
     pub share_chain_height: u64,
-    pub miner_block_stats: BlockStats,
-    pub p2pool_block_stats: BlockStats,
+    pub share_chain_length: u64,
+    // pub miner_block_stats: BlockStats,
+    // pub p2pool_block_stats: BlockStats,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]

--- a/src-tauri/src/p2pool/stats_client.rs
+++ b/src-tauri/src/p2pool/stats_client.rs
@@ -1,6 +1,7 @@
 use crate::p2pool::models::Stats;
 use anyhow::Error;
 
+#[derive(Clone)]
 pub struct Client {
     stats_server_address: String,
 }

--- a/src-tauri/src/p2pool/stats_client.rs
+++ b/src-tauri/src/p2pool/stats_client.rs
@@ -1,6 +1,8 @@
 use crate::p2pool::models::Stats;
 use anyhow::Error;
+use log::warn;
 
+const LOG_TARGET: &str = "tari::universe::p2pool_stats_client";
 #[derive(Clone)]
 pub struct Client {
     stats_server_address: String,
@@ -17,7 +19,8 @@ impl Client {
         let stats = reqwest::get(format!("{}/stats", self.stats_server_address))
             .await?
             .json::<Stats>()
-            .await?;
+            .await
+            .inspect_err(|e| warn!(target: LOG_TARGET, "P2pool stats error: {:?}", e))?;
         Ok(stats)
     }
 }

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -166,6 +166,7 @@ impl ProcessAdapter for P2poolAdapter {
     }
 }
 
+#[derive(Clone)]
 pub struct P2poolStatusMonitor {
     stats_client: p2pool::stats_client::Client,
 }
@@ -180,9 +181,16 @@ impl P2poolStatusMonitor {
 
 #[async_trait]
 impl StatusMonitor for P2poolStatusMonitor {
-    type Status = Stats;
+    async fn check_health(&self) -> bool {
+        match self.stats_client.stats().await {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
 
-    async fn status(&self) -> Result<Self::Status, Error> {
+impl P2poolStatusMonitor {
+    pub async fn status(&self) -> Result<Stats, Error> {
         self.stats_client.stats().await
     }
 }

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -47,7 +47,6 @@ impl ProcessAdapter for P2poolAdapter {
         binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
-        let shutdown_signal = inner_shutdown.to_signal();
 
         info!(target: LOG_TARGET, "Starting p2pool node");
 

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -8,12 +8,14 @@ use std::fs;
 use std::path::PathBuf;
 use tari_common::configuration::Network;
 use tari_shutdown::Shutdown;
+use tokio::runtime::Handle;
 use tokio::select;
 
 use crate::binaries::{Binaries, BinaryResolver};
 use crate::p2pool;
 use crate::p2pool::models::Stats;
 use crate::p2pool_manager::P2poolConfig;
+use crate::process_adapter::ProcessStartupSpec;
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use crate::process_utils::launch_child_process;
 use crate::utils::file_utils::convert_to_string;
@@ -42,6 +44,7 @@ impl ProcessAdapter for P2poolAdapter {
         data_dir: PathBuf,
         _config_dir: PathBuf,
         log_path: PathBuf,
+        binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
         let shutdown_signal = inner_shutdown.to_signal();
@@ -78,80 +81,33 @@ impl ProcessAdapter for P2poolAdapter {
             log_path_string,
         ];
         let pid_file_name = self.pid_file_name().to_string();
+
+        args.push("--tribe".to_string());
+        args.push("default2".to_string());
+        let mut envs = HashMap::new();
+        match Network::get_current_or_user_setting_or_default() {
+            Network::Esmeralda => {
+                envs.insert("TARI_NETWORK".to_string(), "esmeralda".to_string());
+            }
+            Network::NextNet => {
+                envs.insert("TARI_NETWORK".to_string(), "nextnet".to_string());
+            }
+            _ => {
+                return Err(anyhow!("Unsupported network"));
+            }
+        };
         Ok((
             ProcessInstance {
                 shutdown: inner_shutdown,
-                handle: Some(tokio::spawn(async move {
-                    // file details
-                    let file_path = BinaryResolver::current()
-                        .read()
-                        .await
-                        .resolve_path_to_binary_files(Binaries::ShaP2pool)
-                        .await?;
-                    crate::download_utils::set_permissions(&file_path).await?;
-
-                    // let output = process_utils::launch_and_get_outputs(
-                    //     &file_path,
-                    //     vec!["list-tribes".to_string()],
-                    // )
-                    // .await?;
-                    // let tribes: Vec<String> = serde_json::from_slice(&output)?;
-                    // let tribe = match tribes.choose(&mut rand::thread_rng()) {
-                    //     Some(tribe) => tribe.to_string(),
-                    //     None => String::from("default"), // TODO: generate name
-                    // };
-                    args.push("--tribe".to_string());
-                    args.push("default2".to_string());
-
-                    // env
-                    let mut envs = HashMap::new();
-                    match Network::get_current_or_user_setting_or_default() {
-                        Network::Esmeralda => {
-                            envs.insert("TARI_NETWORK".to_string(), "esmeralda".to_string());
-                        }
-                        Network::NextNet => {
-                            envs.insert("TARI_NETWORK".to_string(), "nextnet".to_string());
-                        }
-                        _ => {
-                            return Err(anyhow!("Unsupported network"));
-                        }
-                    }
-
-                    // start
-                    let mut child = launch_child_process(&file_path, Some(envs), &args)?;
-
-                    if let Some(id) = child.id() {
-                        fs::write(data_dir.join(pid_file_name.clone()), id.to_string())?;
-                    }
-                    let exit_code;
-
-                    select! {
-                        _res = shutdown_signal =>{
-                            child.kill().await?;
-                            exit_code = 0;
-                            // res
-                        },
-                        res2 = child.wait() => {
-                            match res2
-                             {
-                                Ok(res) => {
-                                    exit_code = res.code().unwrap_or(0)
-                                    },
-                                Err(e) => {
-                                    warn!(target: LOG_TARGET, "Error in MergeMiningProxyInstance: {}", e);
-                                    return Err(e.into());
-                                }
-                            }
-                        },
-                    };
-                    info!(target: LOG_TARGET, "Stopping p2pool node");
-
-                    if let Err(error) = fs::remove_file(data_dir.join(pid_file_name)) {
-                        warn!(target: LOG_TARGET, "Could not clear p2pool's pid file: {error:?}");
-                    }
-
-                    Ok(exit_code)
-                })),
+                handle: None,
+                startup_spec: ProcessStartupSpec {
+                    file_path: binary_version_path,
+                    envs: Some(envs),
+                    args,
+                    data_dir,
+                    pid_file_name,
+                    name: "P2pool".to_string(),
+                },
             },
             P2poolStatusMonitor::new(format!("http://127.0.0.1:{}", config.stats_server_port)),
         ))

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -15,6 +15,7 @@ use crate::binaries::{Binaries, BinaryResolver};
 use crate::p2pool;
 use crate::p2pool::models::Stats;
 use crate::p2pool_manager::P2poolConfig;
+use crate::process_adapter::HealthStatus;
 use crate::process_adapter::ProcessStartupSpec;
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use crate::process_utils::launch_child_process;
@@ -136,10 +137,10 @@ impl P2poolStatusMonitor {
 
 #[async_trait]
 impl StatusMonitor for P2poolStatusMonitor {
-    async fn check_health(&self) -> bool {
+    async fn check_health(&self) -> HealthStatus {
         match self.stats_client.stats().await {
-            Ok(_) => true,
-            Err(_) => false,
+            Ok(_) => HealthStatus::Healthy,
+            Err(_) => HealthStatus::Unhealthy,
         }
     }
 }

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -130,6 +130,8 @@ impl P2poolManager {
                 sleep(Duration::from_secs(5)).await;
                 if let Ok(_stats) = status_monitor.status().await {
                     break;
+                } else {
+                    warn!(target: LOG_TARGET, "P2pool stats not available yet");
                 }
             } // wait until we have stats from p2pool, so its started
         }

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -122,7 +122,13 @@ impl P2poolManager {
         }
         process_watcher.adapter.config = Some(config);
         process_watcher
-            .start(app_shutdown, base_path, config_path, log_path)
+            .start(
+                app_shutdown,
+                base_path,
+                config_path,
+                log_path,
+                crate::binaries::Binaries::ShaP2pool,
+            )
             .await?;
         process_watcher.wait_ready().await?;
         if let Some(status_monitor) = &process_watcher.status_monitor {

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -70,9 +70,8 @@ pub(crate) trait ProcessAdapter {
 }
 
 #[async_trait]
-pub(crate) trait StatusMonitor {
-    type Status;
-    async fn status(&self) -> Result<Self::Status, anyhow::Error>;
+pub(crate) trait StatusMonitor: Clone + Send + 'static {
+    async fn check_health(&self) -> bool;
 }
 
 pub(crate) struct ProcessInstance {

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -3,13 +3,16 @@ use async_trait::async_trait;
 use log::{error, info, warn};
 use sentry::protocol::Event;
 use sentry_tauri::sentry;
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use tari_shutdown::Shutdown;
 use tokio::runtime::Handle;
+use tokio::select;
 use tokio::task::JoinHandle;
 
 use crate::process_killer::kill_process;
+use crate::process_utils::launch_child_process;
 
 const LOG_TARGET: &str = "tari::universe::process_adapter";
 
@@ -22,6 +25,7 @@ pub(crate) trait ProcessAdapter {
         base_folder: PathBuf,
         config_folder: PathBuf,
         log_folder: PathBuf,
+        binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), anyhow::Error>;
     fn name(&self) -> &str;
 
@@ -30,8 +34,9 @@ pub(crate) trait ProcessAdapter {
         base_folder: PathBuf,
         config_folder: PathBuf,
         log_folder: PathBuf,
+        binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), anyhow::Error> {
-        self.spawn_inner(base_folder, config_folder, log_folder)
+        self.spawn_inner(base_folder, config_folder, log_folder, binary_version_path)
     }
 
     fn pid_file_name(&self) -> &str;
@@ -74,9 +79,20 @@ pub(crate) trait StatusMonitor: Clone + Send + 'static {
     async fn check_health(&self) -> bool;
 }
 
+#[derive(Clone)]
+pub(crate) struct ProcessStartupSpec {
+    pub file_path: PathBuf,
+    pub envs: Option<HashMap<String, String>>,
+    pub args: Vec<String>,
+    pub pid_file_name: String,
+    pub data_dir: PathBuf,
+    pub name: String,
+}
+
 pub(crate) struct ProcessInstance {
     pub shutdown: Shutdown,
     pub handle: Option<JoinHandle<Result<i32, anyhow::Error>>>,
+    pub startup_spec: ProcessStartupSpec,
 }
 
 impl ProcessInstance {
@@ -85,6 +101,56 @@ impl ProcessInstance {
             .as_ref()
             .map(|m| !m.is_finished())
             .unwrap_or_else(|| false)
+    }
+
+    pub async fn start(&mut self) -> Result<(), anyhow::Error> {
+        if self.handle.is_some() {
+            warn!(target: LOG_TARGET, "Process is already running");
+            return Ok(());
+        }
+        let spec = self.startup_spec.clone();
+        let shutdown_signal = self.shutdown.to_signal();
+        self.handle = Some(tokio::spawn(async move {
+            crate::download_utils::set_permissions(&spec.file_path).await?;
+            // start
+            let mut child = launch_child_process(&spec.file_path, spec.envs.as_ref(), &spec.args)?;
+
+            if let Some(id) = child.id() {
+                fs::write(
+                    spec.data_dir.join(spec.pid_file_name.clone()),
+                    id.to_string(),
+                )?;
+            }
+            let exit_code;
+
+            select! {
+                _res = shutdown_signal =>{
+                    child.kill().await?;
+                    exit_code = 0;
+                    // res
+                },
+                res2 = child.wait() => {
+                    match res2
+                     {
+                        Ok(res) => {
+                            exit_code = res.code().unwrap_or(0)
+                            },
+                        Err(e) => {
+                            warn!(target: LOG_TARGET, "Error in process instance {}:  {}", spec.name, e);
+                            return Err(e.into());
+                        }
+                    }
+                },
+            };
+            info!(target: LOG_TARGET, "Stopping {} node", spec.name);
+
+            if let Err(error) = fs::remove_file(spec.data_dir.join(spec.pid_file_name)) {
+                warn!(target: LOG_TARGET, "Could not clear {}'s pid file: {:?}", spec.name, error);
+            }
+
+            Ok(exit_code)
+        }));
+        Ok(())
     }
 
     pub async fn stop(&mut self) -> Result<i32, anyhow::Error> {

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -21,7 +21,7 @@ pub fn launch_child_process(
         Ok(tokio::process::Command::new(file_path)
             .args(args)
             .envs(envs.unwrap_or_default())
-            .stdout(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)
             .creation_flags(PROCESS_CREATION_NO_WINDOW)

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 
 pub fn launch_child_process(
     file_path: &Path,
-    envs: Option<std::collections::HashMap<String, String>>,
+    envs: Option<&std::collections::HashMap<String, String>>,
     args: &[String],
 ) -> Result<tokio::process::Child, anyhow::Error> {
     #[cfg(not(target_os = "windows"))]
     {
         Ok(tokio::process::Command::new(file_path)
             .args(args)
-            .envs(envs.unwrap_or_default())
+            .envs(envs.cloned().unwrap_or_default())
             .stdout(std::process::Stdio::null()) // TODO: uncomment, only for testing
             .stderr(std::process::Stdio::piped()) // TODO: uncomment, only for testing
             .kill_on_drop(true)
@@ -20,7 +20,7 @@ pub fn launch_child_process(
         use crate::consts::PROCESS_CREATION_NO_WINDOW;
         Ok(tokio::process::Command::new(file_path)
             .args(args)
-            .envs(envs.unwrap_or_default())
+            .envs(envs.cloned().unwrap_or_default())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -1,9 +1,10 @@
-use crate::process_adapter::ProcessAdapter;
+use crate::process_adapter::{ProcessAdapter, StatusMonitor};
 use log::{debug, error, info, warn};
 use std::path::PathBuf;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tauri::async_runtime::JoinHandle;
 use tokio::select;
+use tokio::time::timeout;
 use tokio::time::MissedTickBehavior;
 
 const LOG_TARGET: &str = "tari::universe::process_watcher";
@@ -12,6 +13,7 @@ pub struct ProcessWatcher<TAdapter: ProcessAdapter> {
     watcher_task: Option<JoinHandle<Result<i32, anyhow::Error>>>,
     internal_shutdown: Shutdown,
     poll_time: tokio::time::Duration,
+    health_timeout: tokio::time::Duration,
     pub(crate) status_monitor: Option<TAdapter::StatusMonitor>,
 }
 
@@ -21,7 +23,8 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
             adapter,
             watcher_task: None,
             internal_shutdown: Shutdown::new(),
-            poll_time: tokio::time::Duration::from_secs(1),
+            poll_time: tokio::time::Duration::from_secs(5),
+            health_timeout: tokio::time::Duration::from_secs(4),
             status_monitor: None,
         }
     }
@@ -55,8 +58,10 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
         let mut inner_shutdown = self.internal_shutdown.to_signal();
 
         let poll_time = self.poll_time;
+        let health_timeout = self.health_timeout;
 
         let (mut child, status_monitor) = self.adapter.spawn(base_path, config_path, log_path)?;
+        let status_monitor2 = status_monitor.clone();
         self.status_monitor = Some(status_monitor);
 
         let mut app_shutdown = app_shutdown.clone();
@@ -68,9 +73,21 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
             loop {
                 select! {
                       _ = watch_timer.tick() => {
+                            let mut is_healthy = false;
+
                             if child.ping() {
-                            } else {
-                               debug!(target: LOG_TARGET, "{} is not running", name);
+                                if let Ok(inner) = timeout(health_timeout, status_monitor2.check_health()).await.inspect_err(|e|
+                                error!(target: LOG_TARGET, "{} is not healthy: health check timed out", name)) {
+                                            if inner {
+                                                is_healthy = true;
+                                            }
+                                            else {
+                                                error!(target: LOG_TARGET, "{} is not healthy. Health check returned false", name);
+                                            }
+                                    }
+                            }
+
+                            if !is_healthy {
                                match child.stop().await {
                                    Ok(exit_code) => {
                                       if exit_code != 0 {

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -313,6 +313,7 @@ async fn validate_jwt(airdrop_access_token: Arc<RwLock<Option<String>>>) -> Opti
     })
 }
 
+#[allow(clippy::too_many_lines)]
 async fn get_telemetry_data(
     cpu_miner: Arc<RwLock<CpuMiner>>,
     gpu_miner: Arc<RwLock<GpuMiner>>,

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -128,13 +128,13 @@ impl ProcessAdapter for TorAdapter {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct TorStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for TorStatusMonitor {
-    type Status = ();
-
-    async fn status(&self) -> Result<Self::Status, Error> {
-        todo!()
+    async fn check_health(&self) -> bool {
+        // TODO: Implement health check
+        true
     }
 }

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -8,7 +8,9 @@ use tokio::{runtime::Handle, select};
 
 use crate::{
     binaries::{Binaries, BinaryResolver},
-    process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor},
+    process_adapter::{
+        HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
+    },
     process_utils,
     utils::file_utils::convert_to_string,
 };
@@ -99,8 +101,8 @@ pub(crate) struct TorStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for TorStatusMonitor {
-    async fn check_health(&self) -> bool {
+    async fn check_health(&self) -> HealthStatus {
         // TODO: Implement health check
-        true
+        HealthStatus::Healthy
     }
 }

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -45,7 +45,6 @@ impl ProcessAdapter for TorAdapter {
         binary_version_path: PathBuf,
     ) -> Result<(ProcessInstance, Self::StatusMonitor), Error> {
         let inner_shutdown = Shutdown::new();
-        let shutdown_signal = inner_shutdown.to_signal();
 
         info!(target: LOG_TARGET, "Starting tor");
         let working_dir: PathBuf = data_dir.join("tor-data");

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -37,7 +37,13 @@ impl TorManager {
         {
             let mut process_watcher = self.watcher.write().await;
             process_watcher
-                .start(app_shutdown, base_path, config_path, log_path)
+                .start(
+                    app_shutdown,
+                    base_path,
+                    config_path,
+                    log_path,
+                    crate::binaries::Binaries::Tor,
+                )
                 .await?;
         }
         self.wait_ready().await?;

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -1,5 +1,7 @@
 use crate::binaries::{Binaries, BinaryResolver};
-use crate::process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor};
+use crate::process_adapter::{
+    HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
+};
 use crate::process_utils;
 use crate::utils::file_utils::convert_to_string;
 use anyhow::Error;
@@ -165,8 +167,12 @@ pub struct WalletStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for WalletStatusMonitor {
-    async fn check_health(&self) -> bool {
-        self.get_balance().await.is_ok()
+    async fn check_health(&self) -> HealthStatus {
+        if self.get_balance().await.is_ok() {
+            HealthStatus::Healthy
+        } else {
+            HealthStatus::Unhealthy
+        }
     }
 }
 

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -63,7 +63,13 @@ impl WalletManager {
         process_watcher.adapter.base_node_address =
             Some(format!("/ip4/127.0.0.1/tcp/{}", base_node_tcp_port));
         process_watcher
-            .start(app_shutdown, base_path, config_path, log_path)
+            .start(
+                app_shutdown,
+                base_path,
+                config_path,
+                log_path,
+                crate::binaries::Binaries::Wallet,
+            )
             .await?;
         process_watcher.wait_ready().await?;
         Ok(())

--- a/src-tauri/src/xmrig/http_api/mod.rs
+++ b/src-tauri/src/xmrig/http_api/mod.rs
@@ -1,7 +1,8 @@
-mod models;
+pub mod models;
 use log::{debug, error};
 const LOG_TARGET: &str = "tari::universe::xmrig::http_api";
 
+#[derive(Debug, Clone)]
 pub struct XmrigHttpApiClient {
     url: String,
     access_token: String,

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -151,13 +151,13 @@ impl ProcessAdapter for XmrigAdapter {
     }
 }
 
+#[derive(Clone)]
 pub struct XmrigStatusMonitor {}
 
 #[async_trait]
 impl StatusMonitor for XmrigStatusMonitor {
-    type Status = ();
-
-    async fn status(&self) -> Result<Self::Status, Error> {
-        todo!()
+    async fn check_health(&self) -> bool {
+        // TODO: Connect this to actual stats
+        true
     }
 }

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -7,9 +7,11 @@ use log::warn;
 use tari_shutdown::Shutdown;
 use tokio::runtime::Handle;
 
-use crate::process_adapter::{ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor};
-use crate::process_utils;
+use crate::process_adapter::{
+    HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
+};
 use crate::xmrig::http_api::XmrigHttpApiClient;
+use crate::{process_utils, xmrig};
 
 const LOG_TARGET: &str = "tari::universe::xmrig_adapter";
 
@@ -37,29 +39,25 @@ impl XmrigNodeConnection {
 }
 
 pub struct XmrigAdapter {
-    node_connection: XmrigNodeConnection,
-    monero_address: String,
-    http_api_token: String,
-    http_api_port: u16,
-    cpu_max_percentage: isize,
+    pub node_connection: Option<XmrigNodeConnection>,
+    pub monero_address: Option<String>,
+    pub http_api_token: String,
+    pub http_api_port: u16,
+    pub cpu_max_percentage: Option<isize>,
     pub client: XmrigHttpApiClient,
     // TODO: secure
 }
 
 impl XmrigAdapter {
-    pub fn new(
-        xmrig_node_connection: XmrigNodeConnection,
-        monero_address: String,
-        cpu_max_percentage: isize,
-    ) -> Self {
+    pub fn new() -> Self {
         let http_api_port = 9090;
         let http_api_token = "pass".to_string();
         Self {
-            node_connection: xmrig_node_connection,
-            monero_address,
+            node_connection: None,
+            monero_address: None,
             http_api_token: http_api_token.clone(),
             http_api_port,
-            cpu_max_percentage,
+            cpu_max_percentage: None,
             client: XmrigHttpApiClient::new(
                 format!("http://127.0.0.1:{}", http_api_port).clone(),
                 http_api_token.clone(),
@@ -81,8 +79,11 @@ impl ProcessAdapter for XmrigAdapter {
         self.kill_previous_instances(data_dir.clone())?;
 
         let xmrig_shutdown = Shutdown::new();
-        let mut shutdown_signal = xmrig_shutdown.to_signal();
-        let mut args = self.node_connection.generate_args();
+        let mut args = self
+            .node_connection
+            .as_ref()
+            .ok_or(anyhow::anyhow!("Node connection not set"))?
+            .generate_args();
         let xmrig_log_file = log_dir.join("xmrig.log");
 
         let xmrig_log_file_parent = xmrig_log_file
@@ -106,8 +107,17 @@ impl ProcessAdapter for XmrigAdapter {
         args.push(format!("--http-port={}", self.http_api_port));
         args.push(format!("--http-access-token={}", self.http_api_token));
         args.push("--donate-level=1".to_string());
-        args.push(format!("--user={}", self.monero_address));
-        args.push(format!("--threads={}", self.cpu_max_percentage));
+        args.push(format!(
+            "--user={}",
+            self.monero_address
+                .as_ref()
+                .ok_or(anyhow::anyhow!("Monero address not set"))?
+        ));
+        args.push(format!(
+            "--threads={}",
+            self.cpu_max_percentage
+                .ok_or(anyhow::anyhow!("CPU max percentage not set"))?
+        ));
         args.push("--verbose".to_string());
 
         Ok((
@@ -123,7 +133,12 @@ impl ProcessAdapter for XmrigAdapter {
                     name: self.name().to_string(),
                 },
             },
-            XmrigStatusMonitor {},
+            XmrigStatusMonitor {
+                client: XmrigHttpApiClient::new(
+                    format!("http://127.0.0.1:{}", self.http_api_port),
+                    self.http_api_token.clone(),
+                ),
+            },
         ))
     }
 
@@ -137,12 +152,20 @@ impl ProcessAdapter for XmrigAdapter {
 }
 
 #[derive(Clone)]
-pub struct XmrigStatusMonitor {}
+pub struct XmrigStatusMonitor {
+    client: XmrigHttpApiClient,
+}
 
 #[async_trait]
 impl StatusMonitor for XmrigStatusMonitor {
-    async fn check_health(&self) -> bool {
+    async fn check_health(&self) -> HealthStatus {
         // TODO: Connect this to actual stats
-        true
+        HealthStatus::Healthy
+    }
+}
+
+impl XmrigStatusMonitor {
+    pub async fn summary(&self) -> Result<xmrig::http_api::models::Summary, Error> {
+        self.client.summary().await
     }
 }

--- a/src/containers/Settings/ExperimentalSettings.tsx
+++ b/src/containers/Settings/ExperimentalSettings.tsx
@@ -31,7 +31,7 @@ export const ExperimentalSettings = () => {
                     {showExperimental && (
                         <>
                             <P2pMarkup />
-                            <P2poolStatsMarkup />
+                            {/* <P2poolStatsMarkup /> */}
                             <GpuDevices />
                             <DebugSettings />
                             <AppVersions />

--- a/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
@@ -46,11 +46,11 @@ const P2PoolStats = () => {
                         labels={[
                             {
                                 labelText: 'Address',
-                                labelValue: p2poolStats.connection_info?.listener_addresses.join(', ') || '',
+                                labelValue: p2poolStats?.connection_info?.listener_addresses.join(', ') || '',
                             },
                             {
                                 labelText: 'Connected peers',
-                                labelValue: '' + (p2poolStats.connection_info?.connected_peers ?? 0),
+                                labelValue: '' + (p2poolStats?.connection_info?.connected_peers ?? 0),
                             },
                         ]}
                     />
@@ -61,7 +61,7 @@ const P2PoolStats = () => {
                         labels={[
                             {
                                 labelText: 'Connected',
-                                labelValue: p2poolStats.connected ? 'Yes' : 'No',
+                                labelValue: p2poolStats?.connected ? 'Yes' : 'No',
                             },
                         ]}
                     />
@@ -70,34 +70,34 @@ const P2PoolStats = () => {
                         labels={[
                             {
                                 labelText: 'Num Peers',
-                                labelValue: '' + (p2poolStats.connection_info?.network_info.num_peers ?? 0),
+                                labelValue: '' + (p2poolStats?.connection_info?.network_info.num_peers ?? 0),
                             },
                             {
                                 labelText: 'Pending incoming',
                                 labelValue:
                                     '' +
-                                    (p2poolStats.connection_info?.network_info.connection_counters.pending_incoming ??
+                                    (p2poolStats?.connection_info?.network_info.connection_counters.pending_incoming ??
                                         0),
                             },
                             {
                                 labelText: 'Pending outgoing',
                                 labelValue:
                                     '' +
-                                    (p2poolStats.connection_info?.network_info.connection_counters.pending_outgoing ??
+                                    (p2poolStats?.connection_info?.network_info.connection_counters.pending_outgoing ??
                                         0),
                             },
                             {
                                 labelText: 'Established incoming',
                                 labelValue:
                                     '' +
-                                    (p2poolStats.connection_info?.network_info.connection_counters
+                                    (p2poolStats?.connection_info?.network_info.connection_counters
                                         .established_incoming ?? 0),
                             },
                             {
                                 labelText: 'Established outgoing',
                                 labelValue:
                                     '' +
-                                    (p2poolStats.connection_info?.network_info.connection_counters
+                                    (p2poolStats?.connection_info?.network_info.connection_counters
                                         .established_outgoing ?? 0),
                             },
                         ]}

--- a/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/P2poolStatsMarkup.tsx
@@ -23,20 +23,18 @@ const P2PoolStats = () => {
     const p2poolRandomxChainTip = p2poolRandomXStats?.share_chain_height;
 
     useEffect(() => {
-        if (isP2poolEnabled) {
-            const fetchP2pStatsInterval = setInterval(async () => {
-                try {
-                    await fetchP2pStats();
-                } catch (error) {
-                    console.error('Error fetching p2pool stats:', error);
-                }
-            }, 5000);
+        const fetchP2pStatsInterval = setInterval(async () => {
+            try {
+                await fetchP2pStats();
+            } catch (error) {
+                console.error('Error fetching p2pool stats:', error);
+            }
+        }, 5000);
 
-            return () => {
-                clearInterval(fetchP2pStatsInterval);
-            };
-        }
-    }, [fetchP2pStats, isP2poolEnabled]);
+        return () => {
+            clearInterval(fetchP2pStatsInterval);
+        };
+    }, [fetchP2pStats]);
 
     return isP2poolEnabled ? (
         <SettingsGroupWrapper>

--- a/src/store/useP2poolStatsStore.ts
+++ b/src/store/useP2poolStatsStore.ts
@@ -1,11 +1,12 @@
 import { invoke } from '@tauri-apps/api';
 import { create } from './create';
-import { P2poolStatsResult } from '../types/app-status.ts';
+import { P2poolConnectionInfo, P2poolStats, P2poolStatsResult } from '../types/app-status.ts';
 
 type State = Partial<P2poolStatsResult>;
 
 interface Actions {
-    set?: P2poolStatsResult;
+    randomx_stats?: P2poolStats;
+    sha3x_stats?: P2poolStats;
     fetchP2poolStats: () => Promise<void>;
 }
 


### PR DESCRIPTION
* added a check for each service if it is healthy or not, and if it is bad, will restart it. This is mainly because p2pool gets into a state where it pauses for long times.
* Updated p2pool to latest version with many improvements. 
* Hiding p2pool stats for now as they are always going to be zero
* updated to latest gpu miner, mostly with improved stats
* added timeouts on calls to gpu miner
* Increased eco mode on gpu
