### PR TITLE
feat(ui): introduce number-flow animation library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@floating-ui/react": "^0.26.28",
                 "@lottiefiles/dotlottie-react": "^0.10.1",
+                "@number-flow/react": "^0.4.4",
                 "@sentry/react": "^8.42.0",
                 "@tauri-apps/api": "^2.1.1",
                 "@tauri-apps/plugin-os": "^2.0.0",
@@ -1303,6 +1304,20 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@number-flow/react": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@number-flow/react/-/react-0.4.4.tgz",
+            "integrity": "sha512-m2FW55jnWqiJzKNRETgyxgR7a8x0WYIZ1uyiIW8C5g6HyjIynryJJop1mEcmHG6OyNePkcb8OQIcjKlV5TfHAw==",
+            "license": "MIT",
+            "dependencies": {
+                "esm-env": "^1.1.4",
+                "number-flow": "0.4.2"
+            },
+            "peerDependencies": {
+                "react": "^18 || ^19",
+                "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@pkgr/core": {
@@ -3874,6 +3889,12 @@
                 "node": "*"
             }
         },
+        "node_modules/esm-env": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.1.tgz",
+            "integrity": "sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==",
+            "license": "MIT"
+        },
         "node_modules/espree": {
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -6136,6 +6157,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/number-flow": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/number-flow/-/number-flow-0.4.2.tgz",
+            "integrity": "sha512-YLN73/m8BUU4r/6mq9zqLdpFKt3LSPPRectOECheA9jtNWF4PP8EIz0+Z1giqu/x9nS86KnKwwouLXXiqnjhQQ==",
+            "license": "MIT",
+            "dependencies": {
+                "esm-env": "^1.1.4"
             }
         },
         "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "@floating-ui/react": "^0.26.28",
         "@lottiefiles/dotlottie-react": "^0.10.1",
+        "@number-flow/react": "^0.4.4",
         "@sentry/react": "^8.42.0",
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-os": "^2.0.0",

--- a/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
@@ -1,6 +1,6 @@
 import { Wrapper, Number, Label, GemImage, GemsAnimation, GemAnimatedImage } from './styles';
 import gemImage from '../../images/gem.png';
-import { AnimatePresence, useSpring } from 'framer-motion';
+import { AnimatePresence } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import NumberFlow from '@number-flow/react';
 

--- a/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
@@ -2,6 +2,7 @@ import { Wrapper, Number, Label, GemImage, GemsAnimation, GemAnimatedImage } fro
 import gemImage from '../../images/gem.png';
 import { AnimatePresence, useSpring } from 'framer-motion';
 import { useEffect, useState } from 'react';
+import NumberFlow from '@number-flow/react';
 
 interface Props {
     number: number;
@@ -9,7 +10,6 @@ interface Props {
 }
 
 export default function Gems({ number, label }: Props) {
-    const [displayValue, setDisplayValue] = useState(number);
     const [animate, setAnimate] = useState(false);
 
     const getRandomX = (() => {
@@ -28,28 +28,18 @@ export default function Gems({ number, label }: Props) {
         };
     })();
 
-    const spring = useSpring(0, { mass: 0.8, stiffness: 50, damping: 20 });
-
-    spring.on('change', (latest: number) => {
-        setDisplayValue(Math.round(latest));
-    });
-
-    useEffect(() => {
-        spring.set(number);
-    }, [spring, number]);
-
     useEffect(() => {
         setAnimate(true);
         const timer = setTimeout(() => setAnimate(false), 1000);
         return () => clearTimeout(timer);
-    }, [displayValue]);
+    }, [number]);
 
     return (
         <Wrapper>
             <Number>
                 <GemImage src={gemImage} alt="" />
 
-                {displayValue.toLocaleString()}
+                <NumberFlow value={number} continuous={true} willChange={true} />
 
                 <AnimatePresence>
                     {animate && (

--- a/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
@@ -30,7 +30,7 @@ export default function Gems({ number, label }: Props) {
 
     useEffect(() => {
         setAnimate(true);
-        const timer = setTimeout(() => setAnimate(false), 1000);
+        const timer = setTimeout(() => setAnimate(false), 2000);
         return () => clearTimeout(timer);
     }, [number]);
 

--- a/src/containers/main/ShellOfSecrets/SoSWidget/segments/Timer/Timer.tsx
+++ b/src/containers/main/ShellOfSecrets/SoSWidget/segments/Timer/Timer.tsx
@@ -11,6 +11,7 @@ import {
 } from './styles';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
+import NumberFlow from '@number-flow/react';
 
 export default function Timer() {
     const { t } = useTranslation('sos', { useSuspense: false });
@@ -37,12 +38,38 @@ export default function Timer() {
 
             <TimerColumn>
                 <NumberGroup>
-                    <Number>{reminingTime.days}</Number>
+                    <Number>
+                        <NumberFlow
+                            value={reminingTime.days}
+                            willChange={true}
+                            continuous={true}
+                            trend={-1}
+                            format={{
+                                style: 'decimal',
+                                minimumIntegerDigits: 2,
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0,
+                            }}
+                        />
+                    </Number>
                     <Label>{t('widget.timer.days')}</Label>
                 </NumberGroup>
 
                 <NumberGroup>
-                    <Number>{reminingTime.hours}</Number>
+                    <Number>
+                        <NumberFlow
+                            value={reminingTime.hours}
+                            willChange={true}
+                            continuous={true}
+                            trend={-1}
+                            format={{
+                                style: 'decimal',
+                                minimumIntegerDigits: 2,
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0,
+                            }}
+                        />
+                    </Number>
                     <Label>{t('widget.timer.hours')}</Label>
                 </NumberGroup>
             </TimerColumn>

--- a/src/containers/main/ShellOfSecrets/SoSWidget/segments/Timer/styles.ts
+++ b/src/containers/main/ShellOfSecrets/SoSWidget/segments/Timer/styles.ts
@@ -58,23 +58,29 @@ export const TimerColumn = styled('div')`
     display: flex;
     flex-direction: column;
     padding-left: 30px;
-    gap: 4px;
+    gap: 6px;
 `;
 
 export const NumberGroup = styled('div')`
     display: flex;
-    gap: 2px;
     align-items: flex-end;
+    height: 50px;
+    position: relative;
 `;
 
 export const Number = styled('div')`
     font-size: 64px;
-    line-height: 80%;
-    text-transform: uppercase;
+    line-height: 100%;
+    height: 50px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translateY(-22px);
 `;
 
 export const Label = styled('div')`
     font-size: 16px;
     line-height: 100%;
     text-transform: uppercase;
+    padding-left: 79px;
 `;

--- a/src/containers/phase/Setup/components/SetupProgress.tsx
+++ b/src/containers/phase/Setup/components/SetupProgress.tsx
@@ -1,6 +1,7 @@
 import { LinearProgress } from '@app/components/elements/LinearProgress';
 import { Typography } from '@app/components/elements/Typography';
 import { useAppStateStore } from '@app/store/appStateStore';
+import NumberFlow from '@number-flow/react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -29,7 +30,9 @@ export default function SetupProgress() {
 
     return (
         <Wrapper>
-            <Percentage>{progressPercentage}%</Percentage>
+            <Percentage>
+                <NumberFlow value={setupProgress} willChange={true} format={{ style: 'percent' }} />
+            </Percentage>
             <InfoText variant="p">{setupTitle ? t(`setup-view:title.${setupTitle}`, setupTitleParams) : ''}</InfoText>
             <LinearProgress value={progressPercentage} variant="small" />
         </Wrapper>

--- a/src/containers/phase/Setup/components/SetupProgress.tsx
+++ b/src/containers/phase/Setup/components/SetupProgress.tsx
@@ -31,7 +31,7 @@ export default function SetupProgress() {
     return (
         <Wrapper>
             <Percentage>
-                <NumberFlow value={setupProgress} willChange={true} format={{ style: 'percent' }} />
+                <NumberFlow value={setupProgress} willChange={true} continuous={true} format={{ style: 'percent' }} />
             </Percentage>
             <InfoText variant="p">{setupTitle ? t(`setup-view:title.${setupTitle}`, setupTitleParams) : ''}</InfoText>
             <LinearProgress value={progressPercentage} variant="small" />


### PR DESCRIPTION
I found this pretty amazing library for animating numbers, better than what we currently have.

https://number-flow.barvian.me/

The goal of this PR is to add the `number-flow` library and implement it in a few "Low Risk" areas. This will allow us to test how it impacts performance, and if it's performing well we can begin to implement it in other areas of the app. 

Right now it's implemented in the following places:

- Percentage loader on the Setup screen
- Sidebar Gems counter when logged in 
- SoS widget timer

https://www.loom.com/share/96bdd9253e664385b19e96c526f85eb8?sid=97b5b3c7-23a4-43d9-b4da-a64c7f0da372
