### PR TITLE
fix(ui): history item

### DIFF
--- a/src/containers/main/SideBar/components/Wallet/HistoryItem.styles.ts
+++ b/src/containers/main/SideBar/components/Wallet/HistoryItem.styles.ts
@@ -94,18 +94,12 @@ export const HoverWrapper = styled(m.div)`
     position: absolute;
     inset: 0;
     z-index: 4;
-    background-color: rgba(255, 255, 255, 0.1);
-    align-items: center;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    height: 100%;
-    gap: 6px;
-    padding: 0 10px;
     transition: background-color 2s ease;
+    background-color: rgba(255, 255, 255, 0.1);
+    height: 100%;
 `;
 
-export const ReplayButton = styled(m.button)`
+export const ReplayButton = styled.button`
     display: flex;
     border-radius: 100%;
     position: relative;
@@ -113,14 +107,13 @@ export const ReplayButton = styled(m.button)`
     height: 31px;
     justify-content: center;
     border: 1px solid rgba(255, 255, 255, 0.15);
-
     background-color: ${({ theme }) => theme.colors.grey[600]};
     color: #fff;
     box-sizing: border-box;
+    transition: opacity 0.2s ease;
+
     &:hover {
-        svg {
-            scale: 1.05;
-        }
+        opacity: 0.8;
     }
 
     svg {
@@ -128,11 +121,20 @@ export const ReplayButton = styled(m.button)`
         position: relative;
         top: 50%;
         transform: translateY(-50%);
-        transition: scale 0.1s ease;
     }
 `;
 
-export const FlexButton = styled(m.button)`
+export const ButtonWrapper = styled(m.div)`
+    position: relative;
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    padding: 0 10px;
+    justify-content: flex-end;
+    height: 100%;
+    gap: 6px;
+`;
+export const FlexButton = styled.button`
     display: flex;
     height: 31px;
     padding: 8px 5px 8px 18px;
@@ -147,9 +149,9 @@ export const FlexButton = styled(m.button)`
     color: #000;
     font-size: 12px;
     font-weight: 600;
-    line-height: normal;
+    line-height: 1;
     cursor: pointer;
-
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0);
     &:hover {
         box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.4);
     }
@@ -158,17 +160,20 @@ export const FlexButton = styled(m.button)`
 export const GemPill = styled.div`
     border-radius: 60px;
     background: #000;
-
+    justify-content: center;
     display: flex;
     height: 20px;
-    padding: 7px 5px 7px 8px;
+    padding: 0 5px 0 8px;
     align-items: center;
     gap: 4px;
 
-    color: #fff;
-    font-size: 10px;
-    font-weight: 600;
-    line-height: normal;
+    span {
+        color: #fff;
+        display: flex;
+        font-size: 10px;
+        font-weight: 600;
+        line-height: 1.1;
+    }
 `;
 
 export const GemImage = styled.img`

--- a/src/containers/main/SideBar/components/Wallet/HistoryItem.styles.ts
+++ b/src/containers/main/SideBar/components/Wallet/HistoryItem.styles.ts
@@ -22,12 +22,6 @@ export const Wrapper = styled(m.div)`
     font-family:
         GTAmerica Standard,
         sans-serif;
-
-    &:hover {
-        .hover-target {
-            opacity: 0.2;
-        }
-    }
 `;
 
 export const LeftContent = styled.div`
@@ -35,6 +29,11 @@ export const LeftContent = styled.div`
     display: flex;
     gap: 10px;
     flex-shrink: 0;
+    transition: opacity 0.2s ease-in;
+
+    ${Wrapper}:hover & {
+        opacity: 0.2;
+    }
 `;
 
 export const SquadIconWrapper = styled.div<{ $colour: string; $colour1: string; $colour2: string }>`
@@ -77,6 +76,10 @@ export const EarningsWrapper = styled.div`
     flex-shrink: 0;
     font-weight: 600;
     font-size: 16px;
+    transition: opacity 0.2s ease-in;
+    ${Wrapper}:hover & {
+        opacity: 0.2;
+    }
 `;
 
 export const ListLabel = styled.div`
@@ -110,6 +113,7 @@ export const ReplayButton = styled(m.button)`
     height: 31px;
     justify-content: center;
     border: 1px solid rgba(255, 255, 255, 0.15);
+
     background-color: ${({ theme }) => theme.colors.grey[600]};
     color: #fff;
     box-sizing: border-box;
@@ -145,7 +149,6 @@ export const FlexButton = styled(m.button)`
     font-weight: 600;
     line-height: normal;
     cursor: pointer;
-    right: 0;
 
     &:hover {
         box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.4);

--- a/src/containers/main/SideBar/components/Wallet/HistoryItem.tsx
+++ b/src/containers/main/SideBar/components/Wallet/HistoryItem.tsx
@@ -1,5 +1,6 @@
 import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore';
 import {
+    ButtonWrapper,
     EarningsWrapper,
     FlexButton,
     GemImage,
@@ -91,22 +92,24 @@ export default function HistoryItem({ item }: HistoryItemProps) {
             <AnimatePresence>
                 {hovering && (
                     <HoverWrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                        {showShareButton && (
-                            <FlexButton
-                                initial={{ x: 10 }}
-                                animate={{ x: 0 }}
-                                exit={{ x: 10 }}
-                                onClick={handleShareClick}
-                            >
-                                {t('share.history-item-button')}
-                                <GemPill>
-                                    {gemsValue} <GemImage src={gemImage} alt="" />
-                                </GemPill>
-                            </FlexButton>
-                        )}
-                        <ReplayButton onClick={handleReplay}>
-                            <ReplaySVG />
-                        </ReplayButton>
+                        <ButtonWrapper
+                            initial={{ opacity: 0, y: 5 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: 5 }}
+                        >
+                            {showShareButton && (
+                                <FlexButton onClick={handleShareClick}>
+                                    {t('share.history-item-button')}
+                                    <GemPill>
+                                        <span>{gemsValue}</span>
+                                        <GemImage src={gemImage} alt="" />
+                                    </GemPill>
+                                </FlexButton>
+                            )}
+                            <ReplayButton onClick={handleReplay}>
+                                <ReplaySVG />
+                            </ReplayButton>
+                        </ButtonWrapper>
                     </HoverWrapper>
                 )}
             </AnimatePresence>

--- a/src/containers/main/SideBar/components/Wallet/HistoryItem.tsx
+++ b/src/containers/main/SideBar/components/Wallet/HistoryItem.tsx
@@ -88,15 +88,14 @@ export default function HistoryItem({ item }: HistoryItemProps) {
     const showShareButton = sharingEnabled && isLoggedIn;
     return (
         <Wrapper onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)}>
-            {showShareButton && (
-                <AnimatePresence>
-                    {hovering && (
-                        <HoverWrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+            <AnimatePresence>
+                {hovering && (
+                    <HoverWrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                        {showShareButton && (
                             <FlexButton
-                                initial={{ x: 20 }}
+                                initial={{ x: 10 }}
                                 animate={{ x: 0 }}
-                                transition={{ delay: 0.1 }}
-                                exit={{ x: 20 }}
+                                exit={{ x: 10 }}
                                 onClick={handleShareClick}
                             >
                                 {t('share.history-item-button')}
@@ -104,15 +103,15 @@ export default function HistoryItem({ item }: HistoryItemProps) {
                                     {gemsValue} <GemImage src={gemImage} alt="" />
                                 </GemPill>
                             </FlexButton>
-                            <ReplayButton onClick={handleReplay}>
-                                <ReplaySVG />
-                            </ReplayButton>
-                        </HoverWrapper>
-                    )}
-                </AnimatePresence>
-            )}
+                        )}
+                        <ReplayButton onClick={handleReplay}>
+                            <ReplaySVG />
+                        </ReplayButton>
+                    </HoverWrapper>
+                )}
+            </AnimatePresence>
 
-            <LeftContent className={showShareButton ? 'hover-target' : ''}>
+            <LeftContent>
                 <SquadIconWrapper $colour={colour} $colour1={colour1} $colour2={colour2}>
                     <TariSvg />
                 </SquadIconWrapper>


### PR DESCRIPTION
Description
---
- moved the parent hover style reference and added to the right side items too
- noticed while testing the `showShareButton` check meant the replay button would also be hidden if you weren't logged in with airdrop so fixed up those checks too


Motivation and Context
---

| half of the history item styling wasn't updated on hover |
| :---: |
| ![image](https://github.com/user-attachments/assets/874d0597-b9b4-431b-a228-ebeb27e9c1e9) |


How Has This Been Tested?
---

- locally:


https://github.com/user-attachments/assets/e9a39322-addd-4c2f-ba04-eb06816bcf34


https://github.com/user-attachments/assets/fbf12ee8-2f34-41bf-be67-965e7dabd52e

https://github.com/user-attachments/assets/923a4a46-34ec-43ed-bf8e-17599258f612


**(only to show animation change:)**

https://github.com/user-attachments/assets/17c61044-4fb4-4750-af68-23aeb6e3589a




What process can a PR reviewer use to test or verify this change?
---

- check the history items when logged in and out with airdrop
- make sure the history item styling isn't peeking through anywhere on hover:3


Breaking Changes
---

- [x] None
