### PR TITLE
fix: gpuDevices undefined causes crash in settings

### DIFF
--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -54,7 +54,7 @@ const GpuDevices = () => {
                 </SettingsGroup>
                 <SettingsGroup>
                     <SettingsGroupContent>
-                        {gpuDevices.length > 0 ? (
+                        {gpuDevices && gpuDevices.length > 0 ? (
                             gpuDevices.map((device, i) => (
                                 <Stack
                                     key={device.name}


### PR DESCRIPTION
There's a bug in the `Settings / Mining` section that causes a UI crash.  When gpuDevices is `undefined` it breaks. This PR adds an extra check to fix this. 

![CleanShot 2024-11-07 at 17 13 29](https://github.com/user-attachments/assets/c901ed68-c98e-4f73-8cb7-d6da758155e6)

![CleanShot 2024-11-07 at 17 21 32](https://github.com/user-attachments/assets/eca32aec-2d5c-45d0-bb72-c490b9d8e2c6)

![CleanShot 2024-11-07 at 17 17 08](https://github.com/user-attachments/assets/a71c827b-cfdb-4c16-a73a-bb1d0f9636f8)

![CleanShot 2024-11-07 at 17 24 09](https://github.com/user-attachments/assets/781f286e-7e9c-49a5-a941-7407e7ad1b27)

