### PR TITLE
chore: additional latest json url from cdn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           yq eval ".mainBinaryName = \"Tari Universe\"" -i tauri.conf.json
           yq eval ".app.windows[0].title = \"Tari Universe | Testnet\"" -i tauri.conf.json
           yq eval ".identifier = \"com.tari.universe\"" -i tauri.conf.json
-          yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\"]" \
+          yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\", \"https://cdn-universe.tari.com/tari-project/universe/updater/latest.json\"]" \
             -i tauri.conf.json
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Description
---
`AutoUpdate error: Could not fetch a valid release JSON from the remote` is a recurring issue reported on Sentry. Unfortunately, I have limited information regarding the response itself. My assumption is that GitHub releases may occasionally restrict access for certain users. I decided to set an additional endpoint for `latest.json` from our CDN, which will be utilized only when the GitHub endpoint is inaccessible(a non-2XX status code is returned).