### PR TITLE
chore: prevent from clearing wallet data after restart

### DIFF
--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -173,10 +173,6 @@ impl ProcessAdapter for WalletAdapter {
             warn!(target: LOG_TARGET, "Could not clear peer data folder: {}", e);
         }
 
-        //  Delete any old wallets on startup
-        if let Err(e) = std::fs::remove_dir_all(&wallet_data_folder) {
-            warn!(target: LOG_TARGET, "Could not clear wallet data folder: {}", e);
-        }
 
         #[cfg(target_os = "windows")]
         add_firewall_rule(

--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -141,9 +141,6 @@ impl ProcessAdapter for WalletAdapter {
             .join(Network::get_current_or_user_setting_or_default().to_string())
             .join("peer_db");
 
-        let wallet_data_folder =
-            working_dir.join(Network::get_current_or_user_setting_or_default().to_string());
-
         if self.use_tor {
             args.push("-p".to_string());
             args.push("wallet.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true".to_string())
@@ -172,7 +169,6 @@ impl ProcessAdapter for WalletAdapter {
         if let Err(e) = std::fs::remove_dir_all(peer_data_folder) {
             warn!(target: LOG_TARGET, "Could not clear peer data folder: {}", e);
         }
-
 
         #[cfg(target_os = "windows")]
         add_firewall_rule(


### PR DESCRIPTION
Description
We've been clearing the wallet database on startup which forced scanning UTXOs from the tip 0 on every run. Scanning takes really long time each run:
```
DEBUG Scanning round completed up to height 84661 in 440.07s (2116869 outputs scanned, 1478 recovered with value 1479069.697509 T)
```
Clearing was done when we had issues with view keys. Since it's gone, we can keep wallet dir and support caching.

How Has This Been Tested?
---
I tested manually by running the app several times and watching wallet logs(base_layer.log) to check whether wallet uses previously scanned blocks. 
```
Scanning round completed up to height 85291 in 301.62ms (70 outputs scanned, 0 recovered with value 0 µT)
```

I also played with displaying seed words and importing new wallets to ensure everything is doesn't break anything related to the view keys