### PR TITLE
fix: missing dependency dialog | add flag to state for missing deps to emit after FE ready

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -213,7 +213,7 @@ async fn setup_inner(
             .await;
 
         if is_missing {
-            *state.missing_dependencies.write().await = external_dependencies;
+            *state.missing_dependencies.write().await = Some(external_dependencies);
             return Ok(());
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1105,7 +1105,6 @@ fn main() {
 
 
                 let missing_bool = *has_missing_dependencies;
-                info!(target: LOG_TARGET, "MISSING {}", missing_bool);
                 if missing_bool {
                     app_handle.clone().emit("missing-applications", missing_bool).expect("Could not emit event 'missing-applications");
                 }

--- a/src/components/AdminUI/groups/DialogsGroup.tsx
+++ b/src/components/AdminUI/groups/DialogsGroup.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable i18next/no-literal-string */
 import { Button, ButtonGroup, CategoryLabel } from '../styles';
-import { useUIStore } from '@app/store/useUIStore';
+import { setShowExternalDependenciesDialog, useUIStore } from '@app/store/useUIStore';
 import { useAppStateStore } from '@app/store/appStateStore';
 
 export function DialogsGroup() {
     const { setCriticalError, criticalError } = useAppStateStore();
     const { setCriticalProblem, criticalProblem } = useAppStateStore();
-    const { setDialogToShow, dialogToShow, showExternalDependenciesDialog, setShowExternalDependenciesDialog } =
-        useUIStore();
+    const { setDialogToShow, dialogToShow, showExternalDependenciesDialog } = useUIStore();
 
     return (
         <>

--- a/src/components/elements/buttons/BaseButton.styles.ts
+++ b/src/components/elements/buttons/BaseButton.styles.ts
@@ -64,7 +64,7 @@ export const StyledButton = styled.button<ButtonStyleProps>`
             default:
                 return css`
                     color: ${$color
-                        ? theme.colors[$color][theme.mode == 'dark' ? 200 : 600]
+                        ? theme?.colors[$color ?? 'primary']?.[theme.mode == 'dark' ? 200 : 600]
                         : convertHexToRGBA(theme.palette.contrast, 0.7)};
                     background-color: ${$disableColour ? 'transparent' : theme.palette.action.background.default};
                     &:hover {

--- a/src/components/elements/buttons/ExtendedButton.styles.ts
+++ b/src/components/elements/buttons/ExtendedButton.styles.ts
@@ -4,7 +4,7 @@ import { ExtendedButtonStyleProps } from '@app/components/elements/buttons/butto
 const PADDING = '1rem';
 
 export const ButtonSquared = styled.button<ExtendedButtonStyleProps>`
-    ${({ theme, $color, $colorIntensity, $size }) => {
+    ${({ theme, $color = 'grey', $colorIntensity, $size }) => {
         return css`
             cursor: pointer;
             display: inline-flex;
@@ -22,14 +22,14 @@ export const ButtonSquared = styled.button<ExtendedButtonStyleProps>`
             height: 36px;
             border-style: solid;
             border-radius: ${theme.shape.borderRadius.buttonSquared};
-            border-color: ${theme.colors[$color][theme.mode === 'dark' ? 950 : 100]};
-            background: ${theme.colors[$color][theme.mode === 'dark' ? 900 : 50]};
-            color: ${theme.colors[$color][$colorIntensity || theme.mode === 'dark' ? 50 : 800]};
+            border-color: ${theme.colors[$color]?.[theme.mode === 'dark' ? 950 : 100]};
+            background: ${theme.colors[$color]?.[theme.mode === 'dark' ? 900 : 50]};
+            color: ${theme.colors[$color]?.[$colorIntensity ?? (theme.mode === 'dark' ? 50 : 800)]};
             font-size: ${$size === 'small' ? '12px' : $size === 'large' ? '16px' : theme.typography.h6.fontSize};
             padding: ${$size === 'small' ? '4px 6px' : $size === 'large' ? `12px ${PADDING}` : `10px ${PADDING}`};
 
             &:hover {
-                background: ${theme.colors[$color][theme.mode === 'dark' ? 950 : 100]};
+                background: ${theme.colors[$color]?.[theme.mode === 'dark' ? 950 : 100]};
             }
             &:active {
                 opacity: 0.9;
@@ -47,7 +47,7 @@ export const ButtonSquared = styled.button<ExtendedButtonStyleProps>`
 export const StyledTextButton = styled.button<ExtendedButtonStyleProps>`
     ${({ theme, $color, $colorIntensity, $size }) => {
         return css`
-            color: ${theme.colors[$color][$colorIntensity ?? (theme.mode == 'dark' ? 200 : 600)]};
+            color: ${theme.colors[$color ?? 'grey']?.[$colorIntensity ?? (theme.mode == 'dark' ? 200 : 600)]};
             font-size: ${$size === 'small' ? '12px' : $size === 'large' ? '16px' : theme.typography.h6.fontSize};
             padding: ${$size === 'small' ? '4px 6px' : $size === 'large' ? `12px ${PADDING}` : `10px ${PADDING}`};
             opacity: 1;

--- a/src/components/elements/buttons/button.types.ts
+++ b/src/components/elements/buttons/button.types.ts
@@ -3,7 +3,7 @@ import { ThemeColourGroup } from '@app/theme/palettes/colors.ts';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'outlined' | 'gradient';
 export type ButtonSize = 'xs' | 'small' | 'medium' | 'large';
-export type ButtonColor = 'transparent' | 'primary' | 'secondary' | 'gradient' | 'error' | 'warning' | 'info';
+export type ButtonColor = 'transparent' | 'primary' | 'secondary' | 'gradient' | 'error' | 'warning' | 'info' | 'grey';
 
 export type IconPosition = 'end' | 'start' | 'hug';
 

--- a/src/containers/floating/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
+++ b/src/containers/floating/ExternalDependenciesDialog/ExternalDependenciesDialog.tsx
@@ -4,7 +4,7 @@ import { Divider } from '@app/components/elements/Divider';
 import { Stack } from '@app/components/elements/Stack';
 import { Typography } from '@app/components/elements/Typography';
 import { useAppStateStore } from '@app/store/appStateStore';
-import { useUIStore } from '@app/store/useUIStore';
+import { setShowExternalDependenciesDialog, useUIStore } from '@app/store/useUIStore';
 import { ExternalDependencyStatus } from '@app/types/app-status';
 import { invoke } from '@tauri-apps/api/core';
 import { useCallback, useState } from 'react';
@@ -14,7 +14,6 @@ import { useTranslation } from 'react-i18next';
 export const ExternalDependenciesDialog = () => {
     const { t } = useTranslation('external-dependency-dialog', { useSuspense: false });
     const showExternalDependenciesDialog = useUIStore((s) => s.showExternalDependenciesDialog);
-    const setShowExternalDependenciesDialog = useUIStore((s) => s.setShowExternalDependenciesDialog);
     const externalDependencies = useAppStateStore((s) => s.externalDependencies);
     const [isRestarting, setIsRestarting] = useState(false);
     const [installationSlot, setInstallationSlot] = useState<number | null>(null);
@@ -43,9 +42,8 @@ export const ExternalDependenciesDialog = () => {
                     </Stack>
 
                     {Object.values(externalDependencies).map((missingDependency, index, array) => (
-                        <>
+                        <Stack key={`dependency:${index}:${missingDependency.display_name}`}>
                             <ExternalDependencyCard
-                                key={missingDependency.display_name}
                                 missingDependency={missingDependency}
                                 freeInstallationSlot={() => setInstallationSlot(null)}
                                 isInInstallationSlot={installationSlot === index}
@@ -53,7 +51,7 @@ export const ExternalDependenciesDialog = () => {
                                 occupyInstallationSlot={() => setInstallationSlot(index)}
                             />
                             {index === array.length - 1 ? null : <Divider />}
-                        </>
+                        </Stack>
                     ))}
                     <Stack direction="row" justifyContent="flex-end" gap={8}>
                         <SquaredButton

--- a/src/hooks/app/useListenForExternalDependencies.ts
+++ b/src/hooks/app/useListenForExternalDependencies.ts
@@ -1,12 +1,10 @@
-import { useAppStateStore } from '@app/store/appStateStore';
-import { useUIStore } from '@app/store/useUIStore';
+import { loadExternalDependencies } from '@app/store/appStateStore';
+import { setShowExternalDependenciesDialog } from '@app/store/useUIStore';
 import { ExternalDependency } from '@app/types/app-status';
 import { listen } from '@tauri-apps/api/event';
 import { useEffect } from 'react';
 
 export function useListenForExternalDependencies() {
-    const loadExternalDependencies = useAppStateStore((s) => s.loadExternalDependencies);
-    const setShowExternalDependenciesDialog = useUIStore((s) => s.setShowExternalDependenciesDialog);
     useEffect(() => {
         const unlistenPromise = listen<ExternalDependency[]>('missing-applications', (event) => {
             const missingDependencies = event.payload;
@@ -17,6 +15,5 @@ export function useListenForExternalDependencies() {
         return () => {
             unlistenPromise.then((unlisten) => unlisten());
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 }

--- a/src/store/appStateStore.ts
+++ b/src/store/appStateStore.ts
@@ -27,7 +27,6 @@ interface Actions {
     setCriticalProblem: (value?: Partial<CriticalProblem>) => void;
     setIsSettingsOpen: (value: boolean) => void;
     fetchExternalDependencies: () => Promise<void>;
-    loadExternalDependencies: (missingExternalDependencies: ExternalDependency[]) => void;
     fetchApplicationsVersions: () => Promise<void>;
     fetchApplicationsVersionsWithRetry: () => Promise<void>;
     updateApplicationsVersions: () => Promise<void>;
@@ -98,7 +97,6 @@ export const useAppStateStore = create<AppState>()((set, getState) => ({
             console.error('Error loading missing external dependencies', error);
         }
     },
-    loadExternalDependencies: (externalDependencies: ExternalDependency[]) => set({ externalDependencies }),
     setIssueReference: (issueReference) => set({ issueReference }),
 }));
 
@@ -114,3 +112,6 @@ export const setSetupComplete = async () => {
     }
     useAppStateStore.setState({ setupComplete: true });
 };
+
+export const loadExternalDependencies = (externalDependencies: ExternalDependency[]) =>
+    useAppStateStore.setState({ externalDependencies });

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -26,7 +26,6 @@ interface Actions {
     setView: (view: State['view']) => void;
     setSidebarOpen: (sidebarOpen: State['sidebarOpen']) => void;
     setShowExperimental: (showExperimental: boolean) => void;
-    setShowExternalDependenciesDialog: (showExternalDependenciesDialog: boolean) => void;
     setDialogToShow: (dialogToShow: State['dialogToShow']) => void;
     setLatestVersion: (latestVersion: string) => void;
     setIsWebglNotSupported: (isWebglNotSupported: boolean) => void;
@@ -56,7 +55,6 @@ export const useUIStore = create<UIStoreState>()((set) => ({
     setView: (view) => set({ view }),
     setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
     setShowExperimental: (showExperimental) => set({ showExperimental }),
-    setShowExternalDependenciesDialog: (showExternalDependenciesDialog) => set({ showExternalDependenciesDialog }),
     setDialogToShow: (dialogToShow) => set({ dialogToShow }),
     setLatestVersion: (latestVersion) => set({ latestVersion }),
     setIsWebglNotSupported: (isWebglNotSupported) => {
@@ -65,3 +63,6 @@ export const useUIStore = create<UIStoreState>()((set) => ({
     },
     setAdminShow: (adminShow) => set({ adminShow }),
 }));
+
+export const setShowExternalDependenciesDialog = (showExternalDependenciesDialog: boolean) =>
+    useUIStore.setState({ showExternalDependenciesDialog });


### PR DESCRIPTION
Description
---

- add flag (`has_missing_dependencies`) to state for missing deps to emit after FE ready
- fix missing key in dialog and button x theme issues

Motivation and Context
---

https://github.com/tari-project/universe/issues/1421
