### PR TITLE
fix(ui): cannot rotate the 3D canvas with mouse drag

### DIFF
--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -19,7 +19,6 @@ export const GlobalReset = createGlobalStyle`
     fieldset,
     textarea,
     dialog,
-    div,
     button,
     input {
         all: unset;

--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -19,7 +19,6 @@ export const GlobalReset = createGlobalStyle`
     fieldset,
     textarea,
     dialog,
-    button,
     input {
         all: unset;
         /* Chrome, Safari, Edge, Opera */


### PR DESCRIPTION
I noticed a bug where the drag events on the 3D canvas element were being blocked. `pointer-events: none` was not being respected in the browser. Looks like this Global `all: unset;` declaration was overwriting the `pointer-events` rule on div elements. 

Removing `div` from this reset fixes the issue. `div` elements should not need a reset like this anyways since they don't really have any default styles to begin with. 

https://www.loom.com/share/ed56286a903d4c98b54745732c66a092?sid=31821a02-5d33-47f6-b803-93149a6d2bb1