### PR TITLE
fix(ui): add flag to config & fix permissions toggle init

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.5.63"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"]}
+tauri-build = {version = "1.5.5", features = ["isolation"] }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"]}
+async_zip = {version = "0.0.17", features = ["full"] }
 auto-launch = "0.5.0"
 blake2 = "0.10"
 chrono = "0.4.38"
@@ -29,27 +29,27 @@ keyring = {version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-]}
+] }
 libsqlite3-sys = {version = "0.25.1", features = [
   "bundled",
-]}# Required for tari_wallet
+] }# Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"]}
+nix = {version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 opencl3 = "0.9.5"
 phraze = "0.3.15"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
+reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
-sentry = {version = "0.34.0", features = ["anyhow"]}
+sentry = {version = "0.34.0", features = ["anyhow"] }
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"]}
+serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
@@ -59,7 +59,7 @@ tari_common = {git = "https://github.com/tari-project/tari.git", branch = "devel
 tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-]}
+] }
 tari_crypto = "0.21.0"
 tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
 tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
@@ -82,12 +82,12 @@ tauri = {version = "1.8.0", features = [
   "icon-ico",
   "icon-png",
   "process-command-api",
-]}
+] }
 tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"]}
-tokio-util = {version = "0.7.11", features = ["compat"]}
-xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
+tokio = {version = "1", features = ["full"] }
+tokio-util = {version = "0.7.11", features = ["compat"] }
+xz2 = {version = "0.1.7", features = ["static"] }# static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -96,7 +96,7 @@ winreg = "0.52.0"
 # needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}
+libsqlite3-sys = {version = "0.25.1", features = ["bundled"] }
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -71,6 +71,8 @@ pub struct AppConfigFromFile {
     auto_update: bool,
     #[serde(default = "default_false")]
     custom_power_levels_enabled: bool,
+    #[serde(default = "default_false")]
+    sharing_enabled: bool,
 }
 
 impl Default for AppConfigFromFile {
@@ -107,6 +109,7 @@ impl Default for AppConfigFromFile {
             auto_update: true,
             reset_earnings: false,
             custom_power_levels_enabled: false,
+            sharing_enabled: false,
         }
     }
 }
@@ -198,6 +201,7 @@ pub(crate) struct AppConfig {
     custom_max_gpu_usage: Option<isize>,
     auto_update: bool,
     custom_power_levels_enabled: bool,
+    sharing_enabled: bool,
 }
 
 impl AppConfig {
@@ -235,6 +239,7 @@ impl AppConfig {
             mmproxy_monero_nodes: vec!["https://xmr-01.tari.com".to_string()],
             custom_power_levels_enabled: false,
             auto_update: true,
+            sharing_enabled: false,
         }
     }
 
@@ -298,6 +303,7 @@ impl AppConfig {
                 } else {
                     self.reset_earnings = false;
                 }
+                self.sharing_enabled = config.sharing_enabled;
             }
             Err(e) => {
                 warn!(target: LOG_TARGET, "Failed to parse app config: {}", e.to_string());
@@ -621,6 +627,7 @@ impl AppConfig {
             mmproxy_use_monero_fail: self.mmproxy_use_monero_fail,
             auto_update: self.auto_update,
             custom_power_levels_enabled: self.custom_power_levels_enabled,
+            sharing_enabled: self.sharing_enabled,
         };
         let config = serde_json::to_string(config)?;
         debug!(target: LOG_TARGET, "Updating config file: {:?} {:?}", file, self.clone());

--- a/src/containers/SideBar/components/Wallet/HistoryItem.tsx
+++ b/src/containers/SideBar/components/Wallet/HistoryItem.tsx
@@ -46,13 +46,14 @@ export default function HistoryItem({ item }: HistoryItemProps) {
     const theme = useTheme();
     const appLanguage = useAppConfigStore((s) => s.application_language);
     const systemLang = useAppConfigStore((s) => s.should_always_use_system_language);
+    const sharingEnabled = useAppConfigStore((s) => s.sharing_enabled);
+
     const { t } = useTranslation('sidebar', { useSuspense: false });
     const earningsFormatted = useFormatBalance(item.amount).toLowerCase();
     const referralQuestPoints = useAirdropStore((s) => s.referralQuestPoints);
     const airdropTokens = useAirdropStore((s) => s.airdropTokens);
 
     const [hovering, setHovering] = useState(false);
-    const sharingEnabled = useShareRewardStore((s) => s.sharingEnabled);
     const { setShowModal, setItemData } = useShareRewardStore((s) => s);
 
     const { colour, colour1, colour2 } = useMemo(() => {

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -133,7 +133,7 @@ interface AirdropState {
     bonusTiers?: BonusTier[];
     referralQuestPoints?: ReferralQuestPoints;
     miningRewardPoints?: MiningPoint;
-    seenPermissions?: boolean;
+    seenPermissions: boolean;
 }
 
 interface AirdropStore extends AirdropState {
@@ -157,11 +157,10 @@ const initialState: AirdropState = {
     seenPermissions: false,
 };
 
-const clearState: AirdropState = {
+const clearState: Partial<AirdropState> = {
     authUuid: '',
     airdropTokens: undefined,
     miningRewardPoints: undefined,
-    seenPermissions: false,
     userDetails: undefined,
     userPoints: undefined,
 };
@@ -211,4 +210,6 @@ export const useAirdropStore = create<AirdropStore>()(
         }
     )
 );
-useAirdropStore.getState().setSeenPermissions(initialState.seenPermissions || false); // https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#persist-middlware-no-longer-stores-item-at-store-creation
+useAirdropStore
+    .getState()
+    .setSeenPermissions(useAirdropStore.getState().seenPermissions || initialState.seenPermissions); // https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#persist-middlware-no-longer-stores-item-at-store-creation

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -49,6 +49,7 @@ const initialState: State = {
     monero_address: '',
     gpu_mining_enabled: true,
     cpu_mining_enabled: true,
+    sharing_enabled: false,
     airdrop_ui_enabled: false,
     paper_wallet_enabled: false,
     custom_power_levels_enabled: false,

--- a/src/store/useShareRewardStore.ts
+++ b/src/store/useShareRewardStore.ts
@@ -2,7 +2,6 @@ import { create } from './create.ts';
 import { Transaction } from '@app/types/wallet.ts';
 
 interface State {
-    sharingEnabled: boolean;
     showModal: boolean;
     item: Transaction | null;
 }
@@ -13,7 +12,6 @@ interface Actions {
 }
 
 const initialState: State = {
-    sharingEnabled: false,
     showModal: false,
     item: null,
 };

--- a/src/types/app-status.ts
+++ b/src/types/app-status.ts
@@ -35,6 +35,7 @@ export interface AppConfig {
     reset_earnings: boolean;
     mmproxy_use_monero_fail: boolean;
     mmproxy_monero_nodes: string[];
+    sharing_enabled: boolean;
 }
 
 export enum ExternalDependencyStatus {


### PR DESCRIPTION
Description
---
- remove sharingEnabled flag from js and move to app_config
- fixed setting the iniiiiiitial `seenPermissions` value and check if already set in `useAirdropStore`

Motivation & context
---

- resolves https://github.com/tari-project/universe/issues/1012
- easier testing

How Has This Been Tested?
---

- locally

What process can a PR reviewer use to test or verify this change?
---

- update `sharing_enabled` app_config and check if true/false work as expected
- if it's the very first install permissions toggle should be visible on the setup screen, else it shouldn't be