### PR TITLE
fix(ui): slider disabled styling

### DIFF
--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialog.tsx
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/CustomPowerLevelsDialog.tsx
@@ -160,6 +160,7 @@ export function CustomPowerLevelsDialog({
                                 label={`${t('custom-power-levels.gpu-power-level', { index: index + 1 })}: ${gpu.gpu_name}`}
                                 maxLevel={maxAvailableThreads.max_gpus_threads[index].max_gpu_threads}
                                 value={gpu.max_gpu_threads}
+                                step={2}
                                 desc={'custom-power-levels.choose-gpu-power-level'}
                                 warning={t('custom-power-levels.gpu-warning')}
                                 onChange={(value: number) => {

--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.styles.ts
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.styles.ts
@@ -40,7 +40,6 @@ export const RangeInput = styled.input<{ $thumbLeft?: number }>`
     border-radius: 5px;
     outline: none;
     -webkit-transition: 0.2s;
-    transition: opacity 0.2s;
 
     &::-webkit-slider-thumb {
         appearance: none;
@@ -48,21 +47,22 @@ export const RangeInput = styled.input<{ $thumbLeft?: number }>`
         width: ${SLIDER_THUMB_WIDTH}px;
         height: ${SLIDER_THUMB_WIDTH}px;
         z-index: 5;
-        background: white;
         border-radius: 50%;
         border: 2px solid #813bf5;
+        background-color: #fff;
         cursor: pointer;
         position: absolute;
         left: calc(${({ $thumbLeft = 0 }) => `${$thumbLeft}% - ${SLIDER_THUMB_WIDTH / 2}px`});
         bottom: -50%;
+        transition: border 0.2s;
     }
 
     &:disabled {
-        opacity: 0.6;
         pointer-events: none;
 
         &::-webkit-slider-thumb {
             pointer-events: none;
+            border: 2px solid rgba(129, 59, 245, 0.47);
         }
     }
 `;

--- a/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.tsx
+++ b/src/containers/main/SideBar/Miner/components/CustomPowerLevels/RangeInput.tsx
@@ -30,6 +30,10 @@ function convertToPercentage(value: number, max: number): number {
     return Math.ceil((value * 100) / max);
 }
 
+function getSafeStepValue(step: number, value: number): number {
+    return value % step === 0 ? value : value + (value % step);
+}
+
 export const RangeInputComponent = ({
     label,
     maxLevel,
@@ -45,7 +49,8 @@ export const RangeInputComponent = ({
     const [isHover, setIsHover] = useState(false);
     const { t } = useTranslation('settings', { useSuspense: true });
     const inputRef = useRef<HTMLInputElement>(null);
-    const [currentValue, setCurrentValue] = useState(value);
+
+    const [currentValue, setCurrentValue] = useState(getSafeStepValue(step, value));
 
     const hasChanges = useRef(false);
 
@@ -68,10 +73,11 @@ export const RangeInputComponent = ({
     const handleChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
             const newValue = Number(event.target.value);
-            setCurrentValue(newValue >= min ? newValue : min);
+            const safeValue = getSafeStepValue(step, newValue);
+            setCurrentValue(safeValue >= min ? safeValue : min);
             hasChanges.current = true;
         },
-        [min]
+        [min, step]
     );
 
     const valueBasedStyles = useMemo(() => {


### PR DESCRIPTION
Description
---

- fixed slider's thumb styling so that isn't all a lighter opacity when `disabled` (`isLoading`) - only lighten the border
- also added a helper to get a "safe" value based on the range slider steps, because i noticed the GPU threads initial value was an odd number, and i could slide to an odd number,  but that should only increment in steps of two

Motivation and Context
---

- resolves https://github.com/tari-project/universe/issues/1121

How Has This Been Tested?
---

- locally:

https://github.com/user-attachments/assets/e40c6653-d74e-4083-a3e5-5592e576800b



What process can a PR reviewer use to test or verify this change?
---
1. see ticket
2. see that GPU settings can't set to an odd number
