### PR TITLE
fix: sentry errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
     "name": "tari-universe",
-    "version": "0.5.51",
+    "version": "0.5.52",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "0.5.51",
+            "version": "0.5.52",
             "dependencies": {
                 "@floating-ui/react": "^0.26.25",
                 "@sentry/react": "^8.35.0",
                 "@tauri-apps/api": "^1",
                 "emoji-regex": "^10.4.0",
-                "framer-motion": "^11.11.9",
+                "framer-motion": "^11.11.10",
                 "globals": "^15.11.0",
-                "i18next": "^23.16.2",
+                "i18next": "^23.16.4",
                 "i18next-browser-languagedetector": "^8.0.0",
                 "i18next-http-backend": "^2.6.2",
                 "linkify-react": "^4.1.3",
@@ -24,7 +24,7 @@
                 "react-hook-form": "^7.53.1",
                 "react-i18next": "^15.1.0",
                 "react-icons": "^5.3.0",
-                "socket.io-client": "^4.8.0",
+                "socket.io-client": "^4.8.1",
                 "styled-components": "^6.1.12",
                 "uuid": "^10.0.0",
                 "vite-tsconfig-paths": "^5.0.1",
@@ -36,7 +36,7 @@
                 "@sentry/vite-plugin": "^2.22.6",
                 "@tauri-apps/cli": "^1.6.3",
                 "@types/eslint__js": "^8.42.3",
-                "@types/node": "^22.7.9",
+                "@types/node": "^22.8.2",
                 "@types/react": "^18.3.12",
                 "@types/react-dom": "^18.3.1",
                 "@types/uuid": "^10.0.0",
@@ -53,7 +53,7 @@
                 "prettier-eslint": "^16.3.0",
                 "react-qr-code": "^2.0.15",
                 "typescript": "^5.6.3",
-                "typescript-eslint": "^8.11.0",
+                "typescript-eslint": "^8.12.1",
                 "vite": "^5.4.10"
             }
         },
@@ -2128,12 +2128,12 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "22.7.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-            "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+            "version": "22.8.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
+            "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
             "dev": true,
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.19.8"
             }
         },
         "node_modules/@types/prop-types": {
@@ -2173,16 +2173,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
-            "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.1.tgz",
+            "integrity": "sha512-gNg/inLRcPoBsKKIe4Vv38SVSOhk4BKWNO0T56sVff33gRqtTpOsrhHtiOKD1lmIOmCtZMPaW2x/h2FlM+sCEg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.11.0",
-                "@typescript-eslint/type-utils": "8.11.0",
-                "@typescript-eslint/utils": "8.11.0",
-                "@typescript-eslint/visitor-keys": "8.11.0",
+                "@typescript-eslint/scope-manager": "8.12.1",
+                "@typescript-eslint/type-utils": "8.12.1",
+                "@typescript-eslint/utils": "8.12.1",
+                "@typescript-eslint/visitor-keys": "8.12.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -2206,15 +2206,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
-            "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.1.tgz",
+            "integrity": "sha512-I/I9Bg7qFa8rOgBnUUHIWTgzbB5wVkSLX+04xGUzTcJUtdq/I2uHWR9mbW6qUYJG/UmkuDcTax5JHvoEWOAHOQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.11.0",
-                "@typescript-eslint/types": "8.11.0",
-                "@typescript-eslint/typescript-estree": "8.11.0",
-                "@typescript-eslint/visitor-keys": "8.11.0",
+                "@typescript-eslint/scope-manager": "8.12.1",
+                "@typescript-eslint/types": "8.12.1",
+                "@typescript-eslint/typescript-estree": "8.12.1",
+                "@typescript-eslint/visitor-keys": "8.12.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2234,13 +2234,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
-            "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.1.tgz",
+            "integrity": "sha512-bma6sD1iViTt+y9MAwDlBdPTMCqoH/BNdcQk4rKhIZWv3eM0xHmzeSrPJA663PAqFqfpOmtdugycpr0E1mZDVA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.11.0",
-                "@typescript-eslint/visitor-keys": "8.11.0"
+                "@typescript-eslint/types": "8.12.1",
+                "@typescript-eslint/visitor-keys": "8.12.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2251,13 +2251,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
-            "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.1.tgz",
+            "integrity": "sha512-zJzrvbDVjIzVKV2TGHcjembEhws8RWXJhmqfO9hS2gRXBN0gDwGhRPEdJ6AZglzfJ+YA1q09EWpSLSXjBJpIMQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.11.0",
-                "@typescript-eslint/utils": "8.11.0",
+                "@typescript-eslint/typescript-estree": "8.12.1",
+                "@typescript-eslint/utils": "8.12.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -2275,9 +2275,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
-            "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.1.tgz",
+            "integrity": "sha512-anMS4es5lxBe4UVcDXOkcDb3csnm5BvaNIbOFfvy/pJEohorsggdVB8MFbl5EZiEuBnZZ0ei1z7W5b6FdFiV1Q==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2288,13 +2288,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
-            "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.1.tgz",
+            "integrity": "sha512-k/o9khHOckPeDXilFTIPsP9iAYhhdMh3OsOL3i2072PNpFqhqzRHx472/0DeC8H/WZee3bZG0z2ddGRSPgeOKw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.11.0",
-                "@typescript-eslint/visitor-keys": "8.11.0",
+                "@typescript-eslint/types": "8.12.1",
+                "@typescript-eslint/visitor-keys": "8.12.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -2316,15 +2316,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
-            "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.1.tgz",
+            "integrity": "sha512-sDv9yFHrhKe1WN8EYuzfhKCh/sFRupe9P+m/lZ5YgVvPoCUGHNN50IO4llSu7JAbftUM/QcCh+GeCortXPrBYQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.11.0",
-                "@typescript-eslint/types": "8.11.0",
-                "@typescript-eslint/typescript-estree": "8.11.0"
+                "@typescript-eslint/scope-manager": "8.12.1",
+                "@typescript-eslint/types": "8.12.1",
+                "@typescript-eslint/typescript-estree": "8.12.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2338,12 +2338,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
-            "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.1.tgz",
+            "integrity": "sha512-2RwdwnNGuOQKdGjuhujQHUqBZhEuodg2sLVPvOfWktvA9sOXOVqARjOyHSyhN2LiJGKxV6c8oOcmOtRcAnEeFw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.11.0",
+                "@typescript-eslint/types": "8.12.1",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -3763,9 +3763,9 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "11.11.9",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.9.tgz",
-            "integrity": "sha512-XpdZseuCrZehdHGuW22zZt3SF5g6AHJHJi7JwQIigOznW4Jg1n0oGPMJQheMaKLC+0rp5gxUKMRYI6ytd3q4RQ==",
+            "version": "11.11.10",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.10.tgz",
+            "integrity": "sha512-061Bt1jL/vIm+diYIiA4dP/Yld7vD47ROextS7ESBW5hr4wQFhxB5D5T5zAc3c/5me3cOa+iO5LqhA38WDln/A==",
             "dependencies": {
                 "tslib": "^2.4.0"
             },
@@ -4149,9 +4149,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "23.16.2",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.2.tgz",
-            "integrity": "sha512-dFyxwLXxEQK32f6tITBMaRht25mZPJhQ0WbC0p3bO2mWBal9lABTMqSka5k+GLSRWLzeJBKDpH7BeIA9TZI7Jg==",
+            "version": "23.16.4",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.4.tgz",
+            "integrity": "sha512-9NIYBVy9cs4wIqzurf7nLXPyf3R78xYbxExVqHLK9od3038rjpyOEzW+XB130kZ1N4PZ9inTtJ471CRJ4Ituyg==",
             "funding": [
                 {
                     "type": "individual",
@@ -6243,10 +6243,9 @@
             }
         },
         "node_modules/socket.io-client": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-            "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
-            "license": "MIT",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+            "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
@@ -6648,14 +6647,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.11.0.tgz",
-            "integrity": "sha512-cBRGnW3FSlxaYwU8KfAewxFK5uzeOAp0l2KebIlPDOT5olVi65KDG/yjBooPBG0kGW/HLkoz1c/iuBFehcS3IA==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.12.1.tgz",
+            "integrity": "sha512-SsKedZnq4TStkrpqnk+OqTnmkC9CkYBRNKjQ965CLpFruGcRkPF5UhKxbcbF6c/m2r6YAgKw/UtQxdlMjh3mug==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.11.0",
-                "@typescript-eslint/parser": "8.11.0",
-                "@typescript-eslint/utils": "8.11.0"
+                "@typescript-eslint/eslint-plugin": "8.12.1",
+                "@typescript-eslint/parser": "8.12.1",
+                "@typescript-eslint/utils": "8.12.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
         "@sentry/react": "^8.35.0",
         "@tauri-apps/api": "^1",
         "emoji-regex": "^10.4.0",
-        "framer-motion": "^11.11.9",
+        "framer-motion": "^11.11.10",
         "globals": "^15.11.0",
-        "i18next": "^23.16.2",
+        "i18next": "^23.16.4",
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-http-backend": "^2.6.2",
         "linkify-react": "^4.1.3",
@@ -29,7 +29,7 @@
         "react-hook-form": "^7.53.1",
         "react-i18next": "^15.1.0",
         "react-icons": "^5.3.0",
-        "socket.io-client": "^4.8.0",
+        "socket.io-client": "^4.8.1",
         "styled-components": "^6.1.12",
         "uuid": "^10.0.0",
         "vite-tsconfig-paths": "^5.0.1",
@@ -41,7 +41,7 @@
         "@sentry/vite-plugin": "^2.22.6",
         "@tauri-apps/cli": "^1.6.3",
         "@types/eslint__js": "^8.42.3",
-        "@types/node": "^22.7.9",
+        "@types/node": "^22.8.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/uuid": "^10.0.0",
@@ -58,7 +58,7 @@
         "prettier-eslint": "^16.3.0",
         "react-qr-code": "^2.0.15",
         "typescript": "^5.6.3",
-        "typescript-eslint": "^8.11.0",
+        "typescript-eslint": "^8.12.1",
         "vite": "^5.4.10"
     }
 }

--- a/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
+++ b/src/containers/Airdrop/AirdropGiftTracker/sections/LoggedIn/LoggedIn.tsx
@@ -21,15 +21,15 @@ export default function LoggedIn() {
     } = useAirdropStore();
 
     useEffect(() => {
-        setGems(userPoints?.base.gems || userDetails?.user?.rank?.gems || 0);
-    }, [userPoints?.base.gems, userDetails?.user?.rank?.gems]);
+        setGems(userPoints?.base?.gems || userDetails?.user?.rank?.gems || 0);
+    }, [userPoints?.base?.gems, userDetails?.user?.rank?.gems]);
 
     const bonusTier = useMemo(
         () =>
             bonusTiers
                 ?.sort((a, b) => a.target - b.target)
-                .find((t) => t.target == (userPoints?.base.gems || userDetails?.user?.rank?.gems || 0)),
-        [bonusTiers, userDetails?.user?.rank?.gems, userPoints?.base.gems]
+                .find((t) => t.target == (userPoints?.base?.gems || userDetails?.user?.rank?.gems || 0)),
+        [bonusTiers, userDetails?.user?.rank?.gems, userPoints?.base?.gems]
     );
 
     const flareGems = useMemo(() => {

--- a/src/containers/Dashboard/MiningView/components/BlockTime.tsx
+++ b/src/containers/Dashboard/MiningView/components/BlockTime.tsx
@@ -1,15 +1,14 @@
-import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore';
-import { BlockTimeContainer, SpacedNum, TimerTypography, TitleTypography } from './BlockTime.styles';
+import { useTranslation } from 'react-i18next';
 
 import { useMiningStore } from '@app/store/useMiningStore.ts';
-import { useTranslation } from 'react-i18next';
-import { useShallow } from 'zustand/react/shallow';
+import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore';
+import { BlockTimeContainer, SpacedNum, TimerTypography, TitleTypography } from './BlockTime.styles';
 
 function BlockTime() {
     const { t } = useTranslation('mining-view', { useSuspense: false });
     const isCPUMining = useMiningStore((s) => s.cpu.mining.is_mining);
     const isGPUMining = useMiningStore((s) => s.gpu.mining.is_mining);
-    const blockTime = useBlockchainVisualisationStore(useShallow((s) => s.displayBlockTime));
+    const blockTime = useBlockchainVisualisationStore((s) => s.displayBlockTime);
     const isConnectedToTari = useMiningStore((s) => s.base_node?.is_connected);
     const isMining = isCPUMining || isGPUMining;
 

--- a/src/containers/Dashboard/SetupView/SetupViewContainer.tsx
+++ b/src/containers/Dashboard/SetupView/SetupViewContainer.tsx
@@ -1,13 +1,12 @@
-import { useAppStateStore } from '@app/store/appStateStore';
-import SetupView from './SetupView';
-import { useShallow } from 'zustand/react/shallow';
-import AirdropPermission from '@app/containers/Airdrop/AirdropPermission/AirdropPermission';
 import { useSetUp } from '@app/hooks/useSetUp';
+import { useAppStateStore } from '@app/store/appStateStore';
 import { useAirdropStore } from '@app/store/useAirdropStore.ts';
+import AirdropPermission from '@app/containers/Airdrop/AirdropPermission/AirdropPermission';
+import SetupView from './SetupView';
 
 function SetupViewContainer() {
     const setupTitle = useAppStateStore((s) => s.setupTitle);
-    const setupTitleParams = useAppStateStore(useShallow((s) => s.setupTitleParams));
+    const setupTitleParams = useAppStateStore((s) => s.setupTitleParams);
     const setupProgress = useAppStateStore((s) => s.setupProgress);
     const seenPermissions = useAirdropStore((s) => s.seenPermissions);
     const progressPercentage = Math.floor(setupProgress * 100);

--- a/src/containers/Settings/sections/experimental/AppVersions.tsx
+++ b/src/containers/Settings/sections/experimental/AppVersions.tsx
@@ -3,7 +3,7 @@ import { Environment, useEnvironment } from '@app/hooks/useEnvironment.ts';
 
 import { Stack } from '@app/components/elements/Stack.tsx';
 import { useTranslation } from 'react-i18next';
-import { useShallow } from 'zustand/react/shallow';
+
 import { useAppStateStore } from '@app/store/appStateStore';
 import { CardComponent } from '@app/containers/Settings/components/Card.component.tsx';
 import { CardContainer } from '@app/containers/Settings/components/Settings.styles.tsx';
@@ -13,7 +13,7 @@ import { TextButton } from '@app/components/elements/buttons/TextButton.tsx';
 export default function AppVersions() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const currentEnvironment = useEnvironment();
-    const applicationsVersions = useAppStateStore(useShallow((state) => state.applications_versions));
+    const applicationsVersions = useAppStateStore((state) => state.applications_versions);
     const fetchApplicationsVersions = useAppStateStore((state) => state.fetchApplicationsVersions);
     const updateApplicationsVersions = useAppStateStore((state) => state.updateApplicationsVersions);
 

--- a/src/containers/Settings/sections/experimental/MonerodMarkup/MonerodMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/MonerodMarkup/MonerodMarkup.tsx
@@ -14,7 +14,7 @@ import { IoAddCircleOutline, IoRemoveCircleOutline } from 'react-icons/io5';
 
 import { Stack } from '@app/components/elements/Stack.tsx';
 import { Button } from '@app/components/elements/buttons/Button.tsx';
-import { useShallow } from 'zustand/react/shallow';
+
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { IconButton } from '@app/components/elements/buttons/IconButton';
 import { NodesSettingsContainer, StyledInput } from './MonerodMarkup.styles';
@@ -30,7 +30,7 @@ const MonerodMarkup = () => {
     const { t } = useTranslation('settings', { useSuspense: false });
     const setDialogToShow = useUIStore((s) => s.setDialogToShow);
     const use_monero_fail = useAppConfigStore((s) => Boolean(s.mmproxy_use_monero_fail));
-    const monero_nodes = useAppConfigStore(useShallow((s) => s.mmproxy_monero_nodes || []));
+    const monero_nodes = useAppConfigStore((s) => s.mmproxy_monero_nodes || []);
     const setMonerodConfig = useAppConfigStore((s) => s.setMonerodConfig);
     const {
         control,

--- a/src/containers/SideBar/components/Wallet/SyncTooltip/SyncTooltip.tsx
+++ b/src/containers/SideBar/components/Wallet/SyncTooltip/SyncTooltip.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence } from 'framer-motion';
 import { Menu, Text, Title, Trigger, Wrapper } from './styles';
 import { useState } from 'react';
-import { autoUpdate, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
+import { autoUpdate, offset, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
 
 interface Props {
     trigger: JSX.Element;
@@ -12,10 +12,12 @@ interface Props {
 export default function SyncTooltip({ trigger, title, text }: Props) {
     const [expanded, setExpanded] = useState(false);
 
-    const { refs, context } = useFloating({
+    const { refs, context, floatingStyles } = useFloating({
         open: expanded,
         onOpenChange: setExpanded,
-
+        strategy: 'fixed',
+        placement: 'top',
+        middleware: [offset(5)],
         whileElementsMounted(referenceEl, floatingEl, update) {
             return autoUpdate(referenceEl, floatingEl, update, {
                 layoutShift: false,
@@ -40,10 +42,11 @@ export default function SyncTooltip({ trigger, title, text }: Props) {
                 {expanded && (
                     <Menu
                         ref={refs.setFloating}
-                        {...getFloatingProps()}
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
+                        {...getFloatingProps()}
+                        style={floatingStyles}
                     >
                         <Title>{title}</Title>
                         <Text>{text}</Text>

--- a/src/containers/SideBar/components/Wallet/SyncTooltip/SyncTooltip.tsx
+++ b/src/containers/SideBar/components/Wallet/SyncTooltip/SyncTooltip.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence } from 'framer-motion';
 import { Menu, Text, Title, Trigger, Wrapper } from './styles';
 import { useState } from 'react';
-import { autoUpdate, offset, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
+import { autoUpdate, offset, safePolygon, shift, useFloating, useHover, useInteractions } from '@floating-ui/react';
 
 interface Props {
     trigger: JSX.Element;
@@ -15,9 +15,8 @@ export default function SyncTooltip({ trigger, title, text }: Props) {
     const { refs, context, floatingStyles } = useFloating({
         open: expanded,
         onOpenChange: setExpanded,
-        strategy: 'fixed',
         placement: 'top',
-        middleware: [offset(5)],
+        middleware: [offset(5), shift()],
         whileElementsMounted(referenceEl, floatingEl, update) {
             return autoUpdate(referenceEl, floatingEl, update, {
                 layoutShift: false,
@@ -45,8 +44,8 @@ export default function SyncTooltip({ trigger, title, text }: Props) {
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
-                        {...getFloatingProps()}
                         style={floatingStyles}
+                        {...getFloatingProps()}
                     >
                         <Title>{title}</Title>
                         <Text>{text}</Text>

--- a/src/containers/SideBar/components/Wallet/SyncTooltip/styles.ts
+++ b/src/containers/SideBar/components/Wallet/SyncTooltip/styles.ts
@@ -10,14 +10,7 @@ export const Trigger = styled('div')`
 `;
 
 export const Menu = styled(m.div)`
-    z-index: 2;
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-
-    transform: translateX(-50%);
-
-    margin-bottom: 7px;
+    height: min-content;
 
     display: flex;
     align-items: flex-start;
@@ -28,7 +21,7 @@ export const Menu = styled(m.div)`
 
     border-radius: 15px;
     background: #fff;
-    box-shadow: 0px 2.915px 24.782px 0px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 3px 25px 0 rgba(0, 0, 0, 0.25);
 
     width: 216px;
 `;
@@ -39,6 +32,7 @@ export const Title = styled('div')`
     font-style: normal;
     font-weight: 500;
     line-height: 110%;
+    position: relative;
 `;
 
 export const Text = styled('div')`
@@ -46,4 +40,5 @@ export const Text = styled('div')`
     font-size: 12px;
     font-weight: 500;
     line-height: 116.667%;
+    position: relative;
 `;

--- a/src/containers/SideBar/components/Wallet/Wallet.styles.ts
+++ b/src/containers/SideBar/components/Wallet/Wallet.styles.ts
@@ -22,7 +22,6 @@ export const WalletContainer = styled(m.div)`
     max-height: 508px;
     min-height: 178px;
     z-index: 2;
-    overflow: hidden;
 
     justify-content: space-between;
 
@@ -70,6 +69,8 @@ export const ScrollMask = styled(m.div)`
     width: 100%;
     z-index: 1;
     opacity: 0.7;
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
 `;
 
 export const HistoryContainer = styled(m.div)`
@@ -95,7 +96,6 @@ export const WalletCornerButtons = styled('div')`
     top: 10px;
     right: 13px;
     z-index: 2;
-
     display: flex;
     gap: 3px;
 `;

--- a/src/hooks/airdrop/stateHelpers/useGetAirdropUserDetails.ts
+++ b/src/hooks/airdrop/stateHelpers/useGetAirdropUserDetails.ts
@@ -20,7 +20,7 @@ export const useGetAirdropUserDetails = () => {
             method: 'GET',
             onError: logout,
         }).then((data) => {
-            if (data?.user.id) {
+            if (data?.user?.id) {
                 setUserDetails(data);
                 return data.user;
             }
@@ -33,7 +33,7 @@ export const useGetAirdropUserDetails = () => {
             path: '/user/score',
             method: 'GET',
         });
-        if (!data?.entry.gems) return;
+        if (!data?.entry || !data?.entry?.gems) return;
         setUserPoints({
             base: {
                 gems: data.entry.gems,
@@ -74,7 +74,7 @@ export const useGetAirdropUserDetails = () => {
             if (!details) return;
 
             const requests: Promise<void>[] = [];
-            if (!details?.rank.gems) {
+            if (!details?.rank?.gems) {
                 requests.push(fetchUserPoints());
             }
             requests.push(fetchUserReferralPoints());

--- a/src/hooks/airdrop/useWebsocket.ts
+++ b/src/hooks/airdrop/useWebsocket.ts
@@ -23,7 +23,7 @@ export const useWebsocket = () => {
             socket.emit('auth', airdropToken);
             socket.on(userId as string, (msg: string) => {
                 const msgParsed = JSON.parse(msg) as QuestCompletedEvent;
-                if (msgParsed.data.userPoints?.gems) {
+                if (msgParsed?.data?.userPoints?.gems) {
                     setUserGems(msgParsed.data.userPoints?.gems);
                 }
             });

--- a/src/hooks/useHardwareStats.ts
+++ b/src/hooks/useHardwareStats.ts
@@ -1,6 +1,5 @@
 import { useMiningStore } from '@app/store/useMiningStore';
 import { HardwareParameters } from '../types/app-status';
-import { useShallow } from 'zustand/react/shallow';
 import { useMemo } from 'react';
 
 const roundTo = (num: number, precision = 2) => {
@@ -9,8 +8,8 @@ const roundTo = (num: number, precision = 2) => {
 };
 
 export const useHardwareStats = () => {
-    const cpuHardwareStats = useMiningStore(useShallow((s) => s.cpu.hardware));
-    const gpuHardwareStats = useMiningStore(useShallow((s) => s.gpu.hardware));
+    const cpuHardwareStats = useMiningStore((s) => s.cpu.hardware);
+    const gpuHardwareStats = useMiningStore((s) => s.gpu.hardware);
 
     const cpu = useMemo(() => {
         if (cpuHardwareStats) {

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -211,4 +211,4 @@ export const useAirdropStore = create<AirdropStore>()(
         }
     )
 );
-useAirdropStore.setState({ authUuid: '' }); // https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#persist-middlware-no-longer-stores-item-at-store-creation
+useAirdropStore.getState().setSeenPermissions(initialState.seenPermissions || false); // https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#persist-middlware-no-longer-stores-item-at-store-creation

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -20,8 +20,9 @@ export const COLOUR_TYPES = [
 ] as const;
 type ColourTuple = typeof COLOUR_TYPES;
 type ColourKey = ColourTuple[number];
-export type Colour = { [key in ColourKey]?: string };
-export type Gradients = { [key in ColourKey]?: string };
+
+export type Colour = Partial<Record<ColourKey, string>>;
+export type Gradients = Partial<Record<ColourKey, string>>;
 
 export interface ThemePalette {
     mode: Theme;


### PR DESCRIPTION
Description
---
- bump outdated deps (only items not on `wanted` version), no breaking changes
- fixed optional chaining check for `x.gems` stuff (main sentry errors)
- removed uses of `useShallow` since we updated the zustand store create fns and don't need that anymore + it caused one small sentry err
- fixed wallet section tooltip z-index issue

How Has This Been Tested?
---

- locally

What process can a PR reviewer use to test or verify this change?
---
- after the next release check that there are no "gems of undefined" or "object has own..... shallow" errors in sentry
- check that the tooltip in the wallet isn't hidden