### PR TITLE
fix: updater artifacts V1 compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - platform: 'windows-latest'
             args: ''
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin '
+            args: '--target universal-apple-darwin'
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -211,7 +211,7 @@ jobs:
           prerelease: true
           includeDebug: false
           includeRelease: true
-          args: --bundles updater ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
+          args: ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
 
       - name: Debug Step - artifactPaths
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-22.04'
-            args: '--bundles updater'
+            args: ''
           - platform: 'windows-latest'
-            args: '--bundles msi,updater'
+            args: ''
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin --bundles updater'
+            args: '--target universal-apple-darwin '
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -211,7 +211,7 @@ jobs:
           prerelease: true
           includeDebug: false
           includeRelease: true
-          args: ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
+          args: --bundles updater ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
 
       - name: Debug Step - artifactPaths
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-22.04'
-            args: ''
+            args: '--bundles updater'
           - platform: 'windows-latest'
-            args: ''
+            args: '--bundles msi,updater'
           - platform: 'macos-latest'
-            args: '--target universal-apple-darwin'
+            args: '--target universal-apple-darwin --bundles updater'
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Build Tauri Apps
         id: build
-        uses: tauri-apps/tauri-action@v0.5.16
+        uses: tauri-apps/tauri-action@v0.5.17
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE || secrets.AZURE_TENANT_ID }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
     },
     "bundle": {
         "active": true,
+        "targets": ["deb", "rpm", "appimage", "msi", "dmg"],
         "macOS": {
             "providerShortName": "Tari Labs, LLC"
         },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,6 @@
     },
     "bundle": {
         "active": true,
-        "targets": ["deb", "rpm", "appimage", "msi", "dmg", "app"],
         "macOS": {
             "providerShortName": "Tari Labs, LLC"
         },
@@ -31,7 +30,7 @@
         "shortDescription": "Tari Universe is a mining app for Tari.",
         "longDescription": "Introducing Tari Universe, the beautifully simple mining app for Tari. Install it on your Mac or PC and start mining Tari with one click.",
         "publisher": "Tari Labs, LLC",
-        "createUpdaterArtifacts": true
+        "createUpdaterArtifacts": "v1Compatible"
     },
     "app": {
         "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
     },
     "bundle": {
         "active": true,
-        "targets": ["deb", "rpm", "appimage", "msi", "dmg"],
+        "targets": ["deb", "rpm", "appimage", "msi", "dmg", "app"],
         "macOS": {
             "providerShortName": "Tari Labs, LLC"
         },


### PR DESCRIPTION
Description
---
- fixes missing release artifacts after Tauri V2 merge:

needed to change `createUpdaterArtifacts` to [`v1Compatible`](https://tauri.app/plugin/updater/#building) for the zips

How Has This Been Tested?
---

-  beta build branch:


macOs: 

![image](https://github.com/user-attachments/assets/872bd46e-adb1-45d9-a349-5f25a26846c8)


linux:
![image](https://github.com/user-attachments/assets/29f8da88-39b1-4921-9b61-63d27726ea6e)

windows: 
![image](https://github.com/user-attachments/assets/f0970272-a568-41ef-9552-101098e16175)



What process can a PR reviewer use to test or verify this change?
---


- check artifacts in [the release workflow](https://github.com/tari-project/universe/actions/runs/12294412932)