### PR TITLE
fix: twitter localstorage persistence

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,6 +34,7 @@
         "createUpdaterArtifacts": true
     },
     "app": {
+        "useHttpsScheme": true,
         "security": {
             "capabilities": ["desktop-capability", "default", "migrated"],
             "csp": null


### PR DESCRIPTION
Description
---
This fixes an issue where the twitter login information was lost between v1 and v2 upgrades because of the URL schema change.

Motivation and Context
---
Users on v0.8.11 reported twitter no longer logged in on windows, and re-logging in was not solving the issue.

How Has This Been Tested?
---
It hasn't been tested yet. 
