### PR TITLE
fix: p2pool stats crash

### DIFF
--- a/src/containers/floating/Settings/sections/p2p/PoolMiningSettings.tsx
+++ b/src/containers/floating/Settings/sections/p2p/PoolMiningSettings.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react';
 import P2pMarkup from './P2pMarkup.tsx';
 import P2PoolStats from './P2PoolStats.tsx';
 import { useAppConfigStore } from '@app/store/useAppConfigStore';
+import { useUIStore } from '@app/store/useUIStore.ts';
 
 export const PoolMiningSettings = () => {
-    const [disabledStats, setDisabledStats] = useState(false);
     const isP2poolEnabled = useAppConfigStore((s) => s.p2pool_enabled);
+    const disabledStats = useUIStore((s) => s.disabledP2poolStats);
+    const setDisabledStats = useUIStore((s) => s.setDisabledP2poolStats);
+
     return (
         <>
             <P2pMarkup setDisabledStats={setDisabledStats} />

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -19,6 +19,7 @@ interface State {
     dialogToShow?: DialogType | null;
     isWebglNotSupported: boolean;
     adminShow?: 'setup' | 'main' | 'shutdown' | 'orphanChainWarning' | null;
+    disabledP2poolStats?: boolean;
 }
 interface Actions {
     setTheme: (theme: Theme) => void;
@@ -31,6 +32,7 @@ interface Actions {
     setLatestVersion: (latestVersion: string) => void;
     setIsWebglNotSupported: (isWebglNotSupported: boolean) => void;
     setAdminShow: (adminShow: State['adminShow']) => void;
+    setDisabledP2poolStats: (disabledP2poolStats: boolean) => void;
 }
 
 type UIStoreState = State & Actions;
@@ -44,6 +46,7 @@ const initialState: State = {
     dialogToShow: null,
     showExperimental: false,
     showExternalDependenciesDialog: false,
+    disabledP2poolStats: false,
 };
 
 export const useUIStore = create<UIStoreState>()((set) => ({
@@ -64,4 +67,5 @@ export const useUIStore = create<UIStoreState>()((set) => ({
         set({ isWebglNotSupported });
     },
     setAdminShow: (adminShow) => set({ adminShow }),
+    setDisabledP2poolStats: (disabledP2poolStats) => set({ disabledP2poolStats }),
 }));


### PR DESCRIPTION
#1208

Description
--
Disabled p2pool flag wasn't stored in store since user could close/reopen p2pool stats and crash the app after switching it on.

Testing
--
1. Run app with p2pool disabled
2. Enable p2pool mining, cancel restarting
3. Close and reopen settings view
4. App shouldn't crash