### PR TITLE
fix: auto updater triggered multiple times

### DIFF
--- a/src/hooks/useUpdateStatus.ts
+++ b/src/hooks/useUpdateStatus.ts
@@ -134,6 +134,8 @@ export function useUpdateListener() {
 
     useEffect(() => {
         if (initialCheck.current) return;
-        checkUpdateTariUniverse().then(() => (initialCheck.current = true));
+        initialCheck.current = true;
+
+        checkUpdateTariUniverse();
     }, [checkUpdateTariUniverse]);
 }


### PR DESCRIPTION
Description
---
There was an issue with auto-update checker executed multiple times which led to executing auto-update multiple times in the same time

See logs:
```
[Log] INITIAL CHECK (useUpdateStatus.ts, line 129)
[Log] INITIAL CHECK (useUpdateStatus.ts, line 129)
[Log] INITIAL CHECK (useUpdateStatus.ts, line 129)
[Info] New Tari Universe version available – Object (useUpdateStatus.ts, line 94)
[Info] New Tari Universe version available – Object (useUpdateStatus.ts, line 94)
[Log] INITIAL CHECK FLAG SET TO FALSE (useUpdateStatus.ts, line 131, x2)
[Info] New Tari Universe version available – Object (useUpdateStatus.ts, line 94)
[Info] Proceed with auto-update (useUpdateStatus.ts, line 99)
[Info] Updater event – null – "PENDING" (useUpdateStatus.ts, line 121)
[Log] INITIAL CHECK FLAG SET TO FALSE (useUpdateStatus.ts, line 131)
[Info] Updater event – null – "PENDING" (useUpdateStatus.ts, line 121)
```