### PR TITLE
fix: start processes in working dir

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.53"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"]}
+tauri-build = {version = "1.5.5", features = ["isolation"] }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"]}
+async_zip = {version = "0.0.17", features = ["full"] }
 auto-launch = "0.5.0"
 blake2 = "0.10"
 chrono = "0.4.38"
@@ -29,26 +29,26 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-]}
+] }
 libsqlite3-sys = {version = "0.25.1", features = [
   "bundled",
-]}# Required for tari_wallet
+] }# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"]}
+nix = {version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 phraze = "0.3.15"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
-sentry = {version = "0.34.0", features = ["anyhow"]}
+sentry = {version = "0.34.0", features = ["anyhow"] }
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"]}
+serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -58,7 +58,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-]}
+] }
 tari_crypto = "0.21.0"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -80,12 +80,12 @@ tauri = {version = "1.8.0", features = [
   "icon-ico",
   "icon-png",
   "process-command-api",
-]}
+] }
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"]}
-tokio-util = {version = "0.7.11", features = ["compat"]}
-xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
+tokio = {version = "1", features = ["full"] }
+tokio-util = {version = "0.7.11", features = ["compat"] }
+xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -94,7 +94,7 @@ winreg = "0.52.0"
 # needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -152,7 +152,7 @@ impl GpuMiner {
 
         info!(target: LOG_TARGET, "Gpu miner binary file path {:?}", gpuminer_bin.clone());
         crate::download_utils::set_permissions(&gpuminer_bin).await?;
-        let child = process_utils::launch_child_process(&gpuminer_bin, None, &args)?;
+        let child = process_utils::launch_child_process(&gpuminer_bin, &config_dir, None, &args)?;
         let output = child.wait_with_output().await?;
         info!(target: LOG_TARGET, "Gpu detect exit code: {:?}", output.status.code().unwrap_or_default());
         match output.status.code() {

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -81,7 +81,7 @@ pub enum HealthStatus {
 }
 
 #[async_trait]
-pub(crate) trait StatusMonitor: Clone + Send + 'static {
+pub(crate) trait StatusMonitor: Clone + Sync + Send + 'static {
     async fn check_health(&self) -> HealthStatus;
 }
 
@@ -123,7 +123,12 @@ impl ProcessInstance {
             crate::download_utils::set_permissions(&spec.file_path).await?;
             // start
             info!(target: LOG_TARGET, "Launching {} node", spec.name);
-            let mut child = launch_child_process(&spec.file_path, spec.envs.as_ref(), &spec.args)?;
+            let mut child = launch_child_process(
+                &spec.file_path,
+                spec.data_dir.as_path(),
+                spec.envs.as_ref(),
+                &spec.args,
+            )?;
 
             if let Some(id) = child.id() {
                 fs::write(

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 pub fn launch_child_process(
     file_path: &Path,
+    current_dir: &Path,
     envs: Option<&std::collections::HashMap<String, String>>,
     args: &[String],
 ) -> Result<tokio::process::Child, anyhow::Error> {
@@ -9,6 +10,7 @@ pub fn launch_child_process(
     {
         Ok(tokio::process::Command::new(file_path)
             .args(args)
+            .current_dir(current_dir)
             .envs(envs.cloned().unwrap_or_default())
             .stdout(std::process::Stdio::null()) // TODO: uncomment, only for testing
             .stderr(std::process::Stdio::null()) // TODO: uncomment, only for testing
@@ -20,6 +22,7 @@ pub fn launch_child_process(
         use crate::consts::PROCESS_CREATION_NO_WINDOW;
         Ok(tokio::process::Command::new(file_path)
             .args(args)
+            .current_dir(current_dir)
             .envs(envs.cloned().unwrap_or_default())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())


### PR DESCRIPTION
Starts processes in the data dir. On mac I think if you do not specify the starting location of the process, it tries to create the process in the same dir as the application. For Tor and some other processes, they try to create files on startup, and I believe this is the cause of tor not starting on macos.

Also changed the health check to stop on either the health check or a shutdown. Some processes like mmproxy and p2pool have long timeouts for health checks, so these would still be running when the process tried to shutdown.