### PR TITLE
chore: add translation content json files to .pretterignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,9 @@ coverage
 # Ignore all HTML files:
 **/*.html
 
+# Ignore all JSON files in locales:
+**/locales/**/*.json
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Whenever I make a change to the translation `json` files in `/public/locales/en/*.json` it changes the format for the whole file, which is annoying and a little risky. Merge conflicts are more common and we should be able to track the specific changes within these files when doing code review. 

My solution is just to have Prettier ignore these translation files. Alternatively, to solve this problem we could update all automation scripts to match our prettier settings... but this is simpler. 

Let me know if your thoughts on this change, any objections?