### PR TITLE
fix(ui): shrink paper wallet modal height for shorter resolutions

### DIFF
--- a/src/components/GreenModal/styles.ts
+++ b/src/components/GreenModal/styles.ts
@@ -23,6 +23,10 @@ export const Wrapper = styled('div')`
     @media (max-height: 955px) {
         align-items: flex-start;
     }
+
+    @media (max-height: 800px) {
+        padding: 60px 40px 60px 40px;
+    }
 `;
 
 export const Cover = styled(m.div)`

--- a/src/containers/PaperWalletModal/sections/ConnectSection/styles.ts
+++ b/src/containers/PaperWalletModal/sections/ConnectSection/styles.ts
@@ -8,6 +8,11 @@ export const HeroImage = styled('img')`
     left: 50%;
     transform: translateX(-50%);
     pointer-events: none;
+
+    @media (max-height: 800px) {
+        width: 80%;
+        top: -60px;
+    }
 `;
 
 export const ContentWrapper = styled('div')`
@@ -17,7 +22,7 @@ export const ContentWrapper = styled('div')`
     align-items: center;
     width: 100%;
 
-    padding: 200px 25px 10px 25px;
+    padding: 200px 25px 0px 25px;
 `;
 
 export const Title = styled('div')`


### PR DESCRIPTION
When the app height is shorter than 800px, i'm shrinking the hero image in the Paper Wallet modal so it doesn't get cut off, forcing the user to scroll. 

![CleanShot 2024-10-30 at 18 15 37](https://github.com/user-attachments/assets/bd493834-a76c-491c-871a-e9aa5c0f810a)
