### PR TITLE
chore(logging): optimize logging and initialization

### DIFF
--- a/src-tauri/src/hardware_monitor.rs
+++ b/src-tauri/src/hardware_monitor.rs
@@ -1,7 +1,7 @@
 use std::{fs, ops::Deref, path::PathBuf, sync::LazyLock};
 
 use anyhow::anyhow;
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use nvml_wrapper::{enum_wrappers::device::TemperatureSensor, Nvml};
 use serde::{Deserialize, Serialize};
 use sysinfo::{Component, Components, CpuRefreshKind, RefreshKind, System};
@@ -156,7 +156,7 @@ impl HardwareMonitor {
     pub fn load_status_file(&mut self, config_path: PathBuf) -> Result<(), anyhow::Error> {
         match self.current_implementation.load_status_file(config_path) {
             Ok(_) => {
-                debug!(target: LOG_TARGET, "Gpu status file loaded successfully");
+                trace!(target: LOG_TARGET, "Gpu status file loaded successfully");
                 Ok(())
             }
             Err(e) => Err(anyhow!("Fail to load gpu status file: {:?}", e)),
@@ -303,7 +303,7 @@ impl HardwareMonitorImpl for WindowsHardwareMonitor {
         let file: PathBuf = config_path.join("gpuminer").join("gpu_status.json");
         if file.exists() {
             self.gpu_status_file = Some(file.clone());
-            debug!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
+            trace!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
         } else {
             debug!(target: LOG_TARGET, "Gpu status file does not exist or is corrupt");
         }
@@ -477,7 +477,7 @@ impl HardwareMonitorImpl for LinuxHardwareMonitor {
         let file: PathBuf = config_path.join("gpuminer").join("gpu_status.json");
         if file.exists() {
             self.gpu_status_file = Some(file.clone());
-            debug!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
+            trace!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
         } else {
             debug!(target: LOG_TARGET, "Gpu status file does not exist or is corrupt");
         }
@@ -635,7 +635,7 @@ impl HardwareMonitorImpl for MacOSHardwareMonitor {
         let file: PathBuf = config_path.join("gpuminer").join("gpu_status.json");
         if file.exists() {
             self.gpu_status_file = Some(file.clone());
-            debug!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
+            trace!(target: LOG_TARGET, "Loading gpu status from file: {:?}", file);
         } else {
             debug!(target: LOG_TARGET, "Gpu status file does not exist or is corrupt");
         }

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -296,6 +296,7 @@ impl MinotariNodeStatusMonitor {
         let mut client =
             BaseNodeGrpcClient::connect(format!("http://127.0.0.1:{}", self.grpc_port)).await?;
 
+        let mut last_state: Option<i32> = None;
         loop {
             if self.shutdown_signal.is_triggered() {
                 break;
@@ -308,72 +309,77 @@ impl MinotariNodeStatusMonitor {
                 break;
             }
 
-            if sync_progress.state == SyncState::Startup as i32 {
-                progress_tracker
-                    .update(
-                        "preparing-for-initial-sync".to_string(),
-                        Some(HashMap::from([
-                            (
-                                "initial_connected_peers".to_string(),
-                                sync_progress.initial_connected_peers.to_string(),
-                            ),
-                            (
-                                "required_peers".to_string(),
-                                self.required_sync_peers.to_string(),
-                            ),
-                        ])),
-                        10,
-                    )
-                    .await;
-            } else if sync_progress.state == SyncState::Header as i32 {
-                let progress = if sync_progress.tip_height == 0 {
-                    10
-                } else {
-                    10 + (30 * sync_progress.local_height / sync_progress.tip_height)
-                };
+            let current_state = sync_progress.state;
+            if last_state.is_none() || last_state != Some(current_state) {
+                last_state = Some(current_state);
+                if sync_progress.state == SyncState::Startup as i32 {
+                    progress_tracker
+                        .update(
+                            "preparing-for-initial-sync".to_string(),
+                            Some(HashMap::from([
+                                (
+                                    "initial_connected_peers".to_string(),
+                                    sync_progress.initial_connected_peers.to_string(),
+                                ),
+                                (
+                                    "required_peers".to_string(),
+                                    self.required_sync_peers.to_string(),
+                                ),
+                            ])),
+                            10,
+                        )
+                        .await;
+                } else if sync_progress.state == SyncState::Header as i32 {
+                    let progress = if sync_progress.tip_height == 0 {
+                        10
+                    } else {
+                        10 + (30 * sync_progress.local_height / sync_progress.tip_height)
+                    };
 
-                progress_tracker
-                    .update(
-                        "waiting-for-header-sync".to_string(),
-                        Some(HashMap::from([
-                            (
-                                "local_height".to_string(),
-                                sync_progress.local_height.to_string(),
-                            ),
-                            (
-                                "tip_height".to_string(),
-                                sync_progress.tip_height.to_string(),
-                            ),
-                        ])),
-                        progress,
-                    )
-                    .await;
-            } else if sync_progress.state == SyncState::Block as i32 {
-                let progress = if sync_progress.tip_height == 0 {
-                    40
-                } else {
-                    40 + (60 * sync_progress.local_height / sync_progress.tip_height)
-                };
+                    progress_tracker
+                        .update(
+                            "waiting-for-header-sync".to_string(),
+                            Some(HashMap::from([
+                                (
+                                    "local_height".to_string(),
+                                    sync_progress.local_height.to_string(),
+                                ),
+                                (
+                                    "tip_height".to_string(),
+                                    sync_progress.tip_height.to_string(),
+                                ),
+                            ])),
+                            progress,
+                        )
+                        .await;
+                } else if sync_progress.state == SyncState::Block as i32 {
+                    let progress = if sync_progress.tip_height == 0 {
+                        40
+                    } else {
+                        40 + (60 * sync_progress.local_height / sync_progress.tip_height)
+                    };
 
-                progress_tracker
-                    .update(
-                        "waiting-for-block-sync".to_string(),
-                        Some(HashMap::from([
-                            (
-                                "local_height".to_string(),
-                                sync_progress.local_height.to_string(),
-                            ),
-                            (
-                                "tip_height".to_string(),
-                                sync_progress.tip_height.to_string(),
-                            ),
-                        ])),
-                        progress,
-                    )
-                    .await;
-            } else {
-                //do nothing
+                    progress_tracker
+                        .update(
+                            "waiting-for-block-sync".to_string(),
+                            Some(HashMap::from([
+                                (
+                                    "local_height".to_string(),
+                                    sync_progress.local_height.to_string(),
+                                ),
+                                (
+                                    "tip_height".to_string(),
+                                    sync_progress.tip_height.to_string(),
+                                ),
+                            ])),
+                            progress,
+                        )
+                        .await;
+                } else {
+                    //do nothing
+                }
             }
+
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         }
         Ok(())

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -572,7 +572,7 @@ where
                         e
                     ));
                 } else {
-                    warn!(target: LOG_TARGET, "Retrying {} as it failed due to failure: {:?}", operation_name, e);
+                    warn!(target: LOG_TARGET, "Retrying {} due to failure: {:?}", operation_name, e);
                 }
             }
         }

--- a/src-tauri/src/utils/auto_rollback.rs
+++ b/src-tauri/src/utils/auto_rollback.rs
@@ -1,0 +1,48 @@
+use std::sync::{Arc, Mutex};
+use tokio::time::{sleep, Duration};
+
+#[derive(Debug)]
+pub struct AutoRollback<T> {
+    value: Arc<Mutex<T>>,
+    initial_value: T,
+}
+
+impl<T> AutoRollback<T>
+where
+    T: Clone + Send + 'static,
+{
+    pub fn new(value: T) -> Self {
+        AutoRollback {
+            value: Arc::new(Mutex::new(value.clone())),
+            initial_value: value,
+        }
+    }
+
+    pub async fn set_value(&self, new_value: T, rollback_delay: Duration) {
+        // Update the value
+        {
+            let mut val = self.value.lock().unwrap();
+            *val = new_value;
+        }
+
+        // Spawn a task that will rollback the value after the delay
+        let value_clone = Arc::clone(&self.value);
+        let initial_value = self.initial_value.clone();
+        tokio::spawn(async move {
+            sleep(rollback_delay).await;
+
+            println!("Rollback finished after {:?}", rollback_delay);
+            // Rollback to the initial value
+            let mut val = value_clone.lock().unwrap();
+            *val = initial_value;
+        });
+    }
+
+    pub fn get_value(&self) -> T
+    where
+        T: Clone,
+    {
+        let val = self.value.lock().unwrap();
+        val.clone()
+    }
+}

--- a/src-tauri/src/utils/auto_rollback.rs
+++ b/src-tauri/src/utils/auto_rollback.rs
@@ -21,8 +21,9 @@ where
     pub async fn set_value(&self, new_value: T, rollback_delay: Duration) {
         // Update the value
         {
-            let mut val = self.value.lock().unwrap();
-            *val = new_value;
+            if let Ok(mut val) = self.value.lock() {
+                *val = new_value;
+            }
         }
 
         // Spawn a task that will rollback the value after the delay
@@ -33,8 +34,9 @@ where
 
             println!("Rollback finished after {:?}", rollback_delay);
             // Rollback to the initial value
-            let mut val = value_clone.lock().unwrap();
-            *val = initial_value;
+            if let Ok(mut val) = value_clone.lock() {
+                *val = initial_value;
+            };
         });
     }
 
@@ -42,7 +44,10 @@ where
     where
         T: Clone,
     {
-        let val = self.value.lock().unwrap();
-        val.clone()
+        if let Ok(val) = self.value.lock() {
+            val.clone()
+        } else {
+            self.initial_value.clone()
+        }
     }
 }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,2 +1,2 @@
-pub mod file_utils;
 pub mod auto_rollback;
+pub mod file_utils;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod file_utils;
+pub mod auto_rollback;


### PR DESCRIPTION
Description
---
The frontend was controlling the application initialization process, which means we got caught with some lifecycle issues where a useEffect hook was triggering the `setup_application` invocation multiple times. I added a little debounce mechanism to the call.
We had unnecessary logging, moved some to trace as well as only emit a log if a state has changed.


Motivation and Context
---
The logs were overflowing with useless information. This just streamlines it a little.
The app was needlessly resetting the application state.

How Has This Been Tested?
---
I ran the app, the logs are cleaner and there is less duplication of initialization.

What process can a PR reviewer use to test or verify this change?
---
Run the app, make sure nothing is broken.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
