### PR TITLE
chore(ci): add a best effort option, enabled for linux-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ env:
 jobs:
   builds:
     name: Building ${{ matrix.platform }}
+    # best effort disabled by default
+    continue-on-error: ${{ matrix.best_effort || false }}
     permissions:
       contents: write
     strategy:
@@ -35,6 +37,7 @@ jobs:
             args: ''
           - platform: 'ubuntu-24.04-arm'
             args: ''
+            best_effort: true
           - platform: 'windows-latest'
             args: '--bundles msi,updater'
           - platform: 'macos-latest'


### PR DESCRIPTION
Description
Add a best effort option - enabled for linux-arm64

Motivation and Context
Put an option in place, so that less focus builds don't break the release

How Has This Been Tested?
Builds in local fork, have not had linux-arm64 fail (not seen in testing)
