### PR TITLE
fix: check token expiration before airdrop request

### DIFF
--- a/src/hooks/airdrop/utils/useHandleRequest.ts
+++ b/src/hooks/airdrop/utils/useHandleRequest.ts
@@ -10,10 +10,12 @@ interface RequestProps {
 
 export const useAirdropRequest = () => {
     const airdropToken = useAirdropStore((state) => state.airdropTokens?.token);
+    const airdropTokenExpiration = useAirdropStore((state) => state.airdropTokens?.expiresAt);
     const baseUrl = useAirdropStore((state) => state.backendInMemoryConfig?.airdropApiUrl);
 
     return async <T>({ body, method, path, onError }: RequestProps) => {
-        if (!baseUrl || !airdropToken) return;
+        const isTokenExpired = !airdropTokenExpiration || airdropTokenExpiration * 1000 < Date.now();
+        if (!baseUrl || !airdropToken || isTokenExpired) return;
 
         const fullUrl = `${baseUrl}${path}`;
 


### PR DESCRIPTION
[#853](https://github.com/tari-project/universe/issues/853)

Description
---
We have observed a some number of 401 responses from airdrop requests in Sentry. My previous pr (https://github.com/tari-project/universe/pull/1079) should solve this issue.

I'm additionally adding a check for token expiration.
