### PR TITLE
chore: machete check | remove unused

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2415,12 +2415,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
@@ -3619,7 +3613,7 @@ dependencies = [
  "curve25519-dalek",
  "fixed-hash",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "sealed",
  "serde",
  "thiserror",
@@ -6371,7 +6365,6 @@ dependencies = [
  "blake2",
  "chrono",
  "device_query",
- "dirs-next 2.0.0",
  "dunce",
  "flate2",
  "futures-lite 2.3.0",
@@ -6413,7 +6406,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.12",
- "tor-hash-passwd",
  "winreg 0.52.0",
  "xz2",
  "zip 2.2.0",
@@ -7471,19 +7463,6 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "tor-hash-passwd"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b83cd43a176c0c19d5db4401283e8f5c296b9c6c7fa29029de15cc445f26e12"
-dependencies = [
- "hex",
- "hex-literal 0.3.4",
- "rand 0.8.5",
- "sha1 0.6.0",
- "thiserror",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ auto-launch = "0.5.0"
 blake2 = "0.10"
 chrono = "0.4.38"
 device_query = "2.1.0"
-dirs-next = "2.0.0"
 dunce = "1.0.5"
 flate2 = "1.0.30"
 futures-lite = "2.3.0"
@@ -83,7 +82,6 @@ tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-wor
 thiserror = "1.0.26"
 tokio = {version = "1", features = ["full"]}
 tokio-util = {version = "0.7.11", features = ["compat"]}
-tor-hash-passwd = "1.0.1"
 xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
 zip = "2.2.0"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,6 @@ use external_dependencies::{ExternalDependencies, ExternalDependency, RequiredEx
 use log::trace;
 use log::{debug, error, info, warn};
 use regex::Regex;
-use sentry_tauri::sentry;
 use serde::Serialize;
 use std::fs::{read_dir, remove_dir_all, remove_file};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,6 @@ use external_dependencies::{ExternalDependencies, ExternalDependency, RequiredEx
 use log::trace;
 use log::{debug, error, info, warn};
 use regex::Regex;
-use sentry::protocol::Event;
 use sentry_tauri::sentry;
 use serde::Serialize;
 use std::fs::{read_dir, remove_dir_all, remove_file};


### PR DESCRIPTION
Description
---
- just removed the unused deps machete flagged (they weren't references anywhere but in the cargo.toml)