### PR TITLE
fix(tor): cdn_tor_bundle_url value moved

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.42"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"] }
+tauri-build = {version = "1.5.5", features = ["isolation"]}
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"] }
+async_zip = {version = "0.0.17", features = ["full"]}
 auto-launch = "0.5.0"
 blake2 = "0.10"
 chrono = "0.4.38"
@@ -29,26 +29,26 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-] }
+]}
 libsqlite3-sys = {version = "0.25.1", features = [
   "bundled",
-] }# Required for tari_wallet
+]}# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"] }
+nix = {version = "0.29.0", features = ["signal"]}
 nvml-wrapper = "0.10.0"
 open = "5"
 phraze = "0.3.15"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
 sanitize-filename = "0.5"
 semver = "1.0.23"
-sentry = {version = "0.34.0", features = ["anyhow"] }
+sentry = {version = "0.34.0", features = ["anyhow"]}
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -58,7 +58,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-] }
+]}
 tari_crypto = "0.20.3"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -78,13 +78,13 @@ tauri = {version = "1.8.0", features = [
   "isolation",
   "shell-open",
   "process-command-api",
-] }
+]}
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"] }
-tokio-util = {version = "0.7.11", features = ["compat"] }
+tokio = {version = "1", features = ["full"]}
+tokio-util = {version = "0.7.11", features = ["compat"]}
 tor-hash-passwd = "1.0.1"
-xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
+xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -93,7 +93,7 @@ winreg = "0.52.0"
 # needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.42"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"]}
+tauri-build = {version = "1.5.5", features = ["isolation"] }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"]}
+async_zip = {version = "0.0.17", features = ["full"] }
 auto-launch = "0.5.0"
 blake2 = "0.10"
 chrono = "0.4.38"
@@ -29,26 +29,26 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-]}
+] }
 libsqlite3-sys = {version = "0.25.1", features = [
   "bundled",
-]}# Required for tari_wallet
+] }# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"]}
+nix = {version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 phraze = "0.3.15"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
-sentry = {version = "0.34.0", features = ["anyhow"]}
+sentry = {version = "0.34.0", features = ["anyhow"] }
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"]}
+serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -58,7 +58,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-]}
+] }
 tari_crypto = "0.20.3"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -78,13 +78,13 @@ tauri = {version = "1.8.0", features = [
   "isolation",
   "shell-open",
   "process-command-api",
-]}
+] }
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"]}
-tokio-util = {version = "0.7.11", features = ["compat"]}
+tokio = {version = "1", features = ["full"] }
+tokio-util = {version = "0.7.11", features = ["compat"] }
 tor-hash-passwd = "1.0.1"
-xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
+xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -93,7 +93,7 @@ winreg = "0.52.0"
 # needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"

--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -26,7 +26,8 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
 
         let client = reqwest::Client::new();
         for _ in 0..3 {
-            let response = client.head(cdn_tor_bundle_url).send().await;
+            let cloned_cdn_tor_bundle_url = cdn_tor_bundle_url.clone();
+            let response = client.head(cloned_cdn_tor_bundle_url).send().await;
 
             if let Ok(resp) = response {
                 if resp.status().is_success() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1183,7 +1183,7 @@ async fn fetch_tor_bridges() -> Result<Vec<String>, String> {
         .await
         .map_err(|e| e.to_string())?;
 
-    let re = Regex::new(r"obfs4.*?<br\/>").unwrap();
+    let re = Regex::new(r"obfs4.*?<br\/>").map_err(|e| e.to_string())?;
     let bridges: Vec<String> = re
         .find_iter(&res_html)
         .map(|m| m.as_str().trim_end_matches(" <br/>").to_string())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,6 @@
 use ::sentry::integrations::anyhow::capture_anyhow;
 use auto_launcher::AutoLauncher;
 use external_dependencies::{ExternalDependencies, ExternalDependency, RequiredExternalDependency};
-use futures_util::future::Join;
 use log::trace;
 use log::{debug, error, info, warn};
 use regex::Regex;

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use anyhow::Error;
 use async_trait::async_trait;
-use dirs_next::data_local_dir;
 use log::{info, warn};
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -56,7 +56,7 @@ impl TorAdapter {
     }
 
     fn apply_loaded_config(&mut self, config: String) {
-        self.config = serde_json::from_str::<TorConfig>(&config).unwrap_or(TorConfig::default());
+        self.config = serde_json::from_str::<TorConfig>(&config).unwrap_or_default();
     }
 
     async fn update_config_file(&mut self) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
```
error[E0382]: use of moved value: `cdn_tor_bundle_url`
  --> src/binaries/adapter_tor.rs:29:40
   |
21 |         let cdn_tor_bundle_url = format!(
   |             ------------------ move occurs because `cdn_tor_bundle_url` has type `std::string::String`, which does not implement the `Copy` trait
...
28 |         for _ in 0..3 {
   |         ------------- inside of this loop
29 |             let response = client.head(cdn_tor_bundle_url).send().await;
   |                                        ^^^^^^^^^^^^^^^^^^ value moved here, in previous iteration of loop
   |
   ```