### PR TITLE
fix(tor): restaring issue on unix

### DIFF
--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -106,9 +106,7 @@ impl ProcessAdapter for MinotariNodeAdapter {
             //     "base_node.p2p.transport.tor.listener_address_override=/ip4/127.0.0.1/tcp/18189"
             //         .to_string(),
             // );
-            if cfg!(target_os = "windows") {
-                // No need
-            } else {
+            if !cfg!(target_os = "windows") {
                 args.push("-p".to_string());
                 args.push("use_libtor=false".to_string());
             }

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -24,7 +24,7 @@ const LOG_TARGET: &str = "tari::universe::tor_adapter";
 fn is_port_available(port: u16) -> bool {
     // Try to bind to the port; if successful, the port is available
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    TcpListener::bind(&addr).is_ok()
+    TcpListener::bind(addr).is_ok()
 }
 
 fn get_random_empty_port() -> u16 {

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -104,7 +104,12 @@ impl ProcessAdapter for WalletAdapter {
 
         if self.use_tor {
             args.push("-p".to_string());
-            args.push("wallet.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true".to_string())
+            args.push("wallet.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true".to_string());
+
+            if !cfg!(target_os = "windows") {
+                args.push("-p".to_string());
+                args.push("use_libtor=false".to_string());
+            }
         } else {
             args.push("-p".to_string());
             args.push("wallet.p2p.transport.type=tcp".to_string());

--- a/src/containers/Settings/sections/experimental/TorMarkup/TorDebug.tsx
+++ b/src/containers/Settings/sections/experimental/TorMarkup/TorDebug.tsx
@@ -26,7 +26,7 @@ export const TorDebug = () => {
             // Fetch entry guards after the tor is up
             fetchEntryGuards();
         }
-    });
+    }, [setupProgress]);
 
     return (
         <SettingsGroupWrapper>


### PR DESCRIPTION
BACKGROUND
---
Tor might be already running and using control/socks port. Tor ends in infinite restart loop.

SOLUTION
---
Check if control/socks port are already used and use random one which is available.
This check is done when loading tor's config. Port replacement is done per session, we don't overwrite it in the config file