### PR TITLE
chore(ci): add linux arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         include:
           - platform: 'ubuntu-22.04'
             args: ''
+          - platform: 'ubuntu-24.04-arm'
+            args: ''
           - platform: 'windows-latest'
             args: '--bundles msi,updater'
           - platform: 'macos-latest'


### PR DESCRIPTION
Description
Add linux arm64 build

Motivation and Context
Support Raspberry Pi and possible Asahi Linux devices 

How Has This Been Tested?
Only build tested, not yet run on Raspberry Pi or an Asahi Linux device.
