### PR TITLE
feat: timeout and log latest action during init

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -426,6 +426,13 @@ impl BinaryManager {
             .map_err(|e| anyhow!("Error creating in progress folder. Error: {:?}", e))?;
         let in_progress_file_zip = in_progress_dir.join(asset.name.clone());
 
+        progress_tracker
+            .send_last_action(format!(
+                "Downloading version: {} of binary: {}",
+                version.to_string(),
+                self.binary_name
+            ))
+            .await;
         download_file_with_retries(
             asset.url.as_str(),
             &in_progress_file_zip,
@@ -436,6 +443,13 @@ impl BinaryManager {
 
         info!(target: LOG_TARGET, "Downloaded version: {:?}", version);
 
+        progress_tracker
+            .send_last_action(format!(
+                "Extracting file: {} to dest: {}",
+                in_progress_file_zip.to_str().unwrap_or_default(),
+                destination_dir.to_str().unwrap_or_default()
+            ))
+            .await;
         extract(&in_progress_file_zip, &destination_dir)
             .await
             .map_err(|e| anyhow!("Error extracting version: {:?}. Error: {:?}", version, e))?;

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -1,13 +1,17 @@
 use crate::ProgressTracker;
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
+use log::error;
 use regex::Regex;
 use semver::Version;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::LazyLock;
+use std::time::Duration;
 use tari_common::configuration::Network;
+use tokio::sync::watch::Receiver;
 use tokio::sync::RwLock;
+use tokio::time::timeout;
 
 use super::adapter_github::GithubReleasesAdapter;
 use super::adapter_tor::TorReleaseAdapter;
@@ -200,6 +204,30 @@ impl BinaryResolver {
                 .join(binary.binary_file_name(version)));
         }
         Ok(base_dir.join(binary.binary_file_name(version)))
+    }
+
+    pub async fn initialize_binary_timeout(
+        &mut self,
+        binary: Binaries,
+        progress_tracker: ProgressTracker,
+        should_check_for_update: bool,
+        timeout_channel: Receiver<String>,
+    ) -> Result<(), Error> {
+        match timeout(
+            Duration::from_secs(60 * 5),
+            self.initalize_binary(binary, progress_tracker.clone(), should_check_for_update),
+        )
+        .await
+        {
+            Err(_) => {
+                let last_msg = timeout_channel.borrow().clone();
+                error!(target: "tari::universe::main", "Setup took too long: {:?}", last_msg);
+                let error_msg = format!("Setup took too long: {}", last_msg);
+                sentry::capture_message(&error_msg, sentry::Level::Error);
+                return Err(anyhow!(error_msg));
+            }
+            Ok(result) => result,
+        }
     }
 
     pub async fn initalize_binary(

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -297,6 +297,17 @@ impl BinaryResolver {
         manager.check_for_updates().await;
         let highest_version = manager.select_highest_version();
 
+        progress_tracker
+            .send_last_action(format!(
+                "Checking if files exist before download: {} {}",
+                binary.name(),
+                highest_version
+                    .clone()
+                    .unwrap_or(Version::new(0, 0, 0))
+                    .to_string()
+            ))
+            .await;
+
         let check_if_files_exist =
             manager.check_if_files_for_version_exist(highest_version.clone());
         if !check_if_files_exist {
@@ -305,6 +316,16 @@ impl BinaryResolver {
                 .await?;
         }
 
+        progress_tracker
+            .send_last_action(format!(
+                "Checking if files exist after download: {} {}",
+                binary.name(),
+                highest_version
+                    .clone()
+                    .unwrap_or(Version::new(0, 0, 0))
+                    .to_string()
+            ))
+            .await;
         let check_if_files_exist =
             manager.check_if_files_for_version_exist(highest_version.clone());
         if !check_if_files_exist {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -215,7 +215,7 @@ impl BinaryResolver {
     ) -> Result<(), Error> {
         match timeout(
             Duration::from_secs(60 * 5),
-            self.initalize_binary(binary, progress_tracker.clone(), should_check_for_update),
+            self.initialize_binary(binary, progress_tracker.clone(), should_check_for_update),
         )
         .await
         {
@@ -224,13 +224,13 @@ impl BinaryResolver {
                 error!(target: "tari::universe::main", "Setup took too long: {:?}", last_msg);
                 let error_msg = format!("Setup took too long: {}", last_msg);
                 sentry::capture_message(&error_msg, sentry::Level::Error);
-                return Err(anyhow!(error_msg));
+                Err(anyhow!(error_msg))
             }
             Ok(result) => result,
         }
     }
 
-    pub async fn initalize_binary(
+    pub async fn initialize_binary(
         &mut self,
         binary: Binaries,
         progress_tracker: ProgressTracker,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -31,8 +31,6 @@ use std::time::{Duration, Instant, SystemTime};
 use tari_common::configuration::Network;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tauri::{Manager, PhysicalPosition, PhysicalSize};
-use tokio::sync::watch;
-use tokio::time::timeout;
 
 const MAX_ACCEPTABLE_COMMAND_TIME: Duration = Duration::from_secs(1);
 const LOG_TARGET: &str = "tari::universe::commands";
@@ -1427,23 +1425,11 @@ pub async fn setup_application(
         return Ok(res);
     }
     rollback.set_value(true, Duration::from_millis(1000)).await;
-    let (tx, rx) = watch::channel("".to_string());
-
-    if let Err(_) = timeout(
-        Duration::from_secs(60 * 1),
-        setup_inner(window, state.clone(), app, tx),
-    )
-    .await
-    {
-        println!("Setup took too long");
-        let last_msg = rx.borrow().clone();
-        error!(target: LOG_TARGET, "Setup took too long: {:?}", last_msg);
-    }
-    // setup_inner(window, state.clone(), app).await.map_err(|e| {
-    //     warn!(target: LOG_TARGET, "Error setting up application: {:?}", e);
-    //     capture_anyhow(&e);
-    //     e.to_string()
-    // })?;
+    setup_inner(window, state.clone(), app).await.map_err(|e| {
+        warn!(target: LOG_TARGET, "Error setting up application: {:?}", e);
+        capture_anyhow(&e);
+        e.to_string()
+    })?;
 
     let res = state.config.read().await.auto_mining();
     if timer.elapsed() > MAX_ACCEPTABLE_COMMAND_TIME {
@@ -1636,6 +1622,7 @@ pub async fn update_applications(
         app.get_window("main")
             .expect("Could not get main window")
             .clone(),
+        None,
     );
     binary_resolver
         .update_binary(Binaries::Xmrig, progress_tracker.clone())

--- a/src-tauri/src/download_utils.rs
+++ b/src-tauri/src/download_utils.rs
@@ -33,6 +33,14 @@ pub async fn download_file_with_retries(
                 }
                 retries += 1;
                 eprintln!("Error downloading file: {}. Try {:?}/3", err, retries);
+                progress_tracker
+                    .send_last_action(format!(
+                        "Failed at retry: {} to download binary from url: {} to destination: {}",
+                        retries,
+                        url,
+                        destination.to_str().unwrap_or("unknown")
+                    ))
+                    .await;
                 sleep(Duration::from_secs(1)).await;
             }
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use log::trace;
 use log::{debug, error, info, warn};
 use p2pool::models::Connections;
 use std::fs::{remove_dir_all, remove_file};
+use tokio::sync::watch::Sender;
 
 use log4rs::config::RawConfig;
 use serde::Serialize;
@@ -136,6 +137,7 @@ async fn setup_inner(
     window: tauri::Window,
     state: tauri::State<'_, UniverseAppState>,
     app: tauri::AppHandle,
+    progress_channel: Sender<String>,
 ) -> Result<(), anyhow::Error> {
     window
         .emit(
@@ -229,6 +231,9 @@ async fn setup_inner(
         .unwrap_or(Duration::from_secs(0))
         > Duration::from_secs(60 * 60 * 6);
 
+    progress_channel
+        .send("Checking latest version of tor".to_string())
+        .ok();
     if use_tor && !cfg!(target_os = "macos") {
         progress.set_max(5).await;
         progress
@@ -240,6 +245,9 @@ async fn setup_inner(
         sleep(Duration::from_secs(1));
     }
 
+    progress_channel
+        .send("Checking latest version of node".to_string())
+        .ok();
     progress.set_max(10).await;
     progress
         .update("checking-latest-version-node".to_string(), None, 0)
@@ -253,6 +261,9 @@ async fn setup_inner(
         .await?;
     sleep(Duration::from_secs(1));
 
+    progress_channel
+        .send("Checking latest version of wallet".to_string())
+        .ok();
     progress.set_max(15).await;
     progress
         .update("checking-latest-version-mmproxy".to_string(), None, 0)
@@ -265,6 +276,10 @@ async fn setup_inner(
         )
         .await?;
     sleep(Duration::from_secs(1));
+
+    progress_channel
+        .send("Checking latest version of wallet".to_string())
+        .ok();
     progress.set_max(20).await;
     progress
         .update("checking-latest-version-wallet".to_string(), None, 0)
@@ -272,8 +287,11 @@ async fn setup_inner(
     binary_resolver
         .initalize_binary(Binaries::Wallet, progress.clone(), should_check_for_update)
         .await?;
-
     sleep(Duration::from_secs(1));
+
+    progress_channel
+        .send("Checking latest version of xmrig".to_string())
+        .ok();
     progress.set_max(25).await;
     progress
         .update("checking-latest-version-gpuminer".to_string(), None, 0)
@@ -287,6 +305,9 @@ async fn setup_inner(
         .await?;
     sleep(Duration::from_secs(1));
 
+    progress_channel
+        .send("Checking latest version of xmrig".to_string())
+        .ok();
     progress.set_max(30).await;
     progress
         .update("checking-latest-version-xmrig".to_string(), None, 0)
@@ -295,6 +316,10 @@ async fn setup_inner(
         .initalize_binary(Binaries::Xmrig, progress.clone(), should_check_for_update)
         .await?;
     sleep(Duration::from_secs(1));
+
+    progress_channel
+        .send("Checking latest version of sha-p2pool".to_string())
+        .ok();
     progress.set_max(35).await;
     progress
         .update("checking-latest-version-sha-p2pool".to_string(), None, 0)
@@ -307,6 +332,10 @@ async fn setup_inner(
         )
         .await?;
     sleep(Duration::from_secs(1));
+
+    progress_channel
+        .send("Checking for update".to_string())
+        .ok();
     if should_check_for_update {
         state
             .config
@@ -371,8 +400,10 @@ async fn setup_inner(
             }
         }
     }
-
     info!(target: LOG_TARGET, "Node has started and is ready");
+    progress_channel
+        .send("Node has started and is ready".to_string())
+        .ok();
 
     progress.set_max(40).await;
     progress
@@ -387,7 +418,13 @@ async fn setup_inner(
             log_dir.clone(),
         )
         .await?;
+    progress_channel
+        .send("Wallet has started and is ready".to_string())
+        .ok();
 
+    progress_channel
+        .send("Waiting for initial sync".to_string())
+        .ok();
     progress.set_max(75).await;
     progress
         .update("preparing-for-initial-sync".to_string(), None, 0)
@@ -395,6 +432,7 @@ async fn setup_inner(
     state.node_manager.wait_synced(progress.clone()).await?;
 
     if state.config.read().await.p2pool_enabled() {
+        progress_channel.send("Starting p2pool".to_string()).ok();
         progress.set_max(85).await;
         progress
             .update("starting-p2pool".to_string(), None, 0)
@@ -418,6 +456,7 @@ async fn setup_inner(
             .await?;
     }
 
+    progress_channel.send("Starting mmproxy".to_string()).ok();
     progress.set_max(100).await;
     progress
         .update("starting-mmproxy".to_string(), None, 0)

--- a/src-tauri/src/progress_tracker.rs
+++ b/src-tauri/src/progress_tracker.rs
@@ -30,6 +30,10 @@ impl ProgressTracker {
         self.inner.write().await.set_next_max(max);
     }
 
+    pub async fn send_last_action(&self, action: String) {
+        self.inner.read().await.send_last_action(action);
+    }
+
     pub async fn update(
         &self,
         title: String,
@@ -63,6 +67,15 @@ impl ProgressTrackerInner {
     pub fn set_next_max(&mut self, max: u64) {
         self.min = self.next_max;
         self.next_max = max;
+    }
+
+    pub fn send_last_action(&self, action: String) {
+        if let Some(channel) = &self.last_action_channel {
+            channel
+                .send(action)
+                .inspect_err(|e| error!(target: LOG_TARGET, "Could not send last action: {:?}", e))
+                .ok();
+        }
     }
 
     pub fn update(


### PR DESCRIPTION
Description
---
Timeout if initialization took too long and report to sentry the last action. Timeout is for each binary and is set to fixed value of 5 minutes.
Another big change is that app will exit and show error if timeout was exceeded. Previously user would be stuck at initialization screen.

Closes: https://github.com/tari-project/universe/issues/1170

Motivation and Context
---
Some users reports being stuck at initialization screen. The underlying reason is unknown and we need to increase the logging and sentry reporting.

How Has This Been Tested?
---
Decrease timeout to like 20 seconds and add this line in `binaries_resolver.rs` in `initialize_binary` function to fake timeout on one selected binary:
```rust
match binary {
    Binaries::Xmrig => {
        println!("Sleeping for 30 seconds");
        sleep(Duration::from_secs(30)).await;
        println!("Waking up");
    }
    _ => {}
}
```

What process can a PR reviewer use to test or verify this change?
---
Same as above

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
