### PR TITLE
chore: dedupe sentry logging | ignore already getting x warns | fix lints

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,12 +9,12 @@ version = "0.7.4"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {version = "1.5.5", features = ["isolation"]}
+tauri-build = { version = "1.5.5", features = ["isolation"] }
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.81"
-async_zip = {version = "0.0.17", features = ["full"]}
+async_zip = { version = "0.0.17", features = ["full"] }
 auto-launch = "0.5.0"
 base64 = "0.22.1"
 blake2 = "0.10"
@@ -27,46 +27,46 @@ futures-lite = "2.3.0"
 futures-util = "0.3.30"
 human_format = "1.1.0"
 jsonwebtoken = "9.3.0"
-keyring = {version = "3.0.5", features = [
+keyring = { version = "3.0.5", features = [
   "windows-native",
   "apple-native",
   "linux-native",
-]}
-libsqlite3-sys = {version = "0.25.1", features = [
+] }
+libsqlite3-sys = { version = "0.25.1", features = [
   "bundled",
-]}# Required for tari_wallet
+] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-minotari_wallet_grpc_client = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-nix = {version = "0.29.0", features = ["signal"]}
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 phraze = "0.3.15"
 rand = "0.8.5"
 regex = "1.10.5"
-reqwest = {version = "0.12.5", features = ["stream", "json", "multipart"]}
+reqwest = { version = "0.12.5", features = ["stream", "json", "multipart"] }
 sanitize-filename = "0.5"
 semver = "1.0.23"
-sentry = {version = "0.34.0", features = ["anyhow"]}
+sentry = { version = "0.34.0", features = ["anyhow"] }
 sentry-tauri = "0.3.0"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.10"
 sha2 = "0.10.8"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-tari_common_types = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-tari_core = {git = "https://github.com/tari-project/tari.git", branch = "development", features = [
+tari_common = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+tari_core = { git = "https://github.com/tari-project/tari.git", branch = "development", features = [
   "transactions",
-]}
+] }
 tari_crypto = "0.21.0"
-tari_key_manager = {git = "https://github.com/tari-project/tari.git", branch = "development"}
-tari_shutdown = {git = "https://github.com/tari-project/tari.git", branch = "development"}
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", branch = "development" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", branch = "development" }
 tari_utilities = "0.8.0"
-tauri = {version = "1.8.0", features = [
+tauri = { version = "1.8.0", features = [
   "window-unmaximize",
   "window-unminimize",
   "os-all",
@@ -86,12 +86,12 @@ tauri = {version = "1.8.0", features = [
   "icon-ico",
   "icon-png",
   "process-command-api",
-]}
-tauri-plugin-single-instance = {git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1"}
+] }
+tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 thiserror = "1.0.26"
-tokio = {version = "1", features = ["full"]}
-tokio-util = {version = "0.7.11", features = ["compat"]}
-xz2 = {version = "0.1.7", features = ["static"]}# static bind lzma
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7.11", features = ["compat"] }
+xz2 = { version = "0.1.7", features = ["static"] } # static bind lzma
 zip = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
@@ -100,7 +100,7 @@ winreg = "0.52.0"
 # needed for keymanager. TODO: Find a way of creating a keymanager without bundling sqlite
 chrono = "0.4.38"
 device_query = "2.1.0"
-libsqlite3-sys = {version = "0.25.1", features = ["bundled"]}
+libsqlite3-sys = { version = "0.25.1", features = ["bundled"] }
 log = "0.4.22"
 nvml-wrapper = "0.10.0"
 rand = "0.8.5"

--- a/src/App/AppWrapper.tsx
+++ b/src/App/AppWrapper.tsx
@@ -1,3 +1,4 @@
+import { IGNORE_FETCHING } from '@app/App/sentryIgnore';
 import { useDisableRefresh } from '@app/hooks/useDisableRefresh';
 import { useListenForExternalDependencies } from '@app/hooks/useListenForExternalDependencies';
 import { useUpdateListener } from '@app/hooks/useUpdateStatus';
@@ -16,7 +17,7 @@ import App from './App.tsx';
 const environment = import.meta.env.MODE;
 const sentryOptions = {
     dsn: 'https://edd6b9c1494eb7fda6ee45590b80bcee@o4504839079002112.ingest.us.sentry.io/4507979991285760',
-    integrations: [Sentry.captureConsoleIntegration({ levels: ['warn', 'error'] })],
+    integrations: [Sentry.captureConsoleIntegration({ levels: ['warn', 'error'] }), Sentry.extraErrorDataIntegration()],
     release: packageInfo.version,
     environment,
     // Set tracesSampleRate to 1.0 to capture 100%
@@ -24,6 +25,7 @@ const sentryOptions = {
     tracesSampleRate: 1.0,
     attachStacktrace: true,
     autoSessionTracking: false,
+    ignoreErrors: [...IGNORE_FETCHING],
     enabled: environment !== 'development',
 };
 
@@ -37,7 +39,6 @@ export default function AppWrapper() {
     useUpdateListener();
     useLangaugeResolver();
     useListenForExternalDependencies();
-
     useEffect(() => {
         async function initialize() {
             await fetchAppConfig();

--- a/src/App/sentryIgnore.ts
+++ b/src/App/sentryIgnore.ts
@@ -1,0 +1,10 @@
+const HISTORY = 'Already getting transaction history';
+const METRICS = 'Already getting miner metrics';
+const BALANCE = 'Already getting wallet balance';
+
+export const ALREADY_FETCHING = {
+    HISTORY,
+    METRICS,
+    BALANCE,
+};
+export const IGNORE_FETCHING = Object.values(ALREADY_FETCHING);

--- a/src/components/dialogs/RestartDialog.tsx
+++ b/src/components/dialogs/RestartDialog.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/tauri';
@@ -34,7 +33,6 @@ export default function RestartDialog() {
             console.info('Restarting application.');
             await invoke('restart_application', { shouldStopMiners: true });
         } catch (error) {
-            Sentry.captureException(error);
             console.error('Restart error: ', error);
         }
     }, []);

--- a/src/components/dialogs/SendLogsDialog.tsx
+++ b/src/components/dialogs/SendLogsDialog.tsx
@@ -11,7 +11,6 @@ import { Stack } from '@app/components/elements/Stack.tsx';
 
 import { TextArea } from '@app/components/elements/inputs/TextArea.tsx';
 import { SquaredButton } from '@app/components/elements/buttons/SquaredButton.tsx';
-import * as Sentry from '@sentry/react';
 
 export function SendLogsDialog({ onSetReference }: { onSetReference?: (reference: string) => void }) {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
@@ -46,7 +45,7 @@ export function SendLogsDialog({ onSetReference }: { onSetReference?: (reference
                 onSetReference?.(r);
             })
             .catch((error) => {
-                Sentry.captureException(error);
+                console.error('Error sending feedback: ', error);
                 setError(error.toString());
             })
             .finally(() => {

--- a/src/containers/floating/CriticalErrorDialog/CriticalErrorDialog.tsx
+++ b/src/containers/floating/CriticalErrorDialog/CriticalErrorDialog.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import Linkify from 'linkify-react';
 
 import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog';
@@ -31,8 +30,7 @@ const CriticalErrorDialog = () => {
             setIsExiting(true);
             await invoke('exit_application');
         } catch (e) {
-            Sentry.captureException(e, { data: 'handleExit in CriticalErrorDialog' });
-            console.error('Error closing application: ', e);
+            console.error('Error closing application| handleExit in CriticalErrorDialog: ', e);
         }
         setIsExiting(false);
     }, []);

--- a/src/containers/floating/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
+++ b/src/containers/floating/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/react';
-
 import { SquaredButton } from '@app/components/elements/buttons/SquaredButton';
 import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog';
 import { Divider } from '@app/components/elements/Divider';
@@ -30,7 +28,6 @@ export const ExternalDependenciesDialog = () => {
             setIsRestarting(true);
             await invoke('restart_application', { shouldStopMiners: true });
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Error restarting application:', e);
         }
         setIsRestarting(false);
@@ -42,7 +39,6 @@ export const ExternalDependenciesDialog = () => {
         setIsInitializing(true);
         invoke('setup_application')
             .catch((e) => {
-                Sentry.captureException(e);
                 setCriticalError(`Failed to setup application: ${e}`);
                 setView('mining');
             })

--- a/src/containers/floating/ExternalDependenciesDialog/ExternalDependencyCard.tsx
+++ b/src/containers/floating/ExternalDependenciesDialog/ExternalDependencyCard.tsx
@@ -9,7 +9,6 @@ import { useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@app/components/elements/buttons/Button.tsx';
-import * as Sentry from '@sentry/react';
 
 import { SpinnerIcon } from '@app/components/elements/loaders/SpinnerIcon.tsx';
 
@@ -39,11 +38,10 @@ export const ExternalDependencyCard = ({
                     await fetchExternalDependencies();
                 })
                 .catch((e) => {
-                    Sentry.captureException(e);
+                    console.error('External dependency | caught error in download', e);
                     setError(`Failed to download and start installer: ${e} Please try again.`);
                 });
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Error downloading installer: ', e);
         }
 

--- a/src/containers/floating/PaperWalletModal/sections/ConnectSection/ConnectSection.tsx
+++ b/src/containers/floating/PaperWalletModal/sections/ConnectSection/ConnectSection.tsx
@@ -14,7 +14,6 @@ import { useCallback, useState } from 'react';
 import { usePaperWalletStore } from '@app/store/usePaperWalletStore';
 import { invoke } from '@tauri-apps/api/tauri';
 import LoadingSvg from '@app/components/svgs/LoadingSvg';
-import * as Sentry from '@sentry/react';
 
 interface Props {
     setSection: (section: PaperWalletModalSectionType) => void;
@@ -48,8 +47,7 @@ export default function ConnectSection({ setSection }: Props) {
                 setSection('QRCode');
             }
         } catch (e) {
-            Sentry.captureException(e);
-            console.error('Failed to get paper wallet details');
+            console.error('Failed to get paper wallet details', e);
         }
 
         setIsLoading(false);

--- a/src/containers/floating/Settings/sections/airdrop/ApplyInviteCode.tsx
+++ b/src/containers/floating/Settings/sections/airdrop/ApplyInviteCode.tsx
@@ -18,8 +18,6 @@ import { useAppConfigStore } from '@app/store/useAppConfigStore';
 import { open } from '@tauri-apps/api/shell';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
 
-import * as Sentry from '@sentry/react';
-
 export const ApplyInviteCode = () => {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const setAllowTelemetry = useAppConfigStore((s) => s.setAllowTelemetry);
@@ -58,7 +56,7 @@ export const ApplyInviteCode = () => {
                     }
                 })
                 .catch((e) => {
-                    Sentry.captureException(e);
+                    console.error('Backend memory config error:', e);
                     return false;
                 });
 

--- a/src/containers/floating/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
+++ b/src/containers/floating/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import * as Sentry from '@sentry/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/tauri';
 import { useUIStore } from '@app/store/useUIStore.ts';
@@ -75,8 +74,7 @@ export const TorMarkup = () => {
                 setIsRandomControlPort(!torConfig?.control_port);
             })
             .catch((e) => {
-                Sentry.captureException(e);
-                console.error(e);
+                console.error('Get Tor config error:', e);
             });
     }, []);
 
@@ -99,7 +97,6 @@ export const TorMarkup = () => {
                 });
                 setDefaultTorConfig(updatedConfig);
             } catch (error) {
-                Sentry.captureException(error);
                 console.error('Update Tor config error:', error);
             }
         }

--- a/src/containers/floating/Settings/sections/general/LogsSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/LogsSettings.tsx
@@ -18,7 +18,6 @@ import { Stack } from '@app/components/elements/Stack.tsx';
 
 import { IoCheckmarkOutline, IoCopyOutline } from 'react-icons/io5';
 import { IconButton } from '@app/components/elements/buttons/IconButton.tsx';
-import * as Sentry from '@sentry/react';
 
 export default function LogsSettings() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
@@ -33,7 +32,6 @@ export default function LogsSettings() {
                 console.info('Opening logs directory');
             })
             .catch((error) => {
-                Sentry.captureException(error);
                 console.error('Error opening logs directory: ', error);
             });
     };

--- a/src/containers/floating/Settings/sections/general/ResetSettingsButton.tsx
+++ b/src/containers/floating/Settings/sections/general/ResetSettingsButton.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api';
-import * as Sentry from '@sentry/react';
-
 import { useAppStateStore } from '@app/store/appStateStore';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
@@ -36,7 +34,6 @@ export const ResetSettingsButton = () => {
                 setOpen(false);
             })
             .catch((e) => {
-                Sentry.captureException(e);
                 console.error('Error when resetting settings: ', e);
                 setError('Resetting settings failed: ' + e);
                 setLoading(false);

--- a/src/containers/floating/Settings/sections/p2p/P2poolStatsMarkup.tsx
+++ b/src/containers/floating/Settings/sections/p2p/P2poolStatsMarkup.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as Sentry from '@sentry/react';
 
 import { CardComponent } from '@app/containers/floating/Settings/components/Card.component';
 import { CardContainer } from '@app/containers/floating/Settings/components/Settings.styles';
@@ -30,7 +29,6 @@ const P2PoolStats = () => {
             try {
                 await fetchP2pStats();
             } catch (error) {
-                Sentry.captureException(error);
                 console.error('Error fetching p2pool stats:', error);
             }
         }, 5000);

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api/tauri';
-import * as Sentry from '@sentry/react';
 
 export function useGetSeedWords() {
     const [seedWords, setSeedWords] = useState<string[]>([]);
@@ -12,7 +11,6 @@ export function useGetSeedWords() {
             const seedWords = await invoke('get_seed_words');
             setSeedWords(seedWords);
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Could not get seed words', e);
         } finally {
             setSeedWordsFetching(false);

--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialog.tsx
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialog.tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@app/components/elements/Typography';
 import { useMiningStore } from '@app/store/useMiningStore';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { GpuThreads, MaxConsumptionLevels } from '@app/types/app-status';
 import { RangeInputComponent } from './RangeInput';
 import { useAppConfigStore } from '@app/store/useAppConfigStore';
@@ -86,7 +86,7 @@ export function CustomPowerLevelsDialog({
     const changeMiningMode = useMiningStore((s) => s.changeMiningMode);
     const isChangingMode = useMiningStore((s) => s.isChangingMode);
 
-    const { control, handleSubmit, setValue, getValues } = useForm<FormValues>({
+    const { control, handleSubmit, setValue } = useForm<FormValues>({
         defaultValues: {
             [FormFields.CPU]: resolveCpuInitialThreads(configCpuLevels, mode, maxAvailableThreads),
             [FormFields.GPUS]: resolveGpuInitialThreads(configGpuLevels, mode, maxAvailableThreads),
@@ -155,7 +155,7 @@ export function CustomPowerLevelsDialog({
                         key={gpu.id}
                         control={control}
                         name={`${FormFields.GPUS}.${index}.gpu_name`}
-                        render={({ field }) => (
+                        render={({ field: _field }) => (
                             <RangeInputComponent
                                 label={`${t('custom-power-levels.gpu-power-level', { index: index + 1 })}: ${gpu.gpu_name}`}
                                 maxLevel={maxAvailableThreads.max_gpus_threads[index].max_gpu_threads}

--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
@@ -19,7 +19,7 @@ export const CustomPowerLevelsDialogContainer = () => {
         if (!maxThreads) {
             fetchMaxThreads();
         }
-    }, [maxThreads]);
+    }, [fetchMaxThreads, maxThreads]);
 
     return (
         <Dialog

--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.tsx
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.tsx
@@ -99,18 +99,6 @@ export const RangeInputComponent = ({
     }, [currentValue, isHover, maxLevel]);
     if (!maxLevel) return null;
 
-    console.log('RangeInputComponent', {
-        label,
-        maxLevel,
-        value,
-        desc,
-        warning,
-        isLoading,
-        usePercentage,
-        step,
-        onChange,
-    });
-
     return (
         <>
             <InputContainer>

--- a/src/hooks/airdrop/stateHelpers/useAirdropUserPointsListener.ts
+++ b/src/hooks/airdrop/stateHelpers/useAirdropUserPointsListener.ts
@@ -1,7 +1,6 @@
 import { useAirdropStore, UserPoints } from '@app/store/useAirdropStore';
 import { listen } from '@tauri-apps/api/event';
 import { useEffect } from 'react';
-import * as Sentry from '@sentry/react';
 
 export const useAirdropUserPointsListener = () => {
     const setUserPoints = useAirdropStore((state) => state.setUserPoints);
@@ -41,8 +40,7 @@ export const useAirdropUserPointsListener = () => {
                 unListen = unListenFunction;
             })
             .catch((e) => {
-                Sentry.captureException(e);
-                console.error(e);
+                console.error('User points error: ', e);
             });
 
         return () => {

--- a/src/hooks/airdrop/utils/useHandleRequest.ts
+++ b/src/hooks/airdrop/utils/useHandleRequest.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { useAirdropStore } from '@app/store/useAirdropStore';
 
 interface RequestProps {
@@ -30,8 +29,7 @@ export const useAirdropRequest = () => {
 
         try {
             if (!response.ok) {
-                console.error('Error fetching airdrop request:', response);
-                Sentry.captureMessage('Error fetching airdrop request', { extra: { fullUrl } });
+                console.error(`Error fetching airdrop request at ${fullUrl}: `, response);
                 if (onError) {
                     onError(response);
                 }
@@ -39,8 +37,7 @@ export const useAirdropRequest = () => {
             }
             return response.json() as Promise<T>;
         } catch (e) {
-            Sentry.captureException(e, { data: { fullUrl } });
-            console.error('Caught error fetching airdrop data:', e);
+            console.error(`Caught error fetching airdrop data at ${fullUrl}: `, e);
 
             if (onError) {
                 onError(e);

--- a/src/hooks/mining/useTransactions.ts
+++ b/src/hooks/mining/useTransactions.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/react';
+import { ALREADY_FETCHING } from '@app/App/sentryIgnore';
 import { useCallback } from 'react';
 import { invoke } from '@tauri-apps/api';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
@@ -49,9 +49,10 @@ export default function useFetchTx() {
             setTransactionsLoading(false);
         } catch (error) {
             setTransactionsLoading(false);
-            Sentry.captureException(error);
             setError('Could not get transaction history');
-            console.error('Could not get transaction history: ', error);
+            if (error !== ALREADY_FETCHING.HISTORY) {
+                console.error('Could not get transaction history: ', error);
+            }
         }
     }, [isTransactionLoading, setError, setItems, setTransactionsLoading, setupProgress]);
 }

--- a/src/hooks/useMiningMetricsUpdater.ts
+++ b/src/hooks/useMiningMetricsUpdater.ts
@@ -1,10 +1,10 @@
+import { ALREADY_FETCHING } from '@app/App/sentryIgnore';
 import { useMiningStore } from '@app/store/useMiningStore';
 import { useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api';
 import { setAnimationState } from '@app/visuals.ts';
 import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore.ts';
 import useFetchTx from '@app/hooks/mining/useTransactions.ts';
-import * as Sentry from '@sentry/react';
 
 export default function useMiningMetricsUpdater() {
     const fetchTx = useFetchTx();
@@ -44,9 +44,10 @@ export default function useMiningMetricsUpdater() {
                 setIsFetchingMetrics(false);
             }
         } catch (e) {
-            Sentry.captureException(e);
-            console.error('Fetch mining metrics error: ', e);
             setIsFetchingMetrics(false);
+            if (e !== ALREADY_FETCHING.METRICS) {
+                console.error('Fetch mining metrics error:', e);
+            }
         }
     }, [
         baseNodeConnected,

--- a/src/hooks/useSetUp.ts
+++ b/src/hooks/useSetUp.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/tauri';
@@ -68,7 +67,7 @@ export function useSetUp() {
             isInitializingRef.current = true;
             clearStorage();
             invoke('setup_application').catch((e) => {
-                Sentry.captureException(e);
+                console.error(`Failed to setup application: ${e}`);
                 setCriticalError(`Failed to setup application: ${e}`);
             });
         }

--- a/src/hooks/useUpdateStatus.ts
+++ b/src/hooks/useUpdateStatus.ts
@@ -3,7 +3,6 @@ import { useAppStateStore } from '@app/store/appStateStore';
 import { useAppConfigStore } from '@app/store/useAppConfigStore';
 import { checkUpdate, installUpdate, onUpdaterEvent } from '@tauri-apps/api/updater';
 import { useUIStore } from '@app/store/useUIStore';
-import * as Sentry from '@sentry/react';
 import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/tauri';
 
@@ -79,7 +78,6 @@ export const useHandleUpdate = () => {
             console.info('Restarting application after update');
             await invoke('restart_application', { shouldStopMiners: false });
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Relaunch error', e);
         }
         handleClose();
@@ -114,7 +112,6 @@ export function useUpdateListener() {
                 setIsAfterAutoUpdate(true);
             }
         } catch (error) {
-            Sentry.captureException(error);
             console.error('AutoUpdate error:', error);
             setIsAfterAutoUpdate(true);
         }

--- a/src/store/appStateStore.ts
+++ b/src/store/appStateStore.ts
@@ -4,7 +4,6 @@ import { create } from './create';
 import { invoke } from '@tauri-apps/api';
 import { useAppConfigStore } from './useAppConfigStore';
 import { useMiningStore } from './useMiningStore';
-import * as Sentry from '@sentry/react';
 import { addToast } from '@app/components/ToastStack/useToastStore';
 
 interface AppState {
@@ -77,7 +76,6 @@ export const useAppStateStore = create<AppState>()((set, getState) => ({
             const applications_versions = await invoke('get_applications_versions');
             set({ applications_versions });
         } catch (error) {
-            Sentry.captureException(error);
             console.error('Error getting applications versions', error);
         }
     },
@@ -93,7 +91,6 @@ export const useAppStateStore = create<AppState>()((set, getState) => ({
                 await getState().fetchApplicationsVersions();
                 retries--;
             } catch (error) {
-                Sentry.captureException(error);
                 console.error('Error getting applications versions', error);
             }
         }
@@ -103,7 +100,6 @@ export const useAppStateStore = create<AppState>()((set, getState) => ({
             await invoke('update_applications');
             await getState().fetchApplicationsVersions();
         } catch (error) {
-            Sentry.captureException(error);
             console.error('Error updating applications versions', error);
         }
     },
@@ -113,7 +109,6 @@ export const useAppStateStore = create<AppState>()((set, getState) => ({
             const externalDependencies = await invoke('get_external_dependencies');
             set({ externalDependencies });
         } catch (error) {
-            Sentry.captureException(error);
             console.error('Error loading missing external dependencies', error);
         }
     },

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -1,7 +1,6 @@
 import { createWithEqualityFn as create } from 'zustand/traditional';
 import { persist } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/tauri';
-import * as Sentry from '@sentry/react';
 import { useMiningStore } from './useMiningStore';
 
 export const GIFT_GEMS = 5000;
@@ -184,8 +183,7 @@ export const useAirdropStore = create<AirdropStore>()(
                     try {
                         await invoke('set_airdrop_access_token', { token: airdropTokens.token });
                     } catch (error) {
-                        Sentry.captureException(error);
-                        console.error('Error getting airdrop tokens', error);
+                        console.error('Error getting airdrop tokens:', error);
                     }
                     set({
                         syncedWithBackend: true,
@@ -218,7 +216,6 @@ export const useAirdropStore = create<AirdropStore>()(
                     backendInMemoryConfig = await invoke('get_app_in_memory_config', {});
                     set({ backendInMemoryConfig });
                 } catch (e) {
-                    Sentry.captureException(e);
                     console.error('get_app_in_memory_config error:', e);
                 }
                 return backendInMemoryConfig;

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import { invoke } from '@tauri-apps/api';
 import { create } from './create';
 import { AppConfig, GpuThreads } from '../types/app-status.ts';
@@ -77,14 +76,12 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
                 await getState().setTheme(configTheme as displayMode);
             }
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Could not get app config: ', e);
         }
     },
     setShouldAutoLaunch: async (shouldAutoLaunch) => {
         set({ should_auto_launch: shouldAutoLaunch });
         invoke('set_should_auto_launch', { shouldAutoLaunch }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set auto launch', e);
             appStateStore.setError('Could not change auto launch');
@@ -94,7 +91,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setMineOnAppStart: async (mineOnAppStart) => {
         set({ mine_on_app_start: mineOnAppStart });
         invoke('set_mine_on_app_start', { mineOnAppStart }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set mine on app start', e);
             appStateStore.setError('Could not change mine on app start');
@@ -104,7 +100,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setShouldAlwaysUseSystemLanguage: async (shouldAlwaysUseSystemLanguage: boolean) => {
         set({ should_always_use_system_language: shouldAlwaysUseSystemLanguage });
         invoke('set_should_always_use_system_language', { shouldAlwaysUseSystemLanguage }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set should always use system language', e);
             appStateStore.setError('Could not change system language');
@@ -119,7 +114,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
                 changeLanguage(applicationLanguage);
             })
             .catch((e) => {
-                Sentry.captureException(e);
                 const appStateStore = useAppStateStore.getState();
                 console.error('Could not set application language', e);
                 appStateStore.setError('Could not change application language');
@@ -129,7 +123,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setAllowTelemetry: async (allowTelemetry) => {
         set({ allow_telemetry: allowTelemetry });
         invoke('set_allow_telemetry', { allowTelemetry }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set telemetry mode to ', allowTelemetry, e);
             appStateStore.setError('Could not change telemetry mode');
@@ -151,7 +144,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
                 }
             })
             .catch((e) => {
-                Sentry.captureException(e);
                 const appStateStore = useAppStateStore.getState();
                 console.error('Could not set CPU mining enabled', e);
                 appStateStore.setError('Could not change CPU mining enabled');
@@ -182,7 +174,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
                 }
             })
             .catch((e) => {
-                Sentry.captureException(e);
                 const appStateStore = useAppStateStore.getState();
                 console.error('Could not set GPU mining enabled', e);
                 appStateStore.setError('Could not change GPU mining enabled');
@@ -200,7 +191,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setP2poolEnabled: async (p2poolEnabled) => {
         set({ p2pool_enabled: p2poolEnabled });
         invoke('set_p2pool_enabled', { p2poolEnabled }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set P2pool enabled', e);
             appStateStore.setError('Could not change P2pool enabled');
@@ -211,7 +201,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
         const prevMoneroAddress = useAppConfigStore.getState().monero_address;
         set({ monero_address: moneroAddress });
         invoke('set_monero_address', { moneroAddress }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set Monero address', e);
             appStateStore.setError('Could not change Monero address');
@@ -222,13 +211,12 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
         const { mode, customGpuLevels, customCpuLevels } = params;
         const prevMode = useAppConfigStore.getState().mode;
         set({ mode, custom_max_cpu_usage: customCpuLevels, custom_max_gpu_usage: customGpuLevels });
-        console.log('Setting mode', mode, customCpuLevels, customGpuLevels);
+        console.info('Setting mode', mode, customCpuLevels, customGpuLevels);
         invoke('set_mode', {
             mode,
             customCpuUsage: customCpuLevels,
             customGpuUsage: customGpuLevels,
         }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set mode', e);
             appStateStore.setError('Could not change mode');
@@ -238,7 +226,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setUseTor: async (useTor) => {
         set({ use_tor: useTor });
         invoke('set_use_tor', { useTor }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set use Tor', e);
             appStateStore.setError('Could not change Tor usage');
@@ -248,7 +235,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setAutoUpdate: async (autoUpdate) => {
         set({ auto_update: autoUpdate });
         invoke('set_auto_update', { autoUpdate }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set auto update', e);
             appStateStore.setError('Could not change auto update');
@@ -286,7 +272,6 @@ export const useAppConfigStore = create<AppConfigStoreState>()((set, getState) =
     setVisualMode: (enabled) => {
         set({ visual_mode: enabled });
         invoke('set_visual_mode', { enabled }).catch((e) => {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set visual mode', e);
             appStateStore.setError('Could not change visual mode');

--- a/src/store/useMiningStore.ts
+++ b/src/store/useMiningStore.ts
@@ -7,7 +7,6 @@ import { useAppConfigStore } from './useAppConfigStore';
 import { modeType } from './types';
 
 import { useBlockchainVisualisationStore } from './useBlockchainVisualisationStore';
-import * as Sentry from '@sentry/react';
 
 interface State extends MinerMetrics {
     hashrateReady?: boolean;
@@ -94,7 +93,6 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             await invoke('start_mining', {});
             console.info('Mining started.');
         } catch (e) {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Failed to start mining: ', e);
             appStateStore.setError(e as string);
@@ -108,7 +106,6 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             await invoke('stop_mining', {});
             console.info('Mining stopped.');
         } catch (e) {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Failed to stop mining: ', e);
             appStateStore.setError(e as string);
@@ -121,7 +118,6 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             await invoke('stop_mining', {});
             console.info('Mining paused.');
         } catch (e) {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Failed to pause (stop) mining: ', e);
             appStateStore.setError(e as string);
@@ -134,7 +130,6 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             const maxAvailableThreads = await invoke('get_max_consumption_levels');
             set({ maxAvailableThreads });
         } catch (e) {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Failed to get max available threads: ', e);
             appStateStore.setError(e as string);
@@ -147,7 +142,7 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
         set({ isChangingMode: true });
 
         if (state.cpu.mining.is_mining || state.gpu.mining.is_mining) {
-            console.log('Pausing mining...');
+            console.info('Pausing mining...');
             await state.pauseMining();
         }
         try {
@@ -159,11 +154,10 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             });
             console.info(`Mode changed to ${mode}`);
             if (state.miningInitiated) {
-                console.log('Restarting mining...');
+                console.info('Restarting mining...');
                 await state.startMining();
             }
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Failed to change mode: ', e);
         } finally {
             set({ isChangingMode: false });
@@ -176,14 +170,12 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
             try {
                 await state.pauseMining();
             } catch (e) {
-                Sentry.captureException(e);
                 console.error('Failed to pause(restart) mining: ', e);
             }
 
             try {
                 await state.startMining();
             } catch (e) {
-                Sentry.captureException(e);
                 console.error('Failed to start(restart) mining: ', e);
             }
         }
@@ -196,7 +188,6 @@ export const useMiningStore = create<MiningStoreState>()((set, getState) => ({
         try {
             await invoke('set_excluded_gpu_devices', { excludedGpuDevices });
         } catch (e) {
-            Sentry.captureException(e);
             const appStateStore = useAppStateStore.getState();
             console.error('Could not set excluded gpu device: ', e);
             appStateStore.setError(e as string);

--- a/src/store/useP2poolStatsStore.ts
+++ b/src/store/useP2poolStatsStore.ts
@@ -1,7 +1,6 @@
 import { invoke } from '@tauri-apps/api';
 import { create } from './create';
 import { P2poolStats, P2poolStatsResult } from '../types/app-status.ts';
-import * as Sentry from '@sentry/react';
 
 type State = Partial<P2poolStatsResult>;
 
@@ -41,7 +40,6 @@ export const useP2poolStatsStore = create<P2poolStatsStoreState>()((set) => ({
             const stats = await invoke('get_p2pool_stats');
             set(stats);
         } catch (e) {
-            Sentry.captureException(e);
             console.error('Could not get p2p stats: ', e);
         }
     },

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -1,7 +1,7 @@
+import { ALREADY_FETCHING } from '@app/App/sentryIgnore';
 import { create } from './create';
 import { WalletBalance } from '../types/app-status.ts';
 import { invoke } from '@tauri-apps/api';
-import * as Sentry from '@sentry/react';
 import { Transaction } from '@app/types/wallet.ts';
 
 interface State extends WalletBalance {
@@ -56,8 +56,9 @@ export const useWalletStore = create<WalletStoreState>()((set) => ({
                 balance: tari_wallet_details?.wallet_balance ? newBalance : null,
             });
         } catch (error) {
-            Sentry.captureException(error);
-            console.error('Could not get tari wallet details: ', error);
+            if (error !== ALREADY_FETCHING.BALANCE) {
+                console.error('Could not get tari wallet details: ', error);
+            }
         }
     },
     setTransactions: (transactions) => set({ transactions }),
@@ -67,7 +68,6 @@ export const useWalletStore = create<WalletStoreState>()((set) => ({
             set({ is_wallet_importing: true });
             await invoke('import_seed_words', { seedWords });
         } catch (error) {
-            Sentry.captureException(error);
             console.error('Could not import seed words: ', error);
         }
     },


### PR DESCRIPTION
Description
---

noticed the actual error from BE wasn't logged in sentry re. paper_wallet details, then noticed the amount of duplications

- removed `Sentry.captureException(`s in each `catch` because we are already using the `captureConsoleIntegration` 
- added ignore for all the `"Already getting ...."` warnings from BE which are being logged as errors clogging up sentry
- made sure all `console.error`s have a short description and are passing the error through
- fixed lints
