### PR TITLE
fix: don't set setup progress back to 0

### DIFF
--- a/src/hooks/useMiningMetricsUpdater.ts
+++ b/src/hooks/useMiningMetricsUpdater.ts
@@ -12,6 +12,8 @@ export default function useMiningMetricsUpdater() {
     const baseNodeConnected = useMiningStore((s) => s.base_node.is_connected);
     const setMiningMetrics = useMiningStore((s) => s.setMiningMetrics);
     const handleNewBlock = useBlockchainVisualisationStore((s) => s.handleNewBlock);
+    const displayBlockHeight = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
+    const setDisplayBlockHeight = useBlockchainVisualisationStore((s) => s.setDisplayBlockHeight);
     const [isFetchingMetrics, setIsFetchingMetrics] = useState(false);
 
     return useCallback(async () => {
@@ -30,10 +32,13 @@ export default function useMiningMetricsUpdater() {
                 }
 
                 const blockHeight = metrics.base_node.block_height;
-
                 if (blockHeight > 0 && currentBlockHeight > 0 && blockHeight > currentBlockHeight) {
                     await fetchTx();
                     await handleNewBlock(blockHeight, isMining);
+                } else {
+                    if (blockHeight && !displayBlockHeight) {
+                        setDisplayBlockHeight(blockHeight);
+                    }
                 }
                 setMiningMetrics(metrics);
                 setIsFetchingMetrics(false);
@@ -43,5 +48,14 @@ export default function useMiningMetricsUpdater() {
             console.error('Fetch mining metrics error: ', e);
             setIsFetchingMetrics(false);
         }
-    }, [baseNodeConnected, currentBlockHeight, fetchTx, handleNewBlock, isFetchingMetrics, setMiningMetrics]);
+    }, [
+        baseNodeConnected,
+        currentBlockHeight,
+        displayBlockHeight,
+        fetchTx,
+        handleNewBlock,
+        isFetchingMetrics,
+        setDisplayBlockHeight,
+        setMiningMetrics,
+    ]);
 }

--- a/src/hooks/useMiningMetricsUpdater.ts
+++ b/src/hooks/useMiningMetricsUpdater.ts
@@ -30,11 +30,10 @@ export default function useMiningMetricsUpdater() {
                 }
 
                 const blockHeight = metrics.base_node.block_height;
-                if (blockHeight && blockHeight > currentBlockHeight) {
+
+                if (blockHeight > 0 && currentBlockHeight > 0 && blockHeight > currentBlockHeight) {
                     await fetchTx();
-                    if (blockHeight > 0) {
-                        await handleNewBlock(blockHeight, isMining);
-                    }
+                    await handleNewBlock(blockHeight, isMining);
                 }
                 setMiningMetrics(metrics);
                 setIsFetchingMetrics(false);

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -46,7 +46,9 @@ export function useSetUp() {
         const unlistenPromise = listen('message', ({ event: e, payload: p }: TauriEvent) => {
             switch (p.event_type) {
                 case 'setup_status':
-                    setSetupDetails(p.title, p.title_params, p.progress);
+                    if (p.progress > 0) {
+                        setSetupDetails(p.title, p.title_params, p.progress);
+                    }
                     if (p.progress >= 1) {
                         handlePostSetup().finally(() => setSeenPermissions(true));
                     }


### PR DESCRIPTION
### fixes the bug i introduced in #1057 

basically those changes made it so we never fetched wallet details 

- only use `setSetupDetails` if progress is greater than 0 (since the fetch wallet history call only worked on progress > 0.75 and after setup completed progress went back to 0)
- made the block height check stricter (check that both are not 0)