### PR TITLE
feat(ui): add react-scan script for react component refresh testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="icon" type="image/svg+xml" href="/tari.svg" />
 
+        <!-- react-scan Debugging -->
+        <!-- <script type="module">
+            if (process.env.NODE_ENV === 'development') {
+                const script = document.createElement('script');
+                script.src = 'https://unpkg.com/react-scan/dist/auto.global.js';
+                document.head.appendChild(script);
+            }
+        </script> -->
+
         <!-- Preload Poppins fonts -->
         <link
             rel="preload"


### PR DESCRIPTION
This PR adds the `react-scan` debugging tool. It's really useful for React component refresh performance testing. 

This script should always be commented out, and only enabled locally when specifically doing performance improvement work. I added an environment check to the script as an extra precaution in case it's ever accidentally bundled to production. 

Here's a video of `react-scan` in action. 

https://www.loom.com/share/3fc3d6485ab34a7cbee6f9bbf6383b93?sid=b83c9b67-bab9-437e-8d69-105eafb65a82