### PR TITLE
fix(ui): hide p2p stats when p2poll toggled

### DIFF
--- a/src/containers/floating/Settings/sections/p2p/P2pMarkup.tsx
+++ b/src/containers/floating/Settings/sections/p2p/P2pMarkup.tsx
@@ -15,7 +15,11 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 
-const P2pMarkup = () => {
+interface P2pMarkupProps {
+    setDisabledStats: (value: boolean) => void;
+}
+
+const P2pMarkup = ({ setDisabledStats }: P2pMarkupProps) => {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const isP2poolEnabled = useAppConfigStore((state) => state.p2pool_enabled);
     const setP2poolEnabled = useAppConfigStore((state) => state.setP2poolEnabled);
@@ -25,10 +29,11 @@ const P2pMarkup = () => {
 
     const handleP2poolEnabled = useCallback(
         async (event: React.ChangeEvent<HTMLInputElement>) => {
+            setDisabledStats(true);
             await setP2poolEnabled(event.target.checked);
             setDialogToShow('restart');
         },
-        [setDialogToShow, setP2poolEnabled]
+        [setDialogToShow, setDisabledStats, setP2poolEnabled]
     );
 
     return (

--- a/src/containers/floating/Settings/sections/p2p/PoolMiningSettings.tsx
+++ b/src/containers/floating/Settings/sections/p2p/PoolMiningSettings.tsx
@@ -1,14 +1,16 @@
+import { useState } from 'react';
 import P2pMarkup from './P2pMarkup.tsx';
 import P2PoolStats from './P2PoolStats.tsx';
 import { useAppConfigStore } from '@app/store/useAppConfigStore';
 
 export const PoolMiningSettings = () => {
+    const [disabledStats, setDisabledStats] = useState(false);
     const isP2poolEnabled = useAppConfigStore((s) => s.p2pool_enabled);
 
     return (
         <>
-            <P2pMarkup />
-            {isP2poolEnabled && <P2PoolStats />}
+            <P2pMarkup setDisabledStats={setDisabledStats} />
+            {isP2poolEnabled && !disabledStats && <P2PoolStats />}
         </>
     );
 };


### PR DESCRIPTION
#1208

Description
---
P2pool stats should be visible only after restarting the app, when toggled on

[Screencast from 12-06-2024 12:00:40 PM.webm](https://github.com/user-attachments/assets/3114cb1c-aa58-47cc-88c3-0ac182acfcf5)
