### PR TITLE
chore: don't make bundles for every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,9 @@ jobs:
       - name: cargo tauri build
         working-directory: ./src-tauri
         run: |
-          cargo install tauri-cli --version "^2" --locked
+          cargo install tauri-cli --version "2.1.0" --locked
           cargo tauri --version
-          cargo tauri build --ci --no-bundle
+          cargo tauri build --ci --bundles deb
 
   file-licenses:
     name: file-licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           cargo install tauri-cli --version "2.1.0" --locked
           cargo tauri --version
-          cargo tauri build --ci --bundles deb
+          cargo tauri build --ci --no-bundle
 
   file-licenses:
     name: file-licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           cargo install tauri-cli --version "^2" --locked
           cargo tauri --version
-          cargo tauri build --ci --bundles deb
+          cargo tauri build --ci --no-bundle
 
   file-licenses:
     name: file-licenses

--- a/ci/windows-dev-environment-notes.md
+++ b/ci/windows-dev-environment-notes.md
@@ -268,16 +268,15 @@ found 0 vulnerabilities
 ```
 
 # Install Cargo tools - tauri-cli
-```PowerShell
-cd src/universe
-cargo install tauri-cli --version "1.6.4"
+```Pow/universe
+cargo install tauri-cli --version "2.1.0"
 ```
 sample output:
 ```
-PS C:\Users\leet\src\universe> cargo install tauri-cli --version "1.6.4"
+PS C:\Users\leet\src\universe> cargo install tauri-cli --version "2.1.0"
 >>
     Updating crates.io index
-  Installing tauri-cli v1.6.4
+  Installing tauri-cli v2.1.0
     Updating crates.io index
        Fetch [===========>                     ] 48 complete; 1 pending
 ```
@@ -291,14 +290,14 @@ PS C:\Users\leet\src\universe> cargo install tauri-cli --version "1.6.4"
     Building [=======================> ] 491/492: cargo-tauri(bin)
     Finished `release` profile [optimized] target(s) in 13m 14s
   Installing C:\Users\leet\.cargo\bin\cargo-tauri.exe
-   Installed package `tauri-cli v1.6.4` (executable `cargo-tauri.exe`)
+   Installed package `tauri-cli v2.1.0` (executable `cargo-tauri.exe`)
 ```
 ```PowerShell
 cargo tauri --version
 ```
 sample output:
 ```
-  tauri-cli 1.6.4
+  tauri-cli 2.1.0
 ```
 
 # Build from source for ```Tari Universe Alpha```


### PR DESCRIPTION
Description
---
Fix broken CI builds. We suffered two different errors (below), for relatively unknown reasons. To get past the errors I've turned bundles off in the `tauri-build` workflow. We don't need these bundles made. The workflow still does a test release compile. it just isn't packaging the build for any specific platform anymore.

Version was bumped here: https://github.com/tari-project/universe/pull/1349 to resolve a previous error.

First error
```
error: failed to compile `tauri-cli v2.2.2`, intermediate artifacts can be found at `/tmp/cargo-install8JNgkx`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.80.0 is not supported by the following package:
    home@0.5.11 requires rustc 1.81
```

Second error:
```
     Finished `release` profile [optimized + debuginfo] target(s) in 14m 07s
    Built application at: /home/runner/work/universe/universe/src-tauri/target/release/Tari Universe (Alpha)
    Bundling Tari Universe (Alpha)_0.8.40_amd64.deb (/home/runner/work/universe/universe/src-tauri/target/release/bundle/deb/Tari Universe (Alpha)_0.8.40_amd64.deb)
    Error failed to bundle project:
    - Unable to find a bundled project for the updater
Error: Process completed with exit code 1.
```

Motivation and Context
---
Fix CI

How Has This Been Tested?
---
See if CI is green
