### PR TITLE
fix(ui): setup screen nav - simplified the progress animation and added a hover style

### DIFF
--- a/src/components/elements/LinearProgress.tsx
+++ b/src/components/elements/LinearProgress.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div<{ $variant?: 'primary' | 'small' | 'tiny' }>`
     background: ${({ theme, $variant }) =>
         $variant !== 'primary' ? convertHexToRGBA(theme.palette.contrast, 0.1) : theme.palette.base};
 
-    border-radius: 20px;
+    border-radius: 50px;
     overflow: hidden;
     align-items: center;
     display: flex;
@@ -38,7 +38,7 @@ const Wrapper = styled.div<{ $variant?: 'primary' | 'small' | 'tiny' }>`
 `;
 
 const Bar = styled(m.div)<{ $variant?: 'primary' | 'small' | 'tiny' }>`
-    border-radius: 20px;
+    border-radius: 50px;
     background: ${({ theme }) => theme.palette.contrast};
     height: ${({ $variant }) => ($variant ? '5px' : '10px')};
 `;
@@ -46,13 +46,22 @@ const Bar = styled(m.div)<{ $variant?: 'primary' | 'small' | 'tiny' }>`
 export function LinearProgress({
     value = 10,
     variant = 'primary',
+    duration,
+    onAnimationComplete,
 }: {
     value?: number;
     variant?: 'primary' | 'small' | 'tiny';
+    duration?: number;
+    onAnimationComplete?: () => void;
 }) {
     return (
         <Wrapper $variant={variant}>
-            <Bar initial={{ width: 0 }} animate={{ width: `${value}%` }} $variant={variant} />
+            <Bar
+                initial={{ width: 0 }}
+                animate={{ width: `${value}%`, transition: { duration: duration || 0.5, ease: 'linear' } }}
+                $variant={variant}
+                onAnimationComplete={onAnimationComplete}
+            />
         </Wrapper>
     );
 }

--- a/src/containers/floating/Settings/components/Settings.styles.tsx
+++ b/src/containers/floating/Settings/components/Settings.styles.tsx
@@ -40,7 +40,6 @@ export const CardItemLabelWrapper = styled.div`
 export const CardItemLabel = styled(Typography)``;
 export const CardItemLabelValue = styled(Typography)`
     color: ${({ theme }) => theme.palette.text.primary};
-    text-wrap: pretty;
     word-break: break-all;
 `;
 

--- a/src/containers/phase/Setup/components/InfoNav/InfoNav.styles.ts
+++ b/src/containers/phase/Setup/components/InfoNav/InfoNav.styles.ts
@@ -1,5 +1,5 @@
 import { m } from 'framer-motion';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
     display: flex;
@@ -17,7 +17,6 @@ export const Heading = styled.div`
     line-height: 1;
     letter-spacing: -2px;
     white-space: pre-line;
-    text-wrap: nowrap;
 `;
 
 export const Copy = styled.div`
@@ -44,19 +43,33 @@ export const NavContainer = styled.div`
 export const Nav = styled.div`
     display: flex;
     gap: 5px;
+    position: relative;
+    z-index: 2;
 `;
 
 export const NavItem = styled(m.div)<{ $selected?: boolean }>`
-    border-radius: 2px;
+    border-radius: 50px;
     position: relative;
     display: flex;
     width: 70px;
     height: 4px;
     cursor: pointer;
+
+    transition: transform 0.3s ease;
+
+    &:hover {
+        transform: scaleY(2);
+    }
+
+    ${({ $selected }) =>
+        $selected &&
+        css`
+            pointer-events: none;
+        `};
 `;
 
 export const NavItemCurrent = styled(m.div)`
-    border-radius: 2px;
+    border-radius: 50px;
     position: absolute;
     top: 0;
     left: 0;

--- a/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
+++ b/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
@@ -1,52 +1,29 @@
 import { LinearProgress } from '@app/components/elements/LinearProgress';
 import InfoItemGraphic from '@app/containers/phase/Setup/components/InfoNav/InfoItemGraphic';
-import { useAppStateStore } from '@app/store/appStateStore';
 import { AnimatePresence } from 'framer-motion';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import InfoItem from './InfoItem';
 import { Nav, NavContainer, NavItem, NavItemCurrent } from './InfoNav.styles';
 
-const STEP_TIME = 1000 * 15;
+const STEP_TIME_SECONDS = 15;
 const steps = Array.from({ length: 6 }, (_, i) => i + 1);
 
 export default function InfoNav() {
-    const setupProgress = useAppStateStore((s) => s.setupProgress);
-    const progressPercentage = Math.floor(setupProgress * 100);
-
     const [currentStep, setCurrentStep] = useState(steps[0]);
-    const [stepPercentage, setStepPercentage] = useState(0);
-
-    const interval = useRef(0);
 
     const handleStepClick = useCallback((newStep: number) => {
-        interval.current = 0;
         setCurrentStep(newStep);
-        setStepPercentage(0);
     }, []);
 
-    useEffect(() => {
-        const percentageInterval = setInterval(() => {
-            if (interval.current < 15) {
-                interval.current += 1;
+    const handleNextStep = () => {
+        setCurrentStep((c) => {
+            if (c < steps.length) {
+                return c + 1;
+            } else {
+                return 1;
             }
-            setStepPercentage(Math.floor((interval.current / 15) * 100));
-        }, 1000);
-        const stepTimeout = setTimeout(() => {
-            setCurrentStep((c) => {
-                if (c < steps.length) {
-                    return c + 1;
-                } else {
-                    return 1;
-                }
-            });
-            interval.current = 0;
-        }, STEP_TIME);
-
-        return () => {
-            clearInterval(percentageInterval);
-            clearTimeout(stepTimeout);
-        };
-    }, [currentStep, progressPercentage]);
+        });
+    };
 
     const sliderMarkup = steps?.map((step) => {
         const key = `nav-item-${step}`;
@@ -57,12 +34,18 @@ export default function InfoNav() {
                 <LinearProgress value={0} variant="tiny" />
                 {isSelected ? (
                     <NavItemCurrent layoutId="selected" key={`selected:${key}`}>
-                        <LinearProgress value={stepPercentage} variant="tiny" />
+                        <LinearProgress
+                            value={100}
+                            duration={STEP_TIME_SECONDS}
+                            variant="tiny"
+                            onAnimationComplete={handleNextStep}
+                        />
                     </NavItemCurrent>
                 ) : null}
             </NavItem>
         );
     });
+
     return (
         <NavContainer>
             <AnimatePresence mode="wait">

--- a/src/containers/phase/Setup/components/SetupProgress.tsx
+++ b/src/containers/phase/Setup/components/SetupProgress.tsx
@@ -18,7 +18,7 @@ const Percentage = styled(Typography)`
 const InfoText = styled(Typography)`
     font-weight: 400;
     margin-bottom: 14px;
-    text-wrap: nowrap;
+    white-space: nowrap;
 `;
 export default function SetupProgress() {
     const { t } = useTranslation('setup-view');


### PR DESCRIPTION
This PR simplifies the steps navigation on the setup screen nav. It now animates smoothly from 0-100% over 15 seconds. The trigger to jump to the next step is now triggered onAnimationComplete. This way we don't need to sync up timers with the animation ourselves. 

I also added a hover state and made a few minor CSS tweaks along the way. 

![CleanShot 2024-11-08 at 17 37 01](https://github.com/user-attachments/assets/d466ac58-f852-410e-8a67-8459d50dad6e)

https://www.loom.com/share/7cb2b49c927f40309e4f6faf0a3bfeea?sid=cc844d7b-8b09-4428-b2b4-85419320271b