### PR TITLE
fix: app_config overrides

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -52,8 +52,11 @@ pub struct AppConfigFromFile {
     reset_earnings: bool,
     eco_mode_cpu_threads: Option<u32>,
     ludicrous_mode_cpu_threads: Option<u32>,
+    #[serde(default = "default_vec_string")]
     eco_mode_cpu_options: Vec<String>,
+    #[serde(default = "default_vec_string")]
     ludicrous_mode_cpu_options: Vec<String>,
+    #[serde(default = "default_vec_string")]
     custom_mode_cpu_options: Vec<String>,
     #[serde(default = "default_false")]
     mmproxy_use_monero_fail: bool,
@@ -62,7 +65,7 @@ pub struct AppConfigFromFile {
     #[serde(default = "default_custom_max_cpu_usage")]
     custom_max_cpu_usage: Option<u32>,
     #[serde(default = "default_custom_max_gpu_usage")]
-    custom_max_gpu_usage: Vec<GpuThreads>,
+    custom_max_gpu_usage: Option<Vec<GpuThreads>>,
     #[serde(default = "default_true")]
     auto_update: bool,
     #[serde(default = "default_true")]
@@ -92,7 +95,7 @@ impl Default for AppConfigFromFile {
             should_auto_launch: false,
             application_language: default_application_language(),
             custom_max_cpu_usage: None,
-            custom_max_gpu_usage: vec![],
+            custom_max_gpu_usage: Some(vec![]),
             paper_wallet_enabled: true,
             use_tor: true,
             eco_mode_cpu_options: Vec::new(),
@@ -295,7 +298,7 @@ impl AppConfig {
                 self.mmproxy_monero_nodes = config.mmproxy_monero_nodes;
                 self.mmproxy_use_monero_fail = config.mmproxy_use_monero_fail;
                 self.custom_max_cpu_usage = config.custom_max_cpu_usage;
-                self.custom_max_gpu_usage = config.custom_max_gpu_usage.clone();
+                self.custom_max_gpu_usage = config.custom_max_gpu_usage.unwrap_or(vec![]);
                 self.auto_update = config.auto_update;
                 self.reset_earnings = config.reset_earnings;
                 self.custom_power_levels_enabled = config.custom_power_levels_enabled;
@@ -628,7 +631,7 @@ impl AppConfig {
             application_language: self.application_language.clone(),
             paper_wallet_enabled: self.paper_wallet_enabled,
             custom_max_cpu_usage: self.custom_max_cpu_usage,
-            custom_max_gpu_usage: self.custom_max_gpu_usage.clone(),
+            custom_max_gpu_usage: Some(self.custom_max_gpu_usage.clone()),
             use_tor: self.use_tor,
             reset_earnings: self.reset_earnings,
             eco_mode_cpu_options: self.eco_mode_cpu_options.clone(),
@@ -659,8 +662,8 @@ fn default_custom_max_cpu_usage() -> Option<u32> {
     None
 }
 
-fn default_custom_max_gpu_usage() -> Vec<GpuThreads> {
-    vec![]
+fn default_custom_max_gpu_usage() -> Option<Vec<GpuThreads>> {
+    Some(vec![])
 }
 
 fn default_mode() -> String {
@@ -689,6 +692,10 @@ fn default_system_time() -> SystemTime {
 
 fn default_monero_address() -> String {
     DEFAULT_MONERO_ADDRESS.to_string()
+}
+
+fn default_vec_string() -> Vec<String> {
+    vec![]
 }
 
 fn default_application_language() -> String {


### PR DESCRIPTION
Description
---
We've found with @Misieq01 what's causing the `app_config` overrides. It's because older versions have: `custom_max_gpu_usage: Option<u32>`(which is `null` as default). It was later changed to `custom_max_gpu_usage: Vec<GpuThreads>`(which is `[]` by default). It was treated as types inconsistency by serde which led to using and saving default app config