### PR TITLE
fix(ui): cursor pointer missing on a few buttons

### DIFF
--- a/src/components/GreenModal/styles.ts
+++ b/src/components/GreenModal/styles.ts
@@ -62,6 +62,7 @@ export const BoxWrapper = styled(m.div)<{ $boxWidth?: number }>`
 `;
 
 export const CloseButton = styled('button')`
+    cursor: pointer;
     position: absolute;
     top: -20px;
     left: 100%;
@@ -71,6 +72,7 @@ export const CloseButton = styled('button')`
     transition:
         color 0.2s ease,
         transform 0.2s ease;
+
     &:hover {
         color: #fff;
         transform: scale(1.1);

--- a/src/containers/Airdrop/AirdropGiftTracker/components/ClaimModal/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/components/ClaimModal/styles.ts
@@ -144,6 +144,8 @@ export const ClaimButton = styled('button')`
 
     position: relative;
     font-weight: bold;
+    cursor: pointer;
+
     &:hover {
         transform: scale(1.05);
     }

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Invite/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Invite/styles.ts
@@ -24,6 +24,7 @@ export const InviteButton = styled('button')`
 
     transition: transform 0.2s ease;
     overflow: hidden;
+    cursor: pointer;
 
     svg {
         flex-shrink: 0;

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedOut/styles.ts
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedOut/styles.ts
@@ -24,6 +24,7 @@ export const ClaimButton = styled('button')`
     color: ${({ theme }) => theme.palette.action.background.contrast};
     transition: transform 0.2s ease;
     overflow: hidden;
+    cursor: pointer;
 
     &:hover {
         transform: scale(1.05);

--- a/src/containers/PaperWalletModal/styles.ts
+++ b/src/containers/PaperWalletModal/styles.ts
@@ -16,6 +16,7 @@ export const BlackButton = styled('button')`
     width: 100%;
     height: 81px;
     transition: opacity 0.2s ease;
+    cursor: pointer;
 
     span {
         display: block;

--- a/src/containers/StagedSecurity/components/HelpTip/styles.ts
+++ b/src/containers/StagedSecurity/components/HelpTip/styles.ts
@@ -46,4 +46,5 @@ export const TextButton = styled('button')`
     text-decoration-line: underline;
 
     display: inline-flex;
+    cursor: pointer;
 `;

--- a/src/containers/StagedSecurity/sections/SeedPhrase/styles.ts
+++ b/src/containers/StagedSecurity/sections/SeedPhrase/styles.ts
@@ -87,6 +87,7 @@ export const CopyButton = styled('button')`
     max-width: 566px;
     width: 100%;
     margin: auto;
+    cursor: pointer;
 
     &:hover {
         background: rgba(255, 255, 255, 0.5);

--- a/src/containers/StagedSecurity/styles.ts
+++ b/src/containers/StagedSecurity/styles.ts
@@ -45,6 +45,7 @@ export const BlackButton = styled('button')`
     height: 81px;
 
     transition: opacity 0.2s ease;
+    cursor: pointer;
 
     span {
         display: block;


### PR DESCRIPTION
I noticed that a few buttons were missing the `cursor: pointer` declaration. This must have been part of the global CSS before and was recently changed. Not a bad thing, we just need to be consistant manually adding `cursor: pointer` from now on. 

https://www.loom.com/share/930c501a4a7c45e2be42da03ed11cf71?sid=4294567b-4be0-4671-a5d7-9d2d60c678d8