### PR TITLE
feat: add process stats to telemetry

### DIFF
--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -23,6 +23,7 @@
 use crate::app_config::MiningMode;
 use crate::binaries::Binaries;
 use crate::commands::{CpuMinerConnection, CpuMinerConnectionStatus, CpuMinerStatus};
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 use crate::xmrig_adapter::{XmrigAdapter, XmrigNodeConnection};
 use crate::CpuMinerConfig;
@@ -43,9 +44,9 @@ pub(crate) struct CpuMiner {
 }
 
 impl CpuMiner {
-    pub fn new() -> Self {
+    pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder) -> Self {
         let xmrig_adapter = XmrigAdapter::new();
-        let process_watcher = ProcessWatcher::new(xmrig_adapter);
+        let process_watcher = ProcessWatcher::new(xmrig_adapter, stats_collector.take_cpu_miner());
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),
         }

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -31,6 +31,7 @@ use tokio::sync::{watch, RwLock};
 use crate::app_config::GpuThreads;
 use crate::binaries::{Binaries, BinaryResolver};
 use crate::gpu_miner_adapter::GpuNodeSource;
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_utils;
 use crate::{
     app_config::MiningMode,
@@ -64,9 +65,12 @@ pub(crate) struct GpuMiner {
 }
 
 impl GpuMiner {
-    pub fn new(status_broadcast: watch::Sender<GpuMinerStatus>) -> Self {
+    pub fn new(
+        status_broadcast: watch::Sender<GpuMinerStatus>,
+        stats_collector: &mut ProcessStatsCollectorBuilder,
+    ) -> Self {
         let adapter = GpuMinerAdapter::new(vec![], status_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter);
+        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_gpu_miner());
         process_watcher.health_timeout = Duration::from_secs(9);
         process_watcher.poll_time = Duration::from_secs(10);
 

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -32,6 +32,7 @@ use tokio::time::sleep;
 
 use crate::mm_proxy_adapter::{MergeMiningProxyAdapter, MergeMiningProxyConfig};
 use crate::port_allocator::PortAllocator;
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 
 const LOG_TARGET: &str = "tari::universe::mm_proxy_manager";
@@ -66,9 +67,10 @@ impl Clone for MmProxyManager {
 }
 
 impl MmProxyManager {
-    pub fn new() -> Self {
+    pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder) -> Self {
         let sidecar_adapter = MergeMiningProxyAdapter::new();
-        let mut process_watcher = ProcessWatcher::new(sidecar_adapter);
+        let mut process_watcher =
+            ProcessWatcher::new(sidecar_adapter, stats_collector.take_mm_proxy());
         process_watcher.health_timeout = std::time::Duration::from_secs(28);
         process_watcher.poll_time = std::time::Duration::from_secs(30);
 

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -39,6 +39,7 @@ use tokio::sync::{watch, RwLock};
 
 use crate::network_utils::{get_best_block_from_block_scan, get_block_info_from_block_scan};
 use crate::node_adapter::{BaseNodeStatus, MinotariNodeAdapter, MinotariNodeStatusMonitorError};
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 use crate::ProgressTracker;
 
@@ -67,7 +68,10 @@ impl Clone for NodeManager {
 }
 
 impl NodeManager {
-    pub fn new(status_broadcast: watch::Sender<BaseNodeStatus>) -> Self {
+    pub fn new(
+        status_broadcast: watch::Sender<BaseNodeStatus>,
+        stats_collector: &mut ProcessStatsCollectorBuilder,
+    ) -> Self {
         // TODO: wire up to front end
         // let mut use_tor = true;
 
@@ -78,7 +82,8 @@ impl NodeManager {
         // }
 
         let adapter = MinotariNodeAdapter::new(status_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter);
+        let mut process_watcher =
+            ProcessWatcher::new(adapter, stats_collector.take_minotari_node());
         process_watcher.poll_time = Duration::from_secs(5);
         process_watcher.health_timeout = Duration::from_secs(4);
         process_watcher.expected_startup_time = Duration::from_secs(120);

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -33,6 +33,7 @@ use tokio::time::sleep;
 use crate::p2pool::models::{Connections, P2poolStats};
 use crate::p2pool_adapter::P2poolAdapter;
 use crate::port_allocator::PortAllocator;
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 
 const LOG_TARGET: &str = "tari::universe::p2pool_manager";
@@ -109,9 +110,12 @@ pub struct P2poolManager {
 }
 
 impl P2poolManager {
-    pub fn new(stats_broadcast: watch::Sender<Option<P2poolStats>>) -> Self {
+    pub fn new(
+        stats_broadcast: watch::Sender<Option<P2poolStats>>,
+        stats_collector: &mut ProcessStatsCollectorBuilder,
+    ) -> Self {
         let adapter = P2poolAdapter::new(stats_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter);
+        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool());
         process_watcher.expected_startup_time = Duration::from_secs(30);
 
         Self {

--- a/src-tauri/src/process_stats_collector.rs
+++ b/src-tauri/src/process_stats_collector.rs
@@ -1,0 +1,132 @@
+use tokio::sync::watch::{Receiver, Sender};
+
+use crate::process_watcher::ProcessWatcherStats;
+
+pub(crate) struct ProcessStatsCollectorBuilder {
+    cpu_miner_tx: Option<Sender<ProcessWatcherStats>>,
+    cpu_miner_rx: Receiver<ProcessWatcherStats>,
+    gpu_miner_tx: Option<Sender<ProcessWatcherStats>>,
+    gpu_miner_rx: Receiver<ProcessWatcherStats>,
+    mm_proxy_tx: Option<Sender<ProcessWatcherStats>>,
+    mm_proxy_rx: Receiver<ProcessWatcherStats>,
+    node_tx: Option<Sender<ProcessWatcherStats>>,
+    node_rx: Receiver<ProcessWatcherStats>,
+    p2pool_tx: Option<Sender<ProcessWatcherStats>>,
+    p2pool_rx: Receiver<ProcessWatcherStats>,
+    tor_tx: Option<Sender<ProcessWatcherStats>>,
+    tor_rx: Receiver<ProcessWatcherStats>,
+    wallet_tx: Option<Sender<ProcessWatcherStats>>,
+    wallet_rx: Receiver<ProcessWatcherStats>,
+}
+
+impl ProcessStatsCollectorBuilder {
+    pub fn new() -> Self {
+        let (cpu_miner_tx, cpu_miner_rx) =
+            tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (gpu_miner_tx, gpu_miner_rx) =
+            tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (mm_proxy_tx, mm_proxy_rx) =
+            tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (node_tx, node_rx) = tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (p2pool_tx, p2pool_rx) = tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (tor_tx, tor_rx) = tokio::sync::watch::channel(ProcessWatcherStats::default());
+        let (wallet_tx, wallet_rx) = tokio::sync::watch::channel(ProcessWatcherStats::default());
+
+        Self {
+            cpu_miner_tx: Some(cpu_miner_tx),
+            cpu_miner_rx,
+            gpu_miner_tx: Some(gpu_miner_tx),
+            gpu_miner_rx,
+            mm_proxy_tx: Some(mm_proxy_tx),
+            mm_proxy_rx,
+            node_tx: Some(node_tx),
+            node_rx,
+            p2pool_tx: Some(p2pool_tx),
+            p2pool_rx,
+            tor_tx: Some(tor_tx),
+            tor_rx,
+            wallet_tx: Some(wallet_tx),
+            wallet_rx,
+        }
+    }
+
+    pub fn take_cpu_miner(&mut self) -> Sender<ProcessWatcherStats> {
+        self.cpu_miner_tx.take().unwrap()
+    }
+
+    pub fn take_gpu_miner(&mut self) -> Sender<ProcessWatcherStats> {
+        self.gpu_miner_tx.take().unwrap()
+    }
+
+    pub fn take_mm_proxy(&mut self) -> Sender<ProcessWatcherStats> {
+        self.mm_proxy_tx.take().unwrap()
+    }
+
+    pub fn take_minotari_node(&mut self) -> Sender<ProcessWatcherStats> {
+        self.node_tx.take().unwrap()
+    }
+
+    pub fn take_p2pool(&mut self) -> Sender<ProcessWatcherStats> {
+        self.p2pool_tx.take().unwrap()
+    }
+
+    pub fn take_tor(&mut self) -> Sender<ProcessWatcherStats> {
+        self.tor_tx.take().unwrap()
+    }
+
+    pub fn take_wallet(&mut self) -> Sender<ProcessWatcherStats> {
+        self.wallet_tx.take().unwrap()
+    }
+
+    pub fn build(self) -> ProcessStatsCollector {
+        ProcessStatsCollector {
+            cpu_miner_rx: self.cpu_miner_rx,
+            gpu_miner_rx: self.gpu_miner_rx,
+            mm_proxy_rx: self.mm_proxy_rx,
+            node_rx: self.node_rx,
+            p2pool_rx: self.p2pool_rx,
+            tor_rx: self.tor_rx,
+            wallet_rx: self.wallet_rx,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ProcessStatsCollector {
+    cpu_miner_rx: Receiver<ProcessWatcherStats>,
+    gpu_miner_rx: Receiver<ProcessWatcherStats>,
+    mm_proxy_rx: Receiver<ProcessWatcherStats>,
+    node_rx: Receiver<ProcessWatcherStats>,
+    p2pool_rx: Receiver<ProcessWatcherStats>,
+    tor_rx: Receiver<ProcessWatcherStats>,
+    wallet_rx: Receiver<ProcessWatcherStats>,
+}
+
+impl ProcessStatsCollector {
+    pub fn get_p2pool_stats(&self) -> ProcessWatcherStats {
+        self.p2pool_rx.borrow().clone()
+    }
+
+    pub fn get_cpu_miner_stats(&self) -> ProcessWatcherStats {
+        self.cpu_miner_rx.borrow().clone()
+    }
+
+    pub fn get_gpu_miner_stats(&self) -> ProcessWatcherStats {
+        self.gpu_miner_rx.borrow().clone()
+    }
+    pub fn get_mm_proxy_stats(&self) -> ProcessWatcherStats {
+        self.mm_proxy_rx.borrow().clone()
+    }
+
+    pub fn get_minotari_node_stats(&self) -> ProcessWatcherStats {
+        self.node_rx.borrow().clone()
+    }
+
+    pub fn get_tor_stats(&self) -> ProcessWatcherStats {
+        self.tor_rx.borrow().clone()
+    }
+
+    pub fn get_wallet_stats(&self) -> ProcessWatcherStats {
+        self.wallet_rx.borrow().clone()
+    }
+}

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -25,6 +25,7 @@ use crate::gpu_miner_adapter::GpuMinerStatus;
 use crate::hardware::hardware_status_monitor::HardwareStatusMonitor;
 use crate::node_adapter::BaseNodeStatus;
 use crate::p2pool::models::P2poolStats;
+use crate::process_stats_collector::{ProcessStatsCollector, ProcessStatsCollectorBuilder};
 use crate::process_utils::retry_with_backoff;
 use crate::{
     app_config::{AppConfig, MiningMode},
@@ -43,7 +44,10 @@ use serde_json::Value;
 use sha2::Digest;
 use std::collections::HashMap;
 use std::ops::Div;
+use std::os::windows::process;
+use std::time::Instant;
 use std::{sync::Arc, thread::sleep, time::Duration};
+use sysinfo::System;
 use tari_common::configuration::Network;
 use tari_utilities::encoding::MBase58;
 use tauri::Emitter;
@@ -206,6 +210,7 @@ pub struct TelemetryManager {
     gpu_status: watch::Receiver<GpuMinerStatus>,
     node_status: watch::Receiver<BaseNodeStatus>,
     p2pool_status: watch::Receiver<Option<P2poolStats>>,
+    process_stats_collector: ProcessStatsCollector,
 }
 
 impl TelemetryManager {
@@ -217,6 +222,7 @@ impl TelemetryManager {
         gpu_status: watch::Receiver<GpuMinerStatus>,
         node_status: watch::Receiver<BaseNodeStatus>,
         p2pool_status: watch::Receiver<Option<P2poolStats>>,
+        process_stats_collector: ProcessStatsCollector,
     ) -> Self {
         let cancellation_token = CancellationToken::new();
         Self {
@@ -229,6 +235,7 @@ impl TelemetryManager {
             gpu_status,
             node_status,
             p2pool_status,
+            process_stats_collector,
         }
     }
 
@@ -294,6 +301,7 @@ impl TelemetryManager {
         timeout: Duration,
         window: tauri::Window,
     ) -> Result<(), TelemetryManagerError> {
+        let uptime = Instant::now();
         let cpu_miner = self.cpu_miner.clone();
         let gpu_status = self.gpu_status.clone();
         let node_status = self.node_status.clone();
@@ -304,6 +312,7 @@ impl TelemetryManager {
         let config_cloned = self.config.clone();
         let in_memory_config_cloned = self.in_memory_config.clone();
         let airdrop_access_token = self.airdrop_access_token.clone();
+        let stats_collector = self.process_stats_collector.clone();
         tokio::spawn(async move {
             tokio::select! {
                 _ = async {
@@ -312,7 +321,7 @@ impl TelemetryManager {
                         let telemetry_collection_enabled = config_cloned.read().await.allow_telemetry();
                         if telemetry_collection_enabled {
                             let airdrop_access_token_validated = validate_jwt(airdrop_access_token.clone()).await;
-                            let telemetry_data = get_telemetry_data(&cpu_miner, &gpu_status, &node_status, &p2pool_status, &config, network).await;
+                            let telemetry_data = get_telemetry_data(&cpu_miner, &gpu_status, &node_status, &p2pool_status, &config, network, uptime, &stats_collector).await;
                             let airdrop_api_url = in_memory_config_cloned.read().await.airdrop_api_url.clone();
                             handle_telemetry_data(telemetry_data, airdrop_api_url, airdrop_access_token_validated, window.clone()).await;
                         }
@@ -374,6 +383,8 @@ async fn get_telemetry_data(
     p2pool_latest_status: &watch::Receiver<Option<P2poolStats>>,
     config: &RwLock<AppConfig>,
     network: Option<Network>,
+    started: Instant,
+    stats_collector: &ProcessStatsCollector,
 ) -> Result<TelemetryData, TelemetryManagerError> {
     let BaseNodeStatus {
         randomx_network_hashrate,
@@ -478,35 +489,7 @@ async fn get_telemetry_data(
         (false, false) => TelemetryResource::None,
     };
 
-    // let p2pool_gpu_stats_sha3 = p2pool_stats.as_ref().map(|s| s.sha3x_stats.clone());
-    // let p2pool_cpu_stats_randomx = p2pool_stats.as_ref().map(|s| s.randomx_stats.clone());
     let p2pool_enabled = config_guard.p2pool_enabled() && p2pool_stats.is_some();
-    // let (cpu_tribe_name, cpu_tribe_id) = if p2pool_enabled {
-    //     if let Some(randomx_stats) = p2pool_cpu_stats_randomx {
-    //         (
-    //             Some(randomx_stats.squad.name.clone()),
-    //             Some(randomx_stats.squad.id.clone()),
-    //         )
-    //     } else {
-    //         (None, None)
-    //     }
-    // } else {
-    //     (None, None)
-    // };
-
-    // let (gpu_tribe_name, gpu_tribe_id) = if p2pool_enabled {
-    //     if let Some(sha3_stats) = p2pool_gpu_stats_sha3 {
-    //         (
-    //             Some(sha3_stats.squad.name.clone()),
-    //             Some(sha3_stats.squad.id.clone()),
-    //         )
-    //     } else {
-    //         (None, None)
-    //     }
-    // } else {
-    //     (None, None)
-    // };
-
     let mut extra_data = HashMap::new();
     extra_data.insert(
         "config_cpu_enabled".to_string(),
@@ -549,6 +532,55 @@ async fn get_telemetry_data(
         extra_data.insert("all_gpus".to_string(), all_gpus.join(","));
     }
 
+    let system = System::new_all();
+    extra_data.insert(
+        "cpu_usage".to_string(),
+        system.global_cpu_usage().to_string(),
+    );
+    extra_data.insert(
+        "total_memory".to_string(),
+        system.total_memory().to_string(),
+    );
+    extra_data.insert("free_memory".to_string(), system.free_memory().to_string());
+    if let Some(core_count) = system.physical_core_count() {
+        extra_data.insert("physical_core_count".to_string(), core_count.to_string());
+    }
+    if let Some(arch) = System::cpu_arch() {
+        extra_data.insert("cpu_arch".to_string(), arch);
+    }
+    extra_data.insert(
+        "uptime".to_string(),
+        started.elapsed().as_secs().to_string(),
+    );
+
+    add_process_stats(
+        &mut extra_data,
+        stats_collector.get_cpu_miner_stats(),
+        "cpu_miner",
+    );
+    add_process_stats(
+        &mut extra_data,
+        stats_collector.get_gpu_miner_stats(),
+        "gpu_miner",
+    );
+    add_process_stats(
+        &mut extra_data,
+        stats_collector.get_minotari_node_stats(),
+        "node",
+    );
+    add_process_stats(
+        &mut extra_data,
+        stats_collector.get_mm_proxy_stats(),
+        "mmproxy",
+    );
+    add_process_stats(&mut extra_data, stats_collector.get_tor_stats(), "tor");
+
+    add_process_stats(
+        &mut extra_data,
+        stats_collector.get_wallet_stats(),
+        "wallet",
+    );
+
     Ok(TelemetryData {
         app_id: config_guard.anon_id().to_string(),
         block_height,
@@ -571,6 +603,47 @@ async fn get_telemetry_data(
         extra_data,
         current_os: std::env::consts::OS.to_string(),
     })
+}
+
+fn add_process_stats(
+    extra_data: &mut HashMap<String, String>,
+    process_stats: crate::process_watcher::ProcessWatcherStats,
+    process: &str,
+) {
+    extra_data.insert(
+        format!("{}_uptime_seconds", process),
+        process_stats.current_uptime.as_secs().to_string(),
+    );
+    extra_data.insert(
+        format!("{}_total_health_checks", process),
+        process_stats.total_health_checks.to_string(),
+    );
+    extra_data.insert(
+        format!("{}_num_warnings", process),
+        process_stats.num_warnings.to_string(),
+    );
+    extra_data.insert(
+        format!("{}_num_failure", process),
+        process_stats.num_failures.to_string(),
+    );
+    extra_data.insert(
+        format!("{}_num_restarts", process),
+        process_stats.num_restarts.to_string(),
+    );
+    extra_data.insert(
+        format!("{}_max_health_check_seconds", process),
+        process_stats
+            .max_health_check_duration
+            .as_secs()
+            .to_string(),
+    );
+    extra_data.insert(
+        format!("{}_total_health_check_seconds", process),
+        process_stats
+            .total_health_check_duration
+            .as_secs()
+            .to_string(),
+    );
 }
 
 async fn handle_telemetry_data(

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 use crate::tor_adapter::{TorAdapter, TorConfig};
 use std::{path::PathBuf, sync::Arc};
@@ -39,9 +40,9 @@ impl Clone for TorManager {
 }
 
 impl TorManager {
-    pub fn new() -> Self {
+    pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder) -> Self {
         let adapter = TorAdapter::new();
-        let process_watcher = ProcessWatcher::new(adapter);
+        let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_tor());
 
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -22,6 +22,7 @@
 
 use crate::node_manager::NodeManager;
 use crate::node_manager::NodeManagerError;
+use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 use crate::wallet_adapter::TransactionInfo;
 use crate::wallet_adapter::WalletStatusMonitorError;
@@ -61,12 +62,13 @@ impl WalletManager {
     pub fn new(
         node_manager: NodeManager,
         wallet_watch_tx: watch::Sender<Option<WalletBalance>>,
+        stats_collector: &mut ProcessStatsCollectorBuilder,
     ) -> Self {
         // TODO: wire up to front end
         let use_tor = false;
 
         let adapter = WalletAdapter::new(use_tor, wallet_watch_tx);
-        let process_watcher = ProcessWatcher::new(adapter);
+        let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet());
 
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),


### PR DESCRIPTION
Adds stats to telemetry for the following processes:
1. cpu_miner
2. gpu_miner
3. p2pool
4. node
5. mmproxy
6. tor
7. wallet

For each, it adds the following data:
1. uptime
2. total health checks
3. total_health_check time 
4. (avg health check time can be inferred)
5. max health check time
6. num warnings
7. num failures
8. num restarts
