### PR TITLE
feat: better p2pool health check

### DIFF
--- a/src-tauri/src/p2pool/models.rs
+++ b/src-tauri/src/p2pool/models.rs
@@ -71,6 +71,7 @@ pub struct Stats {
     pub connected_since: Option<EpochTime>,
     pub randomx_stats: ChainStats,
     pub sha3x_stats: ChainStats,
+    pub last_gossip_message: EpochTime,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -36,6 +36,7 @@ use crate::process_adapter::HealthStatus;
 use crate::process_adapter::ProcessStartupSpec;
 use crate::process_adapter::{ProcessAdapter, ProcessInstance, StatusMonitor};
 use crate::utils::file_utils::convert_to_string;
+use tari_utilities::epoch_time::EpochTime;
 
 #[cfg(target_os = "windows")]
 use crate::utils::setup_utils::setup_utils::add_firewall_rule;
@@ -163,7 +164,28 @@ impl P2poolStatusMonitor {
 impl StatusMonitor for P2poolStatusMonitor {
     async fn check_health(&self) -> HealthStatus {
         match self.stats_client.stats().await {
-            Ok(_) => HealthStatus::Healthy,
+            Ok(stats) => {
+                if stats
+                    .connection_info
+                    .network_info
+                    .connection_counters
+                    .established_outgoing
+                    + stats
+                        .connection_info
+                        .network_info
+                        .connection_counters
+                        .established_incoming
+                    < 1
+                {
+                    return HealthStatus::Warning;
+                }
+
+                if EpochTime::now().as_u64() - stats.last_gossip_message.as_u64() > 60 {
+                    return HealthStatus::Warning;
+                }
+
+                HealthStatus::Warning
+            }
             Err(e) => {
                 warn!(target: LOG_TARGET, "P2pool health check failed: {}", e);
                 HealthStatus::Unhealthy

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -177,14 +177,16 @@ impl StatusMonitor for P2poolStatusMonitor {
                         .established_incoming
                     < 1
                 {
+                    warn!(target: LOG_TARGET, "P2pool has no connections, health check warning");
                     return HealthStatus::Warning;
                 }
 
                 if EpochTime::now().as_u64() - stats.last_gossip_message.as_u64() > 60 {
+                    warn!(target: LOG_TARGET, "P2pool last gossip message was more than 60 seconds ago, health check warning");
                     return HealthStatus::Warning;
                 }
 
-                HealthStatus::Warning
+                HealthStatus::Healthy
             }
             Err(e) => {
                 warn!(target: LOG_TARGET, "P2pool health check failed: {}", e);


### PR DESCRIPTION
Adds a check that p2pool has received a gossip message and has at least one connection, otherwise returns Warning during the health check. 

Reminder: if a certain number of health checks return Warning in a row, then it will be restarted.