### PR TITLE
fix: change only minotari node to stop on error 114

### DIFF
--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -79,6 +79,7 @@ impl NodeManager {
             let mut process_watcher = self.watcher.write().await;
             process_watcher.adapter.use_tor = use_tor;
             process_watcher.adapter.tor_control_port = tor_control_port;
+            process_watcher.stop_on_exit_codes = vec![114];
             process_watcher
                 .start(
                     app_shutdown,


### PR DESCRIPTION
This exit was added so that we can detect when the base node stops on error 114 so that we can delete the previous database and resync. However, the GPU miner would exit with a weird error code and then it would not be restarted.