### PR TITLE
fix!: fix check for database corruption

### DIFF
--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -4,8 +4,8 @@
         "mmproxy": "=1.9.0-pre.0",
         "minotari_node": "=1.9.0-pre.0",
         "wallet": "=1.9.0-pre.0",
-        "sha-p2pool": "=0.8.1",
-        "xtrgpuminer": "=0.1.19",
+        "sha-p2pool": "=0.9.0",
+        "xtrgpuminer": "=0.1.22",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -1,11 +1,11 @@
 {
     "binaries": {
         "xmrig": "=6.22.0",
-        "mmproxy": "=1.8.0-pre.0",
-        "minotari_node": "=1.8.0-pre.0",
-        "wallet": "=1.8.0-pre.0",
-        "sha-p2pool": "=0.8.0",
-        "xtrgpuminer": "=0.1.17",
+        "mmproxy": "=1.9.0-pre.0",
+        "minotari_node": "=1.9.0-pre.0",
+        "wallet": "=1.9.0-pre.0",
+        "sha-p2pool": "=0.8.1",
+        "xtrgpuminer": "=0.1.19",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/binaries_versions_nextnet.json
+++ b/src-tauri/binaries_versions_nextnet.json
@@ -4,8 +4,8 @@
         "mmproxy": "=1.9.0-rc.0",
         "minotari_node": "=1.9.0-rc.0",
         "wallet": "=1.9.0-rc.0",
-        "sha-p2pool": "=0.8.1",
-        "xtrgpuminer": "=0.1.18",
+        "sha-p2pool": "=0.9.0",
+        "xtrgpuminer": "=0.1.22",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/binaries_versions_nextnet.json
+++ b/src-tauri/binaries_versions_nextnet.json
@@ -1,11 +1,11 @@
 {
     "binaries": {
         "xmrig": "=6.22.0",
-        "mmproxy": "=1.8.0-rc.0",
-        "minotari_node": "=1.8.0-rc.0",
-        "wallet": "=1.8.0-rc.0",
-        "sha-p2pool": "=0.8.0",
-        "xtrgpuminer": "=0.1.17",
+        "mmproxy": "=1.9.0-rc.0",
+        "minotari_node": "=1.9.0-rc.0",
+        "wallet": "=1.9.0-rc.0",
+        "sha-p2pool": "=0.8.1",
+        "xtrgpuminer": "=0.1.18",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -92,7 +92,11 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                       _ = watch_timer.tick() => {
                         let status_monitor3 = status_monitor2.clone();
 
-                        do_health_check(&mut child, status_monitor3, name.clone(), &mut uptime, expected_startup_time, health_timeout, app_shutdown.clone(), inner_shutdown.clone(), &mut warning_count).await?;
+                        let exit_code = do_health_check(&mut child, status_monitor3, name.clone(), &mut uptime, expected_startup_time, health_timeout, app_shutdown.clone(), inner_shutdown.clone(), &mut warning_count).await?;
+                            if exit_code != 0 {
+                            return Ok(exit_code);
+
+                        }
                             //    break;
                       },
                     _ = inner_shutdown.wait() => {
@@ -149,7 +153,7 @@ async fn do_health_check<T: StatusMonitor>(
     app_shutdown: ShutdownSignal,
     inner_shutdown: ShutdownSignal,
     warning_count: &mut u32,
-) -> Result<(), anyhow::Error> {
+) -> Result<i32, anyhow::Error> {
     let mut is_healthy = false;
 
     if child.ping() {
@@ -200,7 +204,8 @@ async fn do_health_check<T: StatusMonitor>(
                 Ok(exit_code) => {
                     if exit_code != 0 {
                         error!(target: LOG_TARGET, "{} exited with error code: {}", name, exit_code);
-                        //   return Ok(exit_code);
+                        // Do not restart on non-zero exit code. This will just keep happening.
+                        return Ok(exit_code);
                     } else {
                         info!(target: LOG_TARGET, "{} exited successfully", name);
                     }
@@ -219,5 +224,5 @@ async fn do_health_check<T: StatusMonitor>(
             // sleep(Duration::from_secs(10)).await;
         }
     }
-    Ok(())
+    Ok(0)
 }


### PR DESCRIPTION
Upgrades to v1.9.0. 

It also fixes a bug where it would not detect a corrupt database. Not sure how this was working before. But if the database was corrupt (or not compatible), it should delete the node database and resync.

BREAKING CHANGE: The hard fork on minotari_node means that the chain needs to be synced again. This will happen automatically, but note that start up will be longer