### PR TITLE
feat(ui): setup slides reading speed timer

### DIFF
--- a/src/components/elements/LinearProgress.tsx
+++ b/src/components/elements/LinearProgress.tsx
@@ -41,6 +41,7 @@ const Bar = styled(m.div)<{ $variant?: 'primary' | 'small' | 'tiny' }>`
     border-radius: 50px;
     background: ${({ theme }) => theme.palette.contrast};
     height: ${({ $variant }) => ($variant ? '5px' : '10px')};
+    will-change: width;
 `;
 
 export function LinearProgress({

--- a/src/containers/phase/Setup/components/InfoNav/InfoItem.tsx
+++ b/src/containers/phase/Setup/components/InfoNav/InfoItem.tsx
@@ -1,13 +1,9 @@
-import { useTranslation } from 'react-i18next';
 import { Container, Heading, Copy, AnimatedTextContainer } from './InfoNav.styles';
 import { m, Variants } from 'framer-motion';
-const emojis = {
-    'step-1': ['💜', '🐢'],
-    'step-6': ['🙏'],
-};
 
 interface InfoItemProps {
-    step?: number;
+    title: string;
+    text: string;
 }
 
 const container: Variants = {
@@ -51,24 +47,14 @@ function AnimatedLetters({ text }: { text: string }) {
     );
 }
 
-export default function InfoItem({ step = 1 }: InfoItemProps) {
-    const { t } = useTranslation('info');
-    const stepEmojis = emojis[`step-${step}`];
-
-    const emojiParams = {};
-    if (stepEmojis?.length) {
-        stepEmojis.forEach((e: string, i: number) => (emojiParams[`emoji${i > 0 ? i : ''}`] = e));
-    }
-
-    const headingText = t(`heading.step-${step}`);
-    const copyText = t(`content.step-${step}`, { ...emojiParams });
+export default function InfoItem({ title, text }: InfoItemProps) {
     return (
         <Container>
             <Heading>
-                <AnimatedLetters text={headingText} />
+                <AnimatedLetters text={title} />
             </Heading>
             <Copy>
-                <AnimatedLetters text={copyText} />
+                <AnimatedLetters text={text} />
             </Copy>
         </Container>
     );

--- a/src/containers/phase/Setup/components/InfoNav/InfoNav.styles.ts
+++ b/src/containers/phase/Setup/components/InfoNav/InfoNav.styles.ts
@@ -60,12 +60,6 @@ export const NavItem = styled(m.div)<{ $selected?: boolean }>`
     &:hover {
         transform: scaleY(2);
     }
-
-    ${({ $selected }) =>
-        $selected &&
-        css`
-            pointer-events: none;
-        `};
 `;
 
 export const NavItemCurrent = styled(m.div)`

--- a/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
+++ b/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
@@ -4,11 +4,26 @@ import { AnimatePresence } from 'framer-motion';
 import { useCallback, useState } from 'react';
 import InfoItem from './InfoItem';
 import { Nav, NavContainer, NavItem, NavItemCurrent } from './InfoNav.styles';
+import { useTranslation } from 'react-i18next';
 
-const STEP_TIME_SECONDS = 9;
 const steps = Array.from({ length: 6 }, (_, i) => i + 1);
 
+const emojis = {
+    'step-1': ['💜', '🐢'],
+    'step-6': ['🙏'],
+};
+
+const slideTime = {
+    'step-1': 6,
+    'step-2': 8,
+    'step-3': 7,
+    'step-4': 6,
+    'step-5': 9,
+    'step-6': 6,
+};
+
 export default function InfoNav() {
+    const { t } = useTranslation('info');
     const [currentStep, setCurrentStep] = useState(steps[0]);
 
     const handleStepClick = useCallback((newStep: number) => {
@@ -36,7 +51,7 @@ export default function InfoNav() {
                     <NavItemCurrent layoutId="selected" key={`selected:${key}`}>
                         <LinearProgress
                             value={100}
-                            duration={STEP_TIME_SECONDS}
+                            duration={slideTime[`step-${currentStep}`]}
                             variant="tiny"
                             onAnimationComplete={handleNextStep}
                         />
@@ -46,10 +61,20 @@ export default function InfoNav() {
         );
     });
 
+    const stepEmojis = emojis[`step-${currentStep}`];
+
+    const emojiParams = {};
+    if (stepEmojis?.length) {
+        stepEmojis.forEach((e: string, i: number) => (emojiParams[`emoji${i > 0 ? i : ''}`] = e));
+    }
+
+    const title = t(`heading.step-${currentStep}`);
+    const text = t(`content.step-${currentStep}`, { ...emojiParams });
+
     return (
         <NavContainer>
             <AnimatePresence mode="wait">
-                <InfoItem key={`step-${currentStep}-content-wrapper`} step={currentStep} />
+                <InfoItem key={`step-${currentStep}-content-wrapper`} title={title} text={text} />
             </AnimatePresence>
             <AnimatePresence>
                 <InfoItemGraphic key={`step-${currentStep}-graphics-wrapper`} step={currentStep} />

--- a/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
+++ b/src/containers/phase/Setup/components/InfoNav/InfoNav.tsx
@@ -13,13 +13,9 @@ const emojis = {
     'step-6': ['🙏'],
 };
 
-const slideTime = {
-    'step-1': 6,
-    'step-2': 8,
-    'step-3': 7,
-    'step-4': 6,
-    'step-5': 9,
-    'step-6': 6,
+const calculateReadingTime = (text) => {
+    const words = text.split(' ').length;
+    return (words / 350) * 60 + 2; // Convert to seconds + 3s for a pause
 };
 
 export default function InfoNav() {
@@ -40,27 +36,6 @@ export default function InfoNav() {
         });
     };
 
-    const sliderMarkup = steps?.map((step) => {
-        const key = `nav-item-${step}`;
-        const isSelected = currentStep === step;
-
-        return (
-            <NavItem key={key} $selected={isSelected} onClick={() => handleStepClick(step)}>
-                <LinearProgress value={0} variant="tiny" />
-                {isSelected ? (
-                    <NavItemCurrent layoutId="selected" key={`selected:${key}`}>
-                        <LinearProgress
-                            value={100}
-                            duration={slideTime[`step-${currentStep}`]}
-                            variant="tiny"
-                            onAnimationComplete={handleNextStep}
-                        />
-                    </NavItemCurrent>
-                ) : null}
-            </NavItem>
-        );
-    });
-
     const stepEmojis = emojis[`step-${currentStep}`];
 
     const emojiParams = {};
@@ -70,6 +45,28 @@ export default function InfoNav() {
 
     const title = t(`heading.step-${currentStep}`);
     const text = t(`content.step-${currentStep}`, { ...emojiParams });
+
+    const sliderMarkup = steps?.map((step) => {
+        const key = `nav-item-${step}`;
+        const isSelected = currentStep === step;
+        const duration = calculateReadingTime(title + text);
+
+        return (
+            <NavItem key={key} $selected={isSelected} onClick={() => handleStepClick(step)}>
+                <LinearProgress value={0} variant="tiny" />
+                {isSelected ? (
+                    <NavItemCurrent layoutId="selected" key={`selected:${key}`}>
+                        <LinearProgress
+                            value={100}
+                            duration={duration}
+                            variant="tiny"
+                            onAnimationComplete={handleNextStep}
+                        />
+                    </NavItemCurrent>
+                ) : null}
+            </NavItem>
+        );
+    });
 
     return (
         <NavContainer>

--- a/src/containers/phase/Setup/components/Permissions.tsx
+++ b/src/containers/phase/Setup/components/Permissions.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
     display: flex;
     height: 45px;
-    padding: 11px;
+    padding: 11px 11px 11px 20px;
     justify-content: center;
     align-items: center;
     border-radius: 60px;


### PR DESCRIPTION
This PR adds a function to calculate the reading speed of each slide on the setup screens based on text length. 

https://www.loom.com/share/df378764a9ac4d10b5fe2ab4a85d2616?sid=cdabc628-7b6d-4e0d-81b4-ad1b4746dd43