### PR TITLE
refactor: emit and logging cleanup

### DIFF
--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -142,7 +142,6 @@ impl AutoLauncher {
             .ok_or(anyhow!("Failed to convert path to string"))?
             .to_string();
 
-        info!(target: LOG_TARGET, "Building auto-launcher with app_name: {} and app_path: {}", app_name, app_path);
         let auto_launcher = AutoLauncher::build_auto_launcher(app_name, &app_path)?;
 
         AutoLauncher::toggle_auto_launcher(&auto_launcher, is_auto_launcher_enabled)?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -753,8 +753,8 @@ async fn setup_inner(
 }
 
 async fn listen_to_frontend_ready(app: tauri::AppHandle) -> Result<(), anyhow::Error> {
-    let app_clone = app.clone();
-    app_clone.listen("frontend_ready", move |_event| {
+    let app_handle = app.clone();
+    app_handle.once("frontend_ready", move |_event| {
         info!(target: LOG_TARGET, "Frontend is ready");
         let app_clone: tauri::AppHandle = app.clone();
         tauri::async_runtime::spawn(async move {

--- a/src/App/AppWrapper.tsx
+++ b/src/App/AppWrapper.tsx
@@ -8,12 +8,17 @@ import setupLogger from '../utils/shared-logger.ts';
 import useListenForCriticalProblem from '@app/hooks/useListenForCriticalProblem.tsx';
 import { setMiningNetwork } from '@app/store/miningStoreActions.ts';
 import App from './App.tsx';
+import { emit } from '@tauri-apps/api/event';
 
 // FOR ANYTHING THAT NEEDS TO BE INITIALISED
 
 setupLogger();
-
+async function emitReady() {
+    await emit('frontend_ready');
+}
 export default function AppWrapper() {
+    void emitReady();
+
     useDetectMode();
     useDisableRefresh();
     useLangaugeResolver();

--- a/src/hooks/app/isAppReady.ts
+++ b/src/hooks/app/isAppReady.ts
@@ -1,20 +1,15 @@
-import { listen, emit } from '@tauri-apps/api/event';
+import { once } from '@tauri-apps/api/event';
 import { useEffect, useState } from 'react';
 
 export const useIsAppReady = () => {
     const [isAppReady, setIsAppReady] = useState(false);
-
     useEffect(() => {
-        emit('frontend_ready', {});
-
-        const listener = listen('app_ready', () => {
+        const listener = once('app_ready', () => {
             setIsAppReady(true);
         });
-
         return () => {
             listener.then((unlisten) => unlisten());
         };
     }, []);
-
     return isAppReady;
 };


### PR DESCRIPTION
Description
---

- removed a redundant log from auto launcher flow
- updated the `frontend_ready` x `app_ready` emits:
  * separated them, moved FE `emit` to `AppWrapper`
  * changed the `app_ready` (FE) listener to use `once`
  * also changed the `frontend_ready` (BE) listener to use `once`



Motivation and Context + How Has This Been Tested?
---

locally

| before: |
| --- |
| ![before](https://github.com/user-attachments/assets/61f7aef1-3051-4ed1-b1e7-ea55acfd299b) |

| after: |
| --- |
| ![29555](https://github.com/user-attachments/assets/47adcd99-df96-4696-a6c6-5c73ff1f1b27) |


What process can a PR reviewer use to test or verify this change?
---

- run locally
- compare terminal logs to when running latest main locally