### PR TITLE
fix(orphan-chain): sentry logging

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,10 +10,10 @@ use keyring::Entry;
 use log::trace;
 use log::{debug, error, info, warn};
 use monero_address_creator::Seed as MoneroSeed;
-use process_utils::set_interval;
 
 use log4rs::config::RawConfig;
 use regex::Regex;
+use sentry::protocol::Event;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::fs::{read_dir, remove_dir_all, remove_file};
@@ -28,6 +28,7 @@ use tari_shutdown::Shutdown;
 use tauri::async_runtime::{block_on, JoinHandle};
 use tauri::{Manager, RunEvent, UpdaterEvent, Window};
 use tokio::sync::{Mutex, RwLock};
+use tokio::time;
 use tor_adapter::TorConfig;
 use utils::logging_utils::setup_logging;
 use wallet_adapter::TransactionInfo;
@@ -980,10 +981,36 @@ async fn setup_inner(
 
     let app_handle_clone: tauri::AppHandle = app.clone();
     tauri::async_runtime::spawn(async move {
-        set_interval(
-            move || check_if_is_orphan_chain(app_handle_clone.clone()),
-            Duration::from_secs(30),
-        );
+        let mut interval: time::Interval = time::interval(Duration::from_secs(30));
+        let mut has_send_error = false;
+        let error_msg = "Miner is stuck on orphan chain".to_string();
+
+        loop {
+            interval.tick().await;
+
+            let state = app_handle_clone.state::<UniverseAppState>().inner();
+            let check_if_orphan = state.node_manager.check_if_is_orphan_chain().await;
+            match check_if_orphan {
+                Ok(is_stuck) => {
+                    if is_stuck {
+                        error!(target: LOG_TARGET, "Miner is stuck on orphan chain");
+                    }
+                    if is_stuck && !has_send_error {
+                        sentry::capture_event(Event {
+                            message: Some(error_msg.clone()),
+                            level: sentry::Level::Error,
+                            culprit: Some("orphan-chain".to_string()),
+                            ..Default::default()
+                        });
+                        has_send_error = true;
+                    }
+                    drop(app_handle_clone.emit_all("is_stuck", is_stuck));
+                }
+                Err(ref e) => {
+                    error!(target: LOG_TARGET, "{}", e);
+                }
+            }
+        }
     });
 
     Ok(())
@@ -1667,22 +1694,6 @@ async fn get_app_config(
     _app: tauri::AppHandle,
 ) -> Result<AppConfig, String> {
     Ok(state.config.read().await.clone())
-}
-
-async fn check_if_is_orphan_chain(app_handle: tauri::AppHandle) {
-    let state = app_handle.state::<UniverseAppState>().inner();
-    let check_if_orphan = state.node_manager.check_if_is_orphan_chain().await;
-    match check_if_orphan {
-        Ok(is_stuck) => {
-            if is_stuck {
-                error!(target: LOG_TARGET, "Miner is stuck on orphan chain");
-            }
-            drop(app_handle.emit_all("is_stuck", is_stuck));
-        }
-        Err(e) => {
-            error!(target: LOG_TARGET, "{}", e);
-        }
-    }
 }
 
 #[allow(clippy::too_many_lines)]

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 use chrono::{NaiveDateTime, TimeZone, Utc};
 use log::{error, info};
 use minotari_node_grpc_client::grpc::Peer;
+use sentry::protocol::Event;
 use tari_common::configuration::Network;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_crypto::ristretto::RistrettoPublicKey;
@@ -206,13 +207,16 @@ impl NodeManager {
         Ok(exit_code)
     }
 
-    pub async fn check_if_is_orphan_chain(&self) -> Result<bool, anyhow::Error> {
+    pub async fn check_if_is_orphan_chain(
+        &self,
+        report_to_sentry: bool,
+    ) -> Result<bool, anyhow::Error> {
         let mut status_monitor_lock = self.watcher.write().await;
         let status_monitor = status_monitor_lock
             .status_monitor
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Node not started"))?;
-        let (_, _, _, _, _, is_synced) = status_monitor
+        let (_, _, _, local_tip, _, is_synced) = status_monitor
             .get_network_hash_rate_and_block_reward()
             .await
             .map_err(|e| {
@@ -247,6 +251,18 @@ impl NodeManager {
                 .iter()
                 .any(|local_block| block_scan_block.1 == local_block.1)
             {
+                if report_to_sentry {
+                    let error_msg = format!(
+                        "Orphan chain detected: block {} at height {} not found in local chain. Block scan tip height: {} - Local tip height: {}",
+                        block_scan_block.1, block_scan_block.0, block_scan_tip, local_tip
+                    );
+                    sentry::capture_event(Event {
+                        message: Some(error_msg),
+                        level: sentry::Level::Error,
+                        culprit: Some("orphan-chain".to_string()),
+                        ..Default::default()
+                    });
+                }
                 return Ok(true);
             }
         }

--- a/src-tauri/src/process_utils.rs
+++ b/src-tauri/src/process_utils.rs
@@ -1,5 +1,4 @@
-use std::{future::Future, path::Path, time::Duration};
-use tokio::time;
+use std::path::Path;
 
 pub fn launch_child_process(
     file_path: &Path,
@@ -31,22 +30,6 @@ pub fn launch_child_process(
             .creation_flags(PROCESS_CREATION_NO_WINDOW)
             .spawn()?)
     }
-}
-
-pub fn set_interval<F, Fut>(mut f: F, dur: Duration)
-where
-    F: Send + 'static + FnMut() -> Fut,
-    Fut: Future<Output = ()> + Send + 'static,
-{
-    let mut interval = time::interval(dur);
-
-    tokio::spawn(async move {
-        interval.tick().await;
-        loop {
-            interval.tick().await;
-            tokio::spawn(f());
-        }
-    });
 }
 
 // pub async fn launch_and_get_outputs(


### PR DESCRIPTION
Description
---
Add sentry logging when an orphan chain has been detected.

Motivation and Context
---
This warning pop ups in many cases which is not obvious. With more logging it will be easier for developers to find the root cause.

How Has This Been Tested?
---
Create locally an orphan chain and check if logs appeared in sentry. 

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
