### PR TITLE
fix(tor): handle unsigned tor on macs

### DIFF
--- a/public/locales/af/settings.json
+++ b/public/locales/af/settings.json
@@ -108,7 +108,9 @@
     "title": "Werk Tari Universe outomaties op"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Gebruik Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Visuele modus",
   "yes": "Yes",
   "your-feedback": "Beskryf asseblief u probleem",

--- a/public/locales/cn/settings.json
+++ b/public/locales/cn/settings.json
@@ -108,7 +108,9 @@
     "title": "自动更新 Tari 宇宙"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "使用Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "视觉模式",
   "yes": "是",
   "your-feedback": "请描述您的问题",

--- a/public/locales/de/settings.json
+++ b/public/locales/de/settings.json
@@ -108,7 +108,9 @@
     "title": "Tari-Universum automatisch aktualisieren"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Tor verwenden",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Visueller Modus",
   "yes": "Ja",
   "your-feedback": "Beschreibe dein Problem, einschließlich deines Telegram-Namens, falls vorhanden, damit wir dich mit Updates kontaktieren können.",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -108,7 +108,9 @@
     "title": "Update Tari Universe automatically"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Use Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Visual mode",
   "yes": "Yes",
   "your-feedback": "Describe your issue, including your Telegram handle if you have one, so that we can contact you with updates.",

--- a/public/locales/fr/settings.json
+++ b/public/locales/fr/settings.json
@@ -108,7 +108,9 @@
     "title": "Mettre à jour Tari Universe automatiquement"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Utiliser Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Mode visuel",
   "yes": "Yes",
   "your-feedback": "Veuillez décrire votre problème",

--- a/public/locales/hi/settings.json
+++ b/public/locales/hi/settings.json
@@ -108,7 +108,9 @@
     "title": "तारी यूनिवर्स को स्वचालित रूप से अपडेट करें"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "टोर का उपयोग करें",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "दृश्य मोड",
   "yes": "हाँ",
   "your-feedback": "कृपया अपनी समस्या का वर्णन करें",

--- a/public/locales/id/settings.json
+++ b/public/locales/id/settings.json
@@ -108,7 +108,9 @@
     "title": "Perbarui Tari Universe secara otomatis"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Gunakan Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Mode visual",
   "yes": "Ya",
   "your-feedback": "Silakan jelaskan masalah Anda",

--- a/public/locales/ja/settings.json
+++ b/public/locales/ja/settings.json
@@ -108,7 +108,9 @@
     "title": "Tari Universeを自動更新"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Torを使用する",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "ビジュアルモード",
   "yes": "はい",
   "your-feedback": "問題を説明してください",

--- a/public/locales/ko/settings.json
+++ b/public/locales/ko/settings.json
@@ -108,7 +108,9 @@
     "title": "Tari Universe 자동 업데이트"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Tor 사용하기",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "시각 모드",
   "yes": "예",
   "your-feedback": "문제를 설명해 주세요",

--- a/public/locales/pl/settings.json
+++ b/public/locales/pl/settings.json
@@ -110,7 +110,9 @@
     "title": "Automatyczna aktualizacja Tari Universe"
   },
   "use-dynamic-fail-data": "Użyj dynamicznych danych o błędach",
+  "use-random-control-port": "Użyj losowego portu kontrolnego",
   "use-tor": "Używaj Tor",
+  "use-tor-bridges": "Użyj mostów Tor",
   "visual-mode": "Tryb wizualny",
   "yes": "Tak",
   "your-feedback": "Proszę opisać swój problem",

--- a/public/locales/ru/settings.json
+++ b/public/locales/ru/settings.json
@@ -108,7 +108,9 @@
     "title": "Автоматическое обновление Tari Universe"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Использовать Tor",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Визуальный режим",
   "yes": "Да",
   "your-feedback": "Пожалуйста, опишите вашу проблему",

--- a/public/locales/tr/settings.json
+++ b/public/locales/tr/settings.json
@@ -108,7 +108,9 @@
     "title": "Tari Universe\"i otomatik olarak güncelle"
   },
   "use-dynamic-fail-data": "Use dynamic fail data",
+  "use-random-control-port": "Use random control port",
   "use-tor": "Tor Kullan",
+  "use-tor-bridges": "Use Tor Bridges",
   "visual-mode": "Görsel mod",
   "yes": "Evet",
   "your-feedback": "Lütfen sorununuzu açıklayın",

--- a/scripts/translator.js
+++ b/scripts/translator.js
@@ -154,8 +154,7 @@ async function main() {
 
             const translations = JSON.parse(file);
             const translationsWithDefaults = mergeDeep(JSON.parse(enTranslations), translations);
-
-            if (args > 1) {
+            if (args.length > 1) {
                 const translation = args[1].split('=');
                 setNestedValue(translationsWithDefaults, translation[0], translation[1]);
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -671,7 +671,7 @@ async fn setup_inner(
         .unwrap_or(Duration::from_secs(0))
         > Duration::from_secs(60 * 60 * 6);
 
-    if use_tor {
+    if use_tor && !cfg!(target_os = "macos") {
         progress.set_max(5).await;
         progress
             .update("checking-latest-version-tor".to_string(), None, 0)
@@ -681,6 +681,7 @@ async fn setup_inner(
             .await?;
         sleep(Duration::from_secs(1));
     }
+
     progress.set_max(10).await;
     progress
         .update("checking-latest-version-node".to_string(), None, 0)
@@ -768,7 +769,7 @@ async fn setup_inner(
         .await
         .inspect_err(|e| error!(target: LOG_TARGET, "Could not detect gpu miner: {:?}", e));
     let mut tor_control_port = None;
-    if use_tor {
+    if use_tor && !cfg!(target_os = "macos") {
         state
             .tor_manager
             .ensure_started(

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -106,9 +106,7 @@ impl ProcessAdapter for MinotariNodeAdapter {
             //     "base_node.p2p.transport.tor.listener_address_override=/ip4/127.0.0.1/tcp/18189"
             //         .to_string(),
             // );
-            if cfg!(target_os = "windows") {
-                // No need
-            } else {
+            if !cfg!(target_os = "macos") {
                 args.push("-p".to_string());
                 args.push("use_libtor=false".to_string());
             }
@@ -119,7 +117,11 @@ impl ProcessAdapter for MinotariNodeAdapter {
             ));
             args.push("-p".to_string());
             args.push("base_node.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true".to_string());
-            if let Some(tor_control_port) = self.tor_control_port {
+            if let Some(mut tor_control_port) = self.tor_control_port {
+                // macos uses libtor, so will be 9051
+                if cfg!(target_os = "macos") {
+                    tor_control_port = 9051;
+                }
                 args.push("-p".to_string());
                 args.push(format!(
                     "base_node.p2p.transport.tor.control_address=/ip4/127.0.0.1/tcp/{}",

--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use tari_shutdown::Shutdown;
 use tokio::fs;
 
+use crate::network_utils;
 use crate::{
     process_adapter::{
         HealthStatus, ProcessAdapter, ProcessInstance, ProcessStartupSpec, StatusMonitor,
@@ -27,10 +28,10 @@ pub(crate) struct TorAdapter {
 
 impl TorAdapter {
     pub fn new() -> Self {
-        let socks_port = 9050;
+        let port = network_utils::get_free_port().unwrap_or(9060);
 
         Self {
-            socks_port,
+            socks_port: port,
             config_file: None,
             config: TorConfig::default(),
         }
@@ -50,12 +51,19 @@ impl TorAdapter {
         } else {
             info!(target: LOG_TARGET, "App config does not exist or is corrupt. Creating new one");
         }
+
         self.update_config_file().await?;
         Ok(())
     }
 
     fn apply_loaded_config(&mut self, config: String) {
-        self.config = serde_json::from_str::<TorConfig>(&config).unwrap_or_default();
+        let mut conf = serde_json::from_str::<TorConfig>(&config).unwrap_or_default();
+        if conf.version < 1 {
+            conf.control_port = 0;
+            conf.version = 1;
+        }
+
+        self.config = conf;
     }
 
     async fn update_config_file(&mut self) -> Result<(), anyhow::Error> {
@@ -72,6 +80,7 @@ impl TorAdapter {
     }
 
     pub fn get_tor_config(&self) -> TorConfig {
+        println!("get_tor_config: {:?}", self.config.clone());
         self.config.clone()
     }
 
@@ -187,6 +196,10 @@ impl ProcessAdapter for TorAdapter {
         if cfg!(target_os = "windows") {
             lyrebird_path.set_extension("exe");
         }
+        let mut control_port = self.config.control_port;
+        if control_port == 0 {
+            control_port = network_utils::get_free_port().unwrap_or(9061);
+        }
 
         let mut args: Vec<String> = vec![
             "--allow-missing-torrc".to_string(),
@@ -196,7 +209,7 @@ impl ProcessAdapter for TorAdapter {
             "--socksport".to_string(),
             self.socks_port.to_string(),
             "--controlport".to_string(),
-            format!("127.0.0.1:{}", self.config.control_port),
+            format!("127.0.0.1:{}", control_port),
             // TODO: Put hashed password back
             // "--HashedControlPassword".to_string(),
             // EncryptedKey::hash_password(&self.password).to_string(),
@@ -239,9 +252,7 @@ impl ProcessAdapter for TorAdapter {
                     name: self.name().to_string(),
                 },
             },
-            TorStatusMonitor {
-                control_port: self.config.control_port,
-            },
+            TorStatusMonitor { control_port },
         ))
     }
 
@@ -269,6 +280,8 @@ impl StatusMonitor for TorStatusMonitor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TorConfig {
+    #[serde(default)]
+    version: u16,
     control_port: u16,
     use_bridges: bool,
     bridges: Vec<String>,
@@ -276,8 +289,10 @@ pub struct TorConfig {
 
 impl Default for TorConfig {
     fn default() -> Self {
+        // let port = network_utils::get_free_port().unwrap_or(9061);
         TorConfig {
-            control_port: 9051,
+            version: 1,
+            control_port: 0,
             use_bridges: false,
             bridges: Vec::new(),
         }

--- a/src/containers/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
+++ b/src/containers/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
@@ -48,6 +48,7 @@ export const TorMarkup = () => {
     const setUseTor = useAppConfigStore((s) => s.setUseTor);
     const [editedUseTor, setEditedUseTor] = useState(Boolean(defaultUseTor));
     const [editedConfig, setEditedConfig] = useState<EditedTorConfig>();
+    const [isRandomControlPort, setIsRandomControlPort] = useState(false);
 
     const hasCheckedOs = useRef(false);
 
@@ -69,6 +70,7 @@ export const TorMarkup = () => {
             .then((torConfig: TorConfig) => {
                 setEditedConfig(torConfig);
                 setDefaultTorConfig(torConfig);
+                setIsRandomControlPort(!torConfig?.control_port);
             })
             .catch((e) => {
                 Sentry.captureException(e);
@@ -110,9 +112,9 @@ export const TorMarkup = () => {
             (editedConfig?.use_bridges &&
                 (!editedConfig?.bridges?.length || editedConfig?.bridges.some((bridge) => hasBridgeError(bridge))) &&
                 !editedConfig?.control_port) ||
-            Number(editedConfig?.control_port) <= 0
+            (!isRandomControlPort && Number(editedConfig?.control_port) <= 0)
         );
-    }, [defaultTorConfig, defaultUseTor, editedConfig, editedUseTor]);
+    }, [defaultTorConfig, defaultUseTor, editedConfig, editedUseTor, isRandomControlPort]);
     const toggleUseBridges = useCallback(async () => {
         const updated_use_bridges = !editedConfig?.use_bridges;
         let bridges = editedConfig?.bridges || [];
@@ -127,6 +129,14 @@ export const TorMarkup = () => {
         }));
     }, [editedConfig?.bridges, editedConfig?.use_bridges]);
 
+    const toggleRandomControlPort = useCallback(() => {
+        setEditedConfig((prev) => ({
+            ...(prev as TorConfig),
+            control_port: isRandomControlPort ? prev?.control_port || 9051 : 0,
+        }));
+        setIsRandomControlPort((prev) => !prev);
+    }, [isRandomControlPort]);
+
     return (
         <>
             <SettingsGroupWrapper>
@@ -140,41 +150,60 @@ export const TorMarkup = () => {
                         </SettingsGroupTitle>
                         <Typography>{t('setup-tor-settings')}</Typography>
                     </SettingsGroupContent>
-                    <SettingsGroupAction>
-                        {isSaveButtonVisible ? (
-                            <Button onClick={onSave}>{t('save')}</Button>
-                        ) : (
-                            <ToggleSwitch checked={editedUseTor} onChange={() => setEditedUseTor((p) => !p)} />
-                        )}
+                    <SettingsGroupAction style={{ alignItems: 'center' }}>
+                        {isSaveButtonVisible && <Button onClick={onSave}>{t('save')}</Button>}
+                        <ToggleSwitch checked={editedUseTor} onChange={() => setEditedUseTor((p) => !p)} />
                     </SettingsGroupAction>
                 </SettingsGroup>
 
                 {editedUseTor && editedConfig ? (
                     <TorSettingsContainer $isMac={isMac}>
-                        <Stack style={{ width: '100%' }} direction="column">
+                        <Stack
+                            direction="row"
+                            justifyContent="space-between"
+                            alignItems="center"
+                            style={{ marginBottom: '16px' }}
+                        >
                             <Typography variant="h6">{t('control-port')}</Typography>
-                            <Input
-                                name="control-port"
-                                value={editedConfig.control_port}
-                                placeholder="9051"
-                                hasError={hasControlPortError(+editedConfig.control_port)}
-                                onChange={({ target }) => {
-                                    if (target.value && isNaN(+target.value)) return;
-                                    setEditedConfig((prev) => ({
-                                        ...(prev as TorConfig),
-                                        control_port: target.value !== '' ? +target.value.trim() : '',
-                                    }));
-                                }}
+                            <ToggleSwitch
+                                label={t('use-random-control-port')}
+                                variant="gradient"
+                                checked={isRandomControlPort}
+                                onChange={toggleRandomControlPort}
                             />
-                            <ErrorTypography variant="p">
-                                {hasControlPortError(+editedConfig.control_port) && t('errors.invalid-control-port')}
-                            </ErrorTypography>
                         </Stack>
 
-                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        {!isRandomControlPort && (
+                            <Stack style={{ width: '100%' }} direction="column">
+                                <Input
+                                    name="control-port"
+                                    value={editedConfig.control_port}
+                                    placeholder="9051"
+                                    hasError={hasControlPortError(+editedConfig.control_port)}
+                                    onChange={({ target }) => {
+                                        if (target.value && isNaN(+target.value)) return;
+                                        setEditedConfig((prev) => ({
+                                            ...(prev as TorConfig),
+                                            control_port: target.value !== '' ? +target.value.trim() : '',
+                                        }));
+                                    }}
+                                />
+                                <ErrorTypography variant="p">
+                                    {hasControlPortError(+editedConfig.control_port) &&
+                                        t('errors.invalid-control-port')}
+                                </ErrorTypography>
+                            </Stack>
+                        )}
+
+                        <Stack
+                            direction="row"
+                            justifyContent="space-between"
+                            alignItems="center"
+                            style={{ marginBottom: '16px' }}
+                        >
                             <Typography variant="h6">{t('tor-bridges')}</Typography>
                             <ToggleSwitch
-                                label={'Use Tor Bridges'}
+                                label={t('use-tor-bridges')}
                                 variant="gradient"
                                 checked={editedConfig.use_bridges}
                                 onChange={toggleUseBridges}


### PR DESCRIPTION
Contains changes from https://github.com/tari-project/universe/pull/985

Background
-
Tor binary is not signed for macOS so we decided to use libtor in this case.

Changes
-
* Use libtor only for macOS
* Use random empty control port if loaded 0 from tor config file
* User can toggle "Use random control port" and set specific port if disabled
* ADDITIONAL: Fixed issue with Save button covering toggle button when use want to toggle "use tor" again
* ADDITIONAL: fixed script for translations

Screencast
-
[Screencast from 11-04-2024 12:16:07 PM.webm](https://github.com/user-attachments/assets/4d7c923f-5711-4d56-ae80-7af80c36c378)

Screenshots
-
![Screenshot from 2024-11-04 12-21-19](https://github.com/user-attachments/assets/bd5c64b8-54c9-47f3-8559-5e627b024e6d)
![Screenshot from 2024-11-04 12-17-10](https://github.com/user-attachments/assets/ab30e541-98ba-45d2-98f6-056fb3b7f489)
![Screenshot from 2024-11-04 12-17-03](https://github.com/user-attachments/assets/aa7252d8-aafe-4e69-a662-9d5418d90a9a)
![Screenshot from 2024-11-04 12-16-56](https://github.com/user-attachments/assets/596bd4cf-ac2d-4a57-aec0-c0eb7b15eba3)

