### PR TITLE
fix: seedword copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
     "name": "tari-universe",
-    "version": "0.8.44",
+    "version": "0.8.45",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "0.8.44",
+            "version": "0.8.45",
             "dependencies": {
                 "@floating-ui/react": "^0.26.28",
                 "@lottiefiles/dotlottie-react": "^0.12.0",
                 "@sentry/react": "^8.48.0",
                 "@tauri-apps/api": "^2.2.0",
+                "@tauri-apps/plugin-clipboard-manager": "^2.2.0",
                 "@tauri-apps/plugin-os": "^2.2.0",
                 "@tauri-apps/plugin-process": "^2.2.0",
                 "@tauri-apps/plugin-shell": "^2.2.0",
@@ -2088,6 +2089,15 @@
             ],
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@tauri-apps/plugin-clipboard-manager": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.2.0.tgz",
+            "integrity": "sha512-sIBrW/HioKq2vqomwwcU/Y8ygAv3DlS32yKPBX5XijCc0IyQKiDxYpGqmvE9DC5Y0lNJ/G53dfS961B31wjJ1g==",
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "@tauri-apps/api": "^2.0.0"
             }
         },
         "node_modules/@tauri-apps/plugin-os": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@lottiefiles/dotlottie-react": "^0.12.0",
         "@sentry/react": "^8.48.0",
         "@tauri-apps/api": "^2.2.0",
+        "@tauri-apps/plugin-clipboard-manager": "^2.2.0",
         "@tauri-apps/plugin-os": "^2.2.0",
         "@tauri-apps/plugin-process": "^2.2.0",
         "@tauri-apps/plugin-shell": "^2.2.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -156,6 +156,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
+dependencies = [
+ "clipboard-win",
+ "core-graphics 0.23.2",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "windows-sys 0.48.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,7 +1078,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "libc",
  "objc",
@@ -1066,7 +1093,7 @@ dependencies = [
  "bitflags 2.7.0",
  "block",
  "core-foundation 0.10.0",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "libc",
  "objc",
 ]
@@ -1164,14 +1191,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.7.0",
  "core-foundation 0.10.0",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1913,6 +1964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
 name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2408,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3122,6 +3189,7 @@ dependencies = [
  "byteorder-lite",
  "num-traits",
  "png",
+ "tiff",
 ]
 
 [[package]]
@@ -3353,6 +3421,12 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -6529,7 +6603,7 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "bytemuck",
  "cfg_aliases 0.2.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -6832,7 +6906,7 @@ dependencies = [
  "bitflags 2.7.0",
  "cocoa",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -6965,6 +7039,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-cli",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-sentry",
@@ -7587,12 +7662,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be2c6f5d82396c1a86d5b16052cc97976a82e92244bf074dd6e2f6272d8619d"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.10",
+]
+
+[[package]]
 name = "tauri-plugin-os"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dda2d571a9baf0664c1f2088db227e3072f9028602fafa885deade7547c3b738"
 dependencies = [
- "gethostname",
+ "gethostname 0.5.0",
  "log",
  "os_info",
  "serde",
@@ -7899,6 +7989,17 @@ checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -8277,7 +8378,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
 dependencies = [
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dirs 5.0.1",
  "libappindicator",
@@ -8837,6 +8938,12 @@ dependencies = [
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "which"
@@ -9487,6 +9594,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+dependencies = [
+ "gethostname 0.4.3",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xattr"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 ring-compat = "0.8.0"
 der = "0.7.9"
 tonic = "0.12.3"
+tauri-plugin-clipboard-manager = "2.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,9 +1,6 @@
 {
     "identifier": "default",
-    "windows": [
-        "main",
-        "splashscreen"
-    ],
+    "windows": ["main", "splashscreen"],
     "permissions": [
         "core:path:default",
         "core:event:default",
@@ -19,6 +16,7 @@
         "shell:allow-open",
         "sentry:default",
         "process:allow-restart",
-        "process:default"
+        "process:default",
+        "clipboard-manager:allow-write-text"
     ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -900,6 +900,7 @@ fn main() {
     };
     let app_state_clone = app_state.clone();
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_sentry::init_with_no_injection(&client))
         .plugin(tauri_plugin_os::init())

--- a/src/containers/floating/PaperWalletModal/sections/QRCodeSection/QRCodeSection.tsx
+++ b/src/containers/floating/PaperWalletModal/sections/QRCodeSection/QRCodeSection.tsx
@@ -1,3 +1,4 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { BlackButton } from '../../styles';
 import {
     ButtonWrapper,
@@ -41,8 +42,7 @@ export default function QRCodeSection({ onDoneClick }: Props) {
     };
 
     const handleCopyClick = () => {
-        navigator.clipboard.writeText(identificationCode);
-        setCopied(true);
+        writeText(identificationCode).then(() => setCopied(true));
     };
 
     useEffect(() => {

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/SeedWordsMarkup.tsx
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/SeedWordsMarkup.tsx
@@ -28,7 +28,7 @@ const SeedWordsMarkup = () => {
         setShowSeedWords((prev) => !prev);
     }, [seedWordsFetched, getSeedWords]);
 
-    const handleCopyClick = useCallback(async () => {
+    const handleCopyClick = useCallback(() => {
         if (seedWordsFetched && seedWords) {
             copyToClipboard(seedWords.join(' '));
         } else {
@@ -42,6 +42,7 @@ const SeedWordsMarkup = () => {
             });
         }
     }, [copyToClipboard, getSeedWords, seedWords, seedWordsFetched]);
+
     const toggleEdit = useCallback(async () => {
         if (!seedWordsFetched) {
             await getSeedWords();
@@ -82,7 +83,7 @@ const SeedWordsMarkup = () => {
                     />
                 ) : null}
                 {showCopy && (
-                    <IconButton size="small" onClick={() => handleCopyClick()}>
+                    <IconButton size="small" onClick={handleCopyClick}>
                         {!isCopied ? (
                             copyFetchLoading ? (
                                 <CircularProgress />

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
@@ -11,7 +11,7 @@ export function useGetSeedWords() {
             const seedWords = await invoke('get_seed_words');
             setSeedWords(seedWords);
 
-            if (seedWords) {
+            if (seedWords.length) {
                 return seedWords;
             }
         } catch (e) {

--- a/src/containers/floating/ShareRewardModal/ShareRewardModal.tsx
+++ b/src/containers/floating/ShareRewardModal/ShareRewardModal.tsx
@@ -1,3 +1,4 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import GreenModal from '@app/components/GreenModal/GreenModal';
 import { AnimatePresence } from 'framer-motion';
 import { useShareRewardStore } from '@app/store/useShareRewardStore';
@@ -59,7 +60,7 @@ export default function ShareRewardModal() {
     const shareUrl = `${airdropUrl}/download/${referralCode}?bh=${block}`;
 
     const handleCopy = () => {
-        navigator.clipboard.writeText(shareUrl);
+        writeText(shareUrl);
         setCopied(true);
     };
 

--- a/src/containers/main/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Invite/Invite.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/sections/LoggedIn/segments/Invite/Invite.tsx
@@ -1,3 +1,4 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { Wrapper, InviteButton, Image, TextWrapper, Title, Text, GemPill, Copied } from './styles';
 import gemImage from '../../../../images/gem.png';
 import { REFERRAL_GEMS, useAirdropStore } from '@app/store/useAirdropStore';
@@ -19,7 +20,7 @@ export default function Invite() {
 
     const handleCopy = () => {
         setCopied(true);
-        navigator.clipboard.writeText(url);
+        writeText(url);
     };
 
     useEffect(() => {

--- a/src/containers/main/ShellOfSecrets/SoSWidget/segments/Friends/Friends.tsx
+++ b/src/containers/main/ShellOfSecrets/SoSWidget/segments/Friends/Friends.tsx
@@ -1,3 +1,4 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import {
     Wrapper,
     FriendsWrapper,
@@ -27,7 +28,7 @@ export default function Friends() {
     const shareLink = 'https://universe.tari.com';
 
     const handleCopy = () => {
-        navigator.clipboard.writeText(shareLink).then(() => {
+        writeText(shareLink).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         });

--- a/src/hooks/helpers/useCopyToClipboard.ts
+++ b/src/hooks/helpers/useCopyToClipboard.ts
@@ -1,3 +1,4 @@
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { useCallback, useEffect, useState } from 'react';
 
 export function useCopyToClipboard() {
@@ -15,8 +16,8 @@ export function useCopyToClipboard() {
     }, [isCopied]);
 
     const copyToClipboard = useCallback((value: string, onCopied?: () => void) => {
-        navigator.clipboard
-            .writeText(value)
+        console.debug(value);
+        writeText(value)
             .then(() => {
                 setIsCopied(true);
                 onCopied?.();

--- a/src/hooks/helpers/useCopyToClipboard.ts
+++ b/src/hooks/helpers/useCopyToClipboard.ts
@@ -16,7 +16,6 @@ export function useCopyToClipboard() {
     }, [isCopied]);
 
     const copyToClipboard = useCallback((value: string, onCopied?: () => void) => {
-        console.debug(value);
         writeText(value)
             .then(() => {
                 setIsCopied(true);


### PR DESCRIPTION
Description
---

- use tauri's clipboard plugin instead of `navigator.clipboard` (there was a permissions error the first time trying with navigator 🤷🏼 )

Motivation and Context
---
#1409 

How Has This Been Tested?
---

locally:

https://github.com/user-attachments/assets/9eb08fac-5656-4a84-935e-8d994305a47c


What process can a PR reviewer use to test or verify this change?
---

- start app
- click copy seed words (before viewing them)
