### PR TITLE
fix(telemetry-service): make app_id the same as in telemetry manager

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -871,11 +871,7 @@ fn main() {
         base_node_watch_rx.clone(),
         p2pool_stats_rx.clone(),
     );
-    let telemetry_service = TelemetryService::new(
-        app_config_raw.anon_id().to_string(),
-        app_config.clone(),
-        app_in_memory_config.clone(),
-    );
+    let telemetry_service = TelemetryService::new(app_config.clone(), app_in_memory_config.clone());
     let updates_manager = UpdatesManager::new(app_config.clone(), shutdown.to_signal());
 
     let feedback = Feedback::new(app_in_memory_config.clone(), app_config.clone());


### PR DESCRIPTION
Description
---
Fixes #1404
Makes field `app_id` have the same value as in the telemetry manager.

Motivation and Context
---
This allows to make more in depth analysis of users bug reports. 

How Has This Been Tested?
---
Added line to print `app_id` just before sending telemetry event in both telemetries and confirmed they are equal.

What process can a PR reviewer use to test or verify this change?
---
Same as above


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
