### PR TITLE
fix: missing imports for windows

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,8 @@ use crate::tor_adapter::TorConfig;
 use crate::utils::shutdown_utils::stop_all_processes;
 use crate::wallet_adapter::{TransactionInfo, WalletBalance};
 use crate::wallet_manager::WalletManagerError;
-use crate::{setup_inner, UniverseAppState, APPLICATION_FOLDER_ID};
+#[allow(unused_imports)]
+use crate::{external_dependencies, setup_inner, UniverseAppState, APPLICATION_FOLDER_ID};
 use keyring::Entry;
 use log::{debug, error, info, warn};
 use monero_address_creator::Seed as MoneroSeed;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,8 +2,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use auto_launcher::AutoLauncher;
-#[allow(unused_imports)]
-use external_dependencies::RequiredExternalDependency;
 use hardware::hardware_status_monitor::HardwareStatusMonitor;
 use log::trace;
 use log::{debug, error, info, warn};
@@ -38,6 +36,8 @@ use crate::cpu_miner::CpuMiner;
 
 use crate::app_config::WindowSettings;
 use crate::commands::{CpuMinerConnection, MinerMetrics, TariWalletDetails};
+#[allow(unused_imports)]
+use crate::external_dependencies::ExternalDependencies;
 use crate::feedback::Feedback;
 use crate::gpu_miner::GpuMiner;
 use crate::internal_wallet::InternalWallet;
@@ -47,7 +47,6 @@ use crate::p2pool::models::Stats;
 use crate::p2pool_manager::{P2poolConfig, P2poolManager};
 use crate::tor_manager::TorManager;
 use crate::utils::auto_rollback::AutoRollback;
-
 use crate::wallet_manager::WalletManager;
 #[cfg(target_os = "macos")]
 use utils::macos_utils::is_app_in_applications_folder;


### PR DESCRIPTION
Description
---

- add back missing `external_dependencies` imports with lint comments for windows

Motivation and Context
---

fixes this:

![image](https://github.com/user-attachments/assets/18a5b8b7-f545-4f8e-afdb-fd88cdf747a4)


How Has This Been Tested?
---
running `cargo check` locally (i'm on mac)