### PR TITLE
fix: remove old auth url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
           BETA_STRING: '(Beta)'
           AIRDROP_BASE_URL: ${{ secrets.BETA_AIRDROP_BASE_URL }}
           AIRDROP_API_BASE_URL: ${{ secrets.BETA_AIRDROP_API_BASE_URL }}
-          AIRDROP_TWITTER_AUTH_URL: ${{ secrets.BETA_AIRDROP_TWITTER_AUTH_URL }}
           TELEMETRY_API_URL: ${{ secrets.BETA_TELEMETRY_API_URL }}
           AIRDROP_WEBSOCKET_CRYPTO_KEY: ${{ secrets.DEV_AIRDROP_WEBSOCKET_CRYPTO_KEY }}
         shell: bash
@@ -68,7 +67,6 @@ jobs:
           echo "TARI_TARGET_NETWORK=testnet" >> $GITHUB_ENV
           echo "AIRDROP_BASE_URL=${{ env.AIRDROP_BASE_URL }}" >> $GITHUB_ENV
           echo "AIRDROP_API_BASE_URL=${{ env.AIRDROP_API_BASE_URL }}" >> $GITHUB_ENV
-          echo "AIRDROP_TWITTER_AUTH_URL=${{ env.AIRDROP_TWITTER_AUTH_URL }}" >> $GITHUB_ENV
           echo "TELEMETRY_API_URL=${{ env.TELEMETRY_API_URL }}" >> $GITHUB_ENV
           echo "AIRDROP_WEBSOCKET_CRYPTO_KEY=${{ env.AIRDROP_WEBSOCKET_CRYPTO_KEY }}" >> $GITHUB_ENV
           echo "TS_FEATURES=release-ci-beta, airdrop-env" >> $GITHUB_ENV

--- a/src-tauri/src/app_in_memory_config.rs
+++ b/src-tauri/src/app_in_memory_config.rs
@@ -34,11 +34,6 @@ const AIRDROP_API_BASE_URL: &str = std::env!(
     "AIRDROP_API_BASE_URL",
     "AIRDROP_API_BASE_URL env var not defined"
 );
-#[cfg(feature = "airdrop-env")]
-const AIRDROP_TWITTER_AUTH_URL: &str = std::env!(
-    "AIRDROP_TWITTER_AUTH_URL",
-    "AIRDROP_TWITTER_AUTH_URL env var not defined"
-);
 #[cfg(feature = "telemetry-env")]
 const TELEMETRY_API_URL: &str =
     std::env!("TELEMETRY_API_URL", "TELEMETRY_API_URL env var not defined");
@@ -47,7 +42,6 @@ const TELEMETRY_API_URL: &str =
 pub struct AppInMemoryConfig {
     pub airdrop_url: String,
     pub airdrop_api_url: String,
-    pub airdrop_twitter_auth_url: String,
     pub airdrop_access_token: Option<String>,
     pub telemetry_api_url: String,
 }
@@ -57,7 +51,6 @@ pub struct AppInMemoryConfig {
 pub struct AirdropInMemoryConfig {
     pub airdrop_url: String,
     pub airdrop_api_url: String,
-    pub airdrop_twitter_auth_url: String,
 }
 
 impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
@@ -65,7 +58,6 @@ impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
         AirdropInMemoryConfig {
             airdrop_url: app_config.airdrop_url,
             airdrop_api_url: app_config.airdrop_api_url,
-            airdrop_twitter_auth_url: app_config.airdrop_twitter_auth_url,
         }
     }
 }
@@ -75,7 +67,6 @@ impl Default for AppInMemoryConfig {
         AppInMemoryConfig {
             airdrop_url: "https://airdrop.tari.com".into(),
             airdrop_api_url: "https://ut.tari.com".into(),
-            airdrop_twitter_auth_url: "https://airdrop.tari.com/auth".into(),
             airdrop_access_token: None,
             telemetry_api_url: "https://ut.tari.com/push".into(),
         }
@@ -121,7 +112,6 @@ impl AppInMemoryConfig {
         return AppInMemoryConfig {
             airdrop_url: AIRDROP_BASE_URL.into(),
             airdrop_api_url: AIRDROP_API_BASE_URL.into(),
-            airdrop_twitter_auth_url: AIRDROP_TWITTER_AUTH_URL.into(),
             airdrop_access_token: None,
             telemetry_api_url: TELEMETRY_API_URL.into(),
         };
@@ -130,7 +120,6 @@ impl AppInMemoryConfig {
         return AppInMemoryConfig {
             airdrop_url: "http://localhost:4000".into(),
             airdrop_api_url: "http://localhost:3004".into(),
-            airdrop_twitter_auth_url: "http://localhost:3004/auth/twitter".into(),
             airdrop_access_token: None,
             telemetry_api_url: "http://localhost:3004".into(),
         };

--- a/src/containers/floating/Settings/sections/airdrop/ApplyInviteCode.tsx
+++ b/src/containers/floating/Settings/sections/airdrop/ApplyInviteCode.tsx
@@ -29,9 +29,9 @@ export const ApplyInviteCode = () => {
 
     const handleAuth = useCallback(() => {
         const token = uuidv4();
-        if (backendInMemoryConfig?.airdropTwitterAuthUrl) {
+        if (backendInMemoryConfig?.airdropUrl) {
             setLoading(true);
-            const refUrl = `${backendInMemoryConfig?.airdropTwitterAuthUrl}?tauri=${token}${claimCode ? `&universeReferral=${claimCode}` : ''}`;
+            const refUrl = `${backendInMemoryConfig?.airdropUrl}/auth?tauri=${token}${claimCode ? `&universeReferral=${claimCode}` : ''}`;
 
             setAllowTelemetry(true).then(() => {
                 setAuthUuid(token);
@@ -39,7 +39,7 @@ export const ApplyInviteCode = () => {
             });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [backendInMemoryConfig?.airdropTwitterAuthUrl, claimCode]);
+    }, [backendInMemoryConfig?.airdropUrl, claimCode]);
 
     const handleToken = useCallback(() => {
         if (authUuid) {

--- a/src/containers/main/Airdrop/AirdropGiftTracker/sections/LoggedOut/LoggedOut.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/sections/LoggedOut/LoggedOut.tsx
@@ -18,15 +18,15 @@ export default function LoggedOut() {
     const handleAuth = useCallback(
         (code?: string) => {
             const token = uuidv4();
-            if (backendInMemoryConfig?.airdropTwitterAuthUrl) {
+            if (backendInMemoryConfig?.airdropUrl) {
                 setAuthUuid(token);
                 open(
-                    `${backendInMemoryConfig?.airdropTwitterAuthUrl}?tauri=${token}${code ? `&universeReferral=${code}` : ''}`
+                    `${backendInMemoryConfig?.airdropUrl}/auth?tauri=${token}${code ? `&universeReferral=${code}` : ''}`
                 );
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [backendInMemoryConfig?.airdropTwitterAuthUrl]
+        [backendInMemoryConfig?.airdropUrl]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Description
---


Removes deprecated url config variable.

Motivation and Context
---


The project switched to the new auth system, which is available through the website url.

How Has This Been Tested?
---


local Tari universe, with the combination of both airdrop local and airdrop production versions.

What process can a PR reviewer use to test or verify this change?
---

The reviewer should start up the app and be able to log in to the airdrop game without any issues.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->