### PR TITLE
feat: add new base node grpc call with new nextnet release

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3903,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -3933,8 +3933,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "bs58 0.5.1",
 ]
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -7002,8 +7002,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "config",
@@ -7026,8 +7026,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -7040,8 +7040,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.7.0",
@@ -7066,8 +7066,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7110,8 +7110,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "bitflags 2.7.0",
@@ -7145,8 +7145,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7155,8 +7155,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7249,13 +7249,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 
 [[package]]
 name = "tari_hashing"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "borsh",
  "digest",
@@ -7264,8 +7264,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "argon2",
  "async-trait",
@@ -7297,8 +7297,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "borsh",
  "serde",
@@ -7308,8 +7308,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "borsh",
  "digest",
@@ -7322,8 +7322,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "fs2",
@@ -7354,8 +7354,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "blake2",
  "borsh",
@@ -7372,8 +7372,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7387,16 +7387,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -7407,8 +7407,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "1.9.10-rc.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
+version = "1.10.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.1#b6fb3b512595d5aa0ac4c1b5140f2e08ceda68a9"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3903,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -3933,8 +3933,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "bs58 0.5.1",
 ]
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "minotari_node_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "minotari_app_grpc",
  "tari_common_types",
@@ -7002,8 +7002,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "config",
@@ -7026,8 +7026,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -7040,8 +7040,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.7.0",
@@ -7066,8 +7066,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7110,8 +7110,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "bitflags 2.7.0",
@@ -7145,8 +7145,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7155,8 +7155,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7249,13 +7249,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 
 [[package]]
 name = "tari_hashing"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "borsh",
  "digest",
@@ -7264,8 +7264,8 @@ dependencies = [
 
 [[package]]
 name = "tari_key_manager"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "argon2",
  "async-trait",
@@ -7297,8 +7297,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "borsh",
  "serde",
@@ -7308,8 +7308,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "borsh",
  "digest",
@@ -7322,8 +7322,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "fs2",
@@ -7354,8 +7354,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "blake2",
  "borsh",
@@ -7372,8 +7372,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7387,16 +7387,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -7407,8 +7407,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "1.9.1-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v1.9.1-rc.1#65a61008a5f7c05c34453535894b9a24132d2665"
+version = "1.9.10-rc.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v1.10.0-rc.0#63cf7b8bc4ff60378585188d91cb8d14c143c77a"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,8 +38,8 @@ libsqlite3-sys = { version = "0.25.1", features = [
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -58,15 +58,15 @@ sha2 = "0.10.8"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1", features = [
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0", features = [
   "transactions",
 ] }
 tauri-plugin-single-instance = '2'
 tari_crypto = "0.21.0"
-tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.9.1-rc.1" }
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
   "isolation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,8 +38,8 @@ libsqlite3-sys = { version = "0.25.1", features = [
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -58,15 +58,15 @@ sha2 = "0.10.8"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0", features = [
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1", features = [
   "transactions",
 ] }
 tauri-plugin-single-instance = '2'
 tari_crypto = "0.21.0"
-tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.0" }
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.10.0-rc.1" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
   "isolation",

--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -1,9 +1,9 @@
 {
     "binaries": {
         "xmrig": "=6.22.0",
-        "mmproxy": "=1.9.2-pre.0",
-        "minotari_node": "=1.9.2-pre.0",
-        "wallet": "=1.9.2-pre.0",
+        "mmproxy": "=1.10.0-pre.1",
+        "minotari_node": "=1.10.0-pre.1",
+        "wallet": "=1.10.0-pre.1",
         "sha-p2pool": "=0.20.0",
         "xtrgpuminer": "=0.2.10",
         "tor": "=13.5.7"

--- a/src-tauri/binaries_versions_nextnet.json
+++ b/src-tauri/binaries_versions_nextnet.json
@@ -1,9 +1,9 @@
 {
     "binaries": {
         "xmrig": "=6.22.0",
-        "mmproxy": "=1.9.2-rc.0",
-        "minotari_node": "=1.9.2-rc.0",
-        "wallet": "=1.9.2-rc.0",
+        "mmproxy": "=1.10.0-rc.1",
+        "minotari_node": "=1.10.0-rc.1",
+        "wallet": "=1.10.0-rc.1",
         "sha-p2pool": "=0.20.0",
         "xtrgpuminer": "=0.2.10",
         "tor": "=13.5.7"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -41,6 +41,7 @@ use crate::wallet_adapter::{TransactionInfo, WalletBalance};
 use crate::wallet_manager::WalletManagerError;
 use crate::{node_adapter, UniverseAppState, APPLICATION_FOLDER_ID};
 
+use crate::node_adapter::BaseNodeState;
 use base64::prelude::*;
 use keyring::Entry;
 use log::{debug, error, info, warn};
@@ -102,6 +103,14 @@ pub struct MinerMetrics {
     base_node: BaseNodeStatus,
 }
 
+impl MinerMetrics {
+    /// Returns `true` if the base node has state `BaseNodeState::Listening`
+    #[allow(dead_code)]
+    pub fn is_synced(&self) -> bool {
+        self.base_node.base_node_state == BaseNodeState::Listening
+    }
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct TariWalletDetails {
     wallet_balance: Option<WalletBalance>,
@@ -113,10 +122,13 @@ pub struct TariWalletDetails {
 pub struct BaseNodeStatus {
     block_height: u64,
     block_time: u64,
-    is_synced: bool,
+    initial_sync_achieved: bool,
+    base_node_state: BaseNodeState,
+    failed_checkpoints: bool,
     is_connected: bool,
     connected_peers: Vec<String>,
 }
+
 #[derive(Debug, Serialize, Clone)]
 pub struct CpuMinerStatus {
     pub is_mining: bool,
@@ -401,17 +413,11 @@ pub async fn get_miner_metrics(
         randomx_network_hashrate,
         block_height,
         block_time,
-        is_synced,
+        initial_sync_achieved,
         block_reward,
+        base_node_state,
+        failed_checkpoints,
     } = node_status;
-    // let (sha_hash_rate, randomx_hash_rate, block_reward, block_height, block_time, is_synced) = state.node_manager
-    //     .get_network_hash_rate_and_block_reward().await
-    //     .unwrap_or_else(|e| {
-    //         if !matches!(e, NodeManagerError::NodeNotStarted) {
-    //             warn!(target: LOG_TARGET, "Error getting network hash rate and block reward: {}", e);
-    //         }
-    //         (0, 0, MicroMinotari(0), 0, 0, false)
-    //     });
 
     let cpu_miner = state.cpu_miner.read().await;
     let cpu_mining_status = match cpu_miner
@@ -461,7 +467,9 @@ pub async fn get_miner_metrics(
         base_node: BaseNodeStatus {
             block_height,
             block_time,
-            is_synced,
+            initial_sync_achieved,
+            base_node_state,
+            failed_checkpoints,
             is_connected: !connected_peers.is_empty(),
             connected_peers,
         },

--- a/src-tauri/src/node_adapter.rs
+++ b/src-tauri/src/node_adapter.rs
@@ -32,10 +32,11 @@ use anyhow::{anyhow, Error};
 use async_trait::async_trait;
 use log::{info, warn};
 use minotari_node_grpc_client::grpc::{
-    BlockHeader, Empty, GetBlocksRequest, HeightRequest, NewBlockTemplateRequest, Peer, PowAlgo,
-    SyncState,
+    BaseNodeState as GrpcBaseNodeState, BlockHeader, Empty, GetBlocksRequest,
+    GetNetworkStateRequest, Peer, SyncState,
 };
 use minotari_node_grpc_client::BaseNodeGrpcClient;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::PathBuf;
@@ -233,16 +234,71 @@ pub enum MinotariNodeStatusMonitorError {
     UnknownError(#[from] anyhow::Error),
     #[error("Node not started")]
     NodeNotStarted,
+    #[error("Conversion error: {0}")]
+    Conversion(String),
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct BaseNodeStatus {
     pub sha_network_hashrate: u64,
     pub randomx_network_hashrate: u64,
     pub block_reward: MicroMinotari,
     pub block_height: u64,
     pub block_time: u64,
-    pub is_synced: bool,
+    pub initial_sync_achieved: bool,
+    pub base_node_state: BaseNodeState,
+    pub failed_checkpoints: bool,
+}
+
+impl Default for BaseNodeStatus {
+    fn default() -> Self {
+        Self {
+            sha_network_hashrate: 0,
+            randomx_network_hashrate: 0,
+            block_reward: MicroMinotari(0),
+            block_height: 0,
+            block_time: 0,
+            initial_sync_achieved: false,
+            base_node_state: BaseNodeState::StartUp,
+            failed_checkpoints: false,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq, Eq)]
+pub enum BaseNodeState {
+    StartUp = 0,
+    HeaderSync = 1,
+    HorizonSync = 2,
+    Connecting = 3,
+    BlockSync = 4,
+    Listening = 5,
+    SyncFailed = 6,
+}
+
+impl From<GrpcBaseNodeState> for BaseNodeState {
+    fn from(state: GrpcBaseNodeState) -> Self {
+        match state {
+            GrpcBaseNodeState::StartUp => BaseNodeState::StartUp,
+            GrpcBaseNodeState::HeaderSync => BaseNodeState::HeaderSync,
+            GrpcBaseNodeState::HorizonSync => BaseNodeState::HorizonSync,
+            GrpcBaseNodeState::Connecting => BaseNodeState::Connecting,
+            GrpcBaseNodeState::BlockSync => BaseNodeState::BlockSync,
+            GrpcBaseNodeState::Listening => BaseNodeState::Listening,
+            GrpcBaseNodeState::SyncFailed => BaseNodeState::SyncFailed,
+        }
+    }
+}
+
+impl TryFrom<i32> for BaseNodeState {
+    type Error = MinotariNodeStatusMonitorError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match GrpcBaseNodeState::try_from(value) {
+            Ok(state) => Ok(state.into()),
+            Err(e) => Err(MinotariNodeStatusMonitorError::Conversion(e.to_string())),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -293,37 +349,8 @@ impl MinotariNodeStatusMonitor {
                 .await
                 .map_err(|_| MinotariNodeStatusMonitorError::NodeNotStarted)?;
 
-        let mut reward = 0;
-        // The base node returns a stupid error if the template is out of sync, so try multiple times
-        let max_template_retries = 5;
-
-        for _ in 0..max_template_retries {
-            let res = match client
-                .get_new_block_template(NewBlockTemplateRequest {
-                    algo: Some(PowAlgo { pow_algo: 1 }),
-                    max_weight: 0,
-                })
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!(target: LOG_TARGET, "Failed to get new block template: {}", e);
-                    continue;
-                }
-            };
-            let res = res.into_inner();
-
-            reward = res
-                .miner_data
-                .ok_or_else(|| {
-                    MinotariNodeStatusMonitorError::UnknownError(anyhow!("No miner data found"))
-                })?
-                .reward;
-            break;
-        }
-
         let res = client
-            .get_tip_info(Empty {})
+            .get_network_state(GetNetworkStateRequest {})
             .await
             .map_err(|e| MinotariNodeStatusMonitorError::UnknownError(e.into()))?;
         let res = res.into_inner();
@@ -335,70 +362,17 @@ impl MinotariNodeStatusMonitor {
                 )));
             }
         };
-        let (sync_achieved, block_height, _hash, block_time) = (
-            res.initial_sync_achieved,
-            metadata.best_block_height,
-            metadata.best_block_hash.clone(),
-            metadata.timestamp,
-        );
 
-        // if sync_achieved && (block_height <= self.last_block_height) {
-        //     return Ok((
-        //         self.last_sha3_estimated_hashrate,
-        //         self.last_randomx_estimated_hashrate,
-        //         MicroMinotari(reward),
-        //         block_height,
-        //         block_time,
-        //         sync_achieved,
-        //     ));
-        // }
-
-        // First try with 10 blocks
-        let blocks = [10, 100];
-        let mut result = Err(anyhow::anyhow!("No difficulty found"));
-        for block in &blocks {
-            // Unfortunately have to use 100 blocks to ensure that there are both randomx and sha blocks included
-            // otherwise the hashrate is 0 for one of them.
-            let res = client
-                .get_network_difficulty(HeightRequest {
-                    from_tip: *block,
-                    start_height: 0,
-                    end_height: 0,
-                })
-                .await
-                .map_err(|e| MinotariNodeStatusMonitorError::UnknownError(e.into()))?;
-            let mut res = res.into_inner();
-            // Get the last one.
-            // base node returns 0 for hashrate when the algo doesn't match, so we need to keep track of last one.
-            let mut last_sha3_estimated_hashrate = 0;
-            let mut last_randomx_estimated_hashrate = 0;
-            while let Some(difficulty) = res
-                .message()
-                .await
-                .map_err(|e| MinotariNodeStatusMonitorError::UnknownError(e.into()))?
-            {
-                if difficulty.sha3x_estimated_hash_rate != 0 {
-                    last_sha3_estimated_hashrate = difficulty.sha3x_estimated_hash_rate;
-                }
-                if difficulty.randomx_estimated_hash_rate != 0 {
-                    last_randomx_estimated_hashrate = difficulty.randomx_estimated_hash_rate;
-                }
-
-                result = Ok(BaseNodeStatus {
-                    sha_network_hashrate: last_sha3_estimated_hashrate,
-                    randomx_network_hashrate: last_randomx_estimated_hashrate,
-                    block_reward: MicroMinotari(reward),
-                    block_height,
-                    block_time,
-                    is_synced: sync_achieved,
-                });
-            }
-            if last_randomx_estimated_hashrate != 0 && last_sha3_estimated_hashrate != 0 {
-                break;
-            }
-        }
-
-        Ok(result?)
+        Ok(BaseNodeStatus {
+            sha_network_hashrate: res.sha3x_estimated_hash_rate,
+            randomx_network_hashrate: res.randomx_estimated_hash_rate,
+            block_reward: MicroMinotari(res.reward),
+            block_height: metadata.best_block_height,
+            block_time: metadata.timestamp,
+            initial_sync_achieved: res.initial_sync_achieved,
+            base_node_state: BaseNodeState::try_from(res.base_node_state)?,
+            failed_checkpoints: res.failed_checkpoints,
+        })
     }
 
     pub async fn get_historical_blocks(

--- a/src-tauri/src/node_manager.rs
+++ b/src-tauri/src/node_manager.rs
@@ -245,7 +245,7 @@ impl NodeManager {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("check_if_is_orphan_chain: Node not started"))?;
         let BaseNodeStatus {
-            is_synced,
+            initial_sync_achieved: is_synced,
             block_height: local_tip,
             ..
         } = status_monitor

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -379,7 +379,7 @@ async fn get_telemetry_data(
         randomx_network_hashrate,
         block_reward,
         block_height,
-        is_synced,
+        initial_sync_achieved: is_synced,
         ..
     } = node_latest_status.borrow().clone();
 

--- a/src-tauri/src/tests/app_config_tests.rs
+++ b/src-tauri/src/tests/app_config_tests.rs
@@ -42,13 +42,13 @@ mod tests {
         config.apply_loaded_config(config_json.to_string());
 
         assert_eq!(config.mode(), MiningMode::Eco);
-        assert_eq!(config.p2pool_enabled(), false);
+        assert!(!config.p2pool_enabled());
         assert_ne!(format!("{:?}", config.last_binaries_update_timestamp()), "");
-        assert_eq!(config.allow_telemetry(), false);
+        assert!(!config.allow_telemetry());
         assert_eq!(config.anon_id().len(), 20);
         assert_eq!(config.monero_address(), DEFAULT_MONERO_ADDRESS.to_string());
-        assert_eq!(config.gpu_mining_enabled(), true);
-        assert_eq!(config.cpu_mining_enabled(), true);
+        assert!(config.gpu_mining_enabled());
+        assert!(config.cpu_mining_enabled());
     }
 
     #[test]
@@ -75,16 +75,16 @@ mod tests {
 
         assert_eq!(config.mode(), MiningMode::Ludicrous);
         // For now always false by default
-        assert_eq!(config.p2pool_enabled(), false);
+        assert!(!config.p2pool_enabled());
         let expected_timestamp = SystemTime::UNIX_EPOCH + Duration::new(1725545367, 379078628);
         assert_eq!(config.last_binaries_update_timestamp(), expected_timestamp);
-        assert_eq!(config.allow_telemetry(), true);
+        assert!(config.allow_telemetry());
         assert_eq!(config.anon_id(), "5GGl^0NQiChrGMsjYXs5");
         assert_eq!(
             config.monero_address(),
             "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A"
         );
-        assert_eq!(config.gpu_mining_enabled(), true);
-        assert_eq!(config.cpu_mining_enabled(), true);
+        assert!(config.gpu_mining_enabled());
+        assert!(config.cpu_mining_enabled());
     }
 }


### PR DESCRIPTION
Description
---
Added the new base node gRPC call `get_network_state` to `fn get_network_hash_rate_and_block_reward` that returns all required base node statuses in a single call.

**The new base node gRPC call `get_network_state` came with the new Tari base layer nextnet release, `v1.10.0-rc.0`**

`MinerMetrics` now has additional members

- `initial_sync_achieved` (renamed from `is_synced`, describing the actual status)
- `failed_checkpoints`
- `base_node_state` 

and also provides a method `MinerMetrics::is_synced()` that will return the is-synced status based on the `base_node_state`.

**Notes:** 
- New `MinerMetrics` must be wired into the code where applicable.

Motivation and Context
---
To implement the new more efficient base node gRPC method call

How Has This Been Tested?
---
CI

What process can a PR reviewer use to test or verify this change?
---
Code review

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [X] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other 

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
