### PR TITLE
fix(ui): change wording on ludicrous warning modal cancel button

### DIFF
--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -13,6 +13,6 @@
     "description": "Ludicrous mode may make your system unresponsive. Please confirm you want to start mining in Ludicrous mode or Tari Universe will switch back to Eco mode in",
     "seconds": "seconds",
     "keepChanges": "Keep Changes",
-    "revertToEco": "Revert to ECO"
+    "cancel": "Cancel"
   }
 }

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -9,7 +9,7 @@
     "required": "Field required"
   },
   "ludicrousConfirmationDialog": {
-    "title": "Stay in Ludicrous Mode?",
+    "title": "Switch to Ludicrous Mode?",
     "description": "Ludicrous mode may make your system unresponsive. Please confirm you want to start mining in Ludicrous mode or Tari Universe will switch back to Eco mode in",
     "seconds": "seconds",
     "keepChanges": "Keep Changes",

--- a/src/containers/floating/LudicrousCofirmationDialog/LudicrousCofirmationDialog.tsx
+++ b/src/containers/floating/LudicrousCofirmationDialog/LudicrousCofirmationDialog.tsx
@@ -50,9 +50,7 @@ export default function LudicrousCofirmationDialog() {
                         <KeepButton onClick={handleChange}>
                             <span>🔥</span> {t('ludicrousConfirmationDialog.keepChanges')}
                         </KeepButton>
-                        <RevertButton onClick={handleClose}>
-                            {t('ludicrousConfirmationDialog.revertToEco')}
-                        </RevertButton>
+                        <RevertButton onClick={handleClose}>{t('ludicrousConfirmationDialog.cancel')}</RevertButton>
                     </ButtonWrapper>
                 </Wrapper>
             </DialogContent>


### PR DESCRIPTION
The Ludicrous warning modal cancel button used to say "Revert to Eco". That wording was misleading since the user wasn't really "reverting" anything. This change makes the button work for both Eco mode and Custom mode and it acts as a clear "Opt-out" for Ludicrous mode. 

I also changed the title of the modal from "Stay in Ludicrous Mode?" to "Switch to Ludicrous Mode?".

![CleanShot 2025-01-22 at 11 11 35@2x](https://github.com/user-attachments/assets/4603dde5-0a15-4751-9b05-1eed1326cbbf)
