### PR TITLE
fix: base node setup time & app crashing

### DIFF
--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -22,7 +22,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use chrono::{NaiveDateTime, TimeZone, Utc};
 use log::{error, info};
@@ -79,7 +79,9 @@ impl NodeManager {
         // }
 
         let adapter = MinotariNodeAdapter::new();
-        let process_watcher = ProcessWatcher::new(adapter);
+        let mut process_watcher = ProcessWatcher::new(adapter);
+        process_watcher.health_timeout = Duration::from_secs(10);
+        process_watcher.expected_startup_time = Duration::from_secs(120);
 
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),

--- a/src/App/AppWrapper.tsx
+++ b/src/App/AppWrapper.tsx
@@ -34,7 +34,7 @@ const sentryOptions = {
 setupLogger();
 
 export default function AppWrapper() {
-    const allowTelemetry = useAppConfigStore((s) => s.allow_telemetry);
+    // const allowTelemetry = useAppConfigStore((s) => s.allow_telemetry);
     const fetchAppConfig = useAppConfigStore((s) => s.fetchAppConfig);
     const setMiningNetwork = useMiningStore((s) => s.setMiningNetwork);
 
@@ -54,13 +54,15 @@ export default function AppWrapper() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    useEffect(() => {
-        if (allowTelemetry && environment !== 'development') {
-            Sentry.init(sentryOptions);
-        } else {
-            Sentry.close();
-        }
-    }, [allowTelemetry]);
+    // We think Sentry/Vite is causing the crashing issues. Disable on the front end for now.
+    //
+    // useEffect(() => {
+    //     if (allowTelemetry && environment !== 'development') {
+    //         Sentry.init(sentryOptions);
+    //     } else {
+    //         Sentry.close();
+    //     }
+    // }, [allowTelemetry]);
 
     return <App />;
 }


### PR DESCRIPTION
Description
---
Allow the base node more time to setup before qualifying it as bad.
Prevent sentry/vite from crashing the front end.

fixes: #1275
fixes: #1269
fixes: #1273

Motivation and Context
---
Fix bug preventing use of the app

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
- Setup, and not run into the 30% bug.
- Run on windows for 2+ hours and not crash
- See the settings panel on windows not be slow