### PR TITLE
fix(orhpan-chain): verify node is synced before checking if it's orphan chain

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1615,7 +1615,6 @@ async fn check_if_is_orphan_chain(app_handle: tauri::AppHandle) {
         }
         Err(e) => {
             error!(target: LOG_TARGET, "{}", e);
-            drop(app_handle.emit_all("is_stuck", true));
         }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1610,8 +1610,8 @@ async fn check_if_is_orphan_chain(app_handle: tauri::AppHandle) {
         Ok(is_stuck) => {
             if is_stuck {
                 error!(target: LOG_TARGET, "Miner is stuck on orphan chain");
-                drop(app_handle.emit_all("is_stuck", is_stuck));
             }
+            drop(app_handle.emit_all("is_stuck", is_stuck));
         }
         Err(e) => {
             error!(target: LOG_TARGET, "{}", e);

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use log::error;
+use log::{error, warn};
 use minotari_node_grpc_client::grpc::Peer;
 use tari_common::configuration::Network;
 use tari_core::transactions::tari_amount::MicroMinotari;
@@ -211,6 +211,13 @@ impl NodeManager {
             .status_monitor
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Node not started"))?;
+        let (_, _, _, _, _, is_synced) = self.get_network_hash_rate_and_block_reward().await?;
+        if !is_synced {
+            warn!(target: LOG_TARGET, "Node is not synced, skipping orphan chain check");
+            return Ok(false);
+        } else {
+            warn!(target: LOG_TARGET, "Node is synced, checking orphan chain");
+        }
         let network = Network::get_current_or_user_setting_or_default();
         let block_scan_tip = get_best_block_from_block_scan(network).await?;
         let heights: Vec<u64> = vec![

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use chrono::{NaiveDateTime, TimeZone, Utc};
-use log::{error, warn};
+use log::{error, info};
 use minotari_node_grpc_client::grpc::Peer;
 use tari_common::configuration::Network;
 use tari_core::transactions::tari_amount::MicroMinotari;
@@ -222,11 +222,10 @@ impl NodeManager {
                 }
             })?;
         if !is_synced {
-            warn!(target: LOG_TARGET, "Node is not synced, skipping orphan chain check");
+            info!(target: LOG_TARGET, "Node is not synced, skipping orphan chain check");
             return Ok(false);
-        } else {
-            warn!(target: LOG_TARGET, "Node is synced, checking orphan chain");
         }
+
         let network = Network::get_current_or_user_setting_or_default();
         let block_scan_tip = get_best_block_from_block_scan(network).await?;
         let heights: Vec<u64> = vec![

--- a/src/containers/main/SideBar/components/OrphanChainAlert.tsx
+++ b/src/containers/main/SideBar/components/OrphanChainAlert.tsx
@@ -15,15 +15,13 @@ export const OrphanChainAlert = () => {
     const { t } = useTranslation('settings', { useSuspense: false });
 
     useEffect(() => {
-        const unlistenPromise = listen('is_stuck', (event) => {
-            if (event.payload) {
-                setIsOrphanChain(true);
-            }
+        const unlistenPromise = listen<boolean>('is_stuck', (event) => {
+            setIsOrphanChain(event.payload);
         });
         return () => {
             unlistenPromise.then((unlisten) => unlisten());
         };
-    });
+    }, [setIsOrphanChain]);
 
     return isOrphanChain ? (
         <Stack direction="row" justifyContent="space-between" alignItems="center">


### PR DESCRIPTION
Description
---
Check if node is synced before validating block hash against text explorer and fix bug where warning was shown even after node was no longer an orphan chain.

Motivation and Context
---
Many users reported false positive where they had warning but they were sure it wasn't the case. This could be achieved if user disconnected internet connection and connected again.

How Has This Been Tested?
---
Disconnect WiFi and connect again. While disconnected there should be warning but after connecting it should go away after 1 minute max.

What process can a PR reviewer use to test or verify this change?
---
Same as above.



Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
