### PR TITLE
fix: coinbase padding

### DIFF
--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -261,7 +261,8 @@ impl TelemetryManager {
         let mut sha256_hasher = sha2::Sha256::new();
         sha2::Digest::update(&mut sha256_hasher, id_as_bytes);
         let id_sha256 = sha256_hasher.finalize();
-        let id_base64_sha256 = BASE64_STANDARD.encode(id_sha256);
+        let id_base64_sha256 = BASE64_STANDARD_NO_PAD.encode(id_sha256);
+
         let unique_string = format!(
             "v3,{},{},{}",
             buf.to_monero_base58(),


### PR DESCRIPTION
Description
---


coinbase '=' padding character caused an issue where an alternative string was written to the blockchain


Motivation and Context
---


Invalid id written to the chain.


How Has This Been Tested?
---



On esmeralda with a local build.  


What process can a PR reviewer use to test or verify this change?
---


Check the coinbase extra string that gets written to the block and compare that to what the merge mining proxy gets as an arg.



Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

