### PR TITLE
fix(ui): fix layout shifting on gems number animation

### DIFF
--- a/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/Gems.tsx
@@ -49,7 +49,20 @@ export default function Gems({ number, label }: Props) {
             <Number>
                 <GemImage src={gemImage} alt="" />
 
-                {displayValue.toLocaleString()}
+                {displayValue
+                    .toLocaleString()
+                    .split('')
+                    .map((char, index) =>
+                        char === ',' || char === '.' ? (
+                            <span key={index} className="digit-char">
+                                {char}
+                            </span>
+                        ) : (
+                            <span key={index} className="digit-num">
+                                {char}
+                            </span>
+                        )
+                    )}
 
                 <AnimatePresence>
                     {animate && (

--- a/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/styles.ts
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/components/Gems/styles.ts
@@ -21,6 +21,16 @@ export const Number = styled('div')`
     line-height: 100%;
 
     font-variant-numeric: tabular-nums;
+
+    .digit-num {
+        width: 10px;
+        text-align: center;
+    }
+
+    .digit-char {
+        width: 4px;
+        text-align: center;
+    }
 `;
 
 export const Label = styled('div')`


### PR DESCRIPTION
This PR fixes the layout shifting on the Gems animated number. using `NumberFlow` would also fix this, but i'm adding this as a quick little improvement while we wait for the full integration of `NumberFlow`. 

Here's a video showing the improvement. It shows the current version at first, then the improved version at the 8 second mark. 

https://github.com/user-attachments/assets/3f6e9553-31b0-4141-8230-82ca2dde07a0

