### PR TITLE
fix(wallet): import seed words on windows

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -905,7 +905,7 @@ async fn set_gpu_mining_enabled(
 async fn import_seed_words(
     seed_words: Vec<String>,
     _window: tauri::Window,
-    _state: tauri::State<'_, UniverseAppState>,
+    state: tauri::State<'_, UniverseAppState>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     let timer = Instant::now();
@@ -917,6 +917,8 @@ async fn import_seed_words(
         .path_resolver()
         .app_local_data_dir()
         .expect("Could not get data dir");
+
+    stop_all_miners(state.inner().clone(), 5).await?;
 
     tauri::async_runtime::spawn(async move {
         match InternalWallet::create_from_seed(config_path, seed_words).await {


### PR DESCRIPTION
An issue was that `InternalWallet::clear_wallet_local_data` was trying to remove cache wallet dir which was opened. I fix it by calling `stop_all_miners` before that action. 