### PR TITLE
fix: first run when denied keychain prompt

### DIFF
--- a/src-tauri/src/credential_manager.rs
+++ b/src-tauri/src/credential_manager.rs
@@ -221,6 +221,11 @@ impl CredentialManager {
 
     fn save_to_file(&self, credential: &Credential) -> Result<(), CredentialError> {
         let serialized = serde_cbor::to_vec(credential)?;
+        if let Some(parent) = self.fallback_file().parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)


### PR DESCRIPTION
Fix: [#1418](https://github.com/tari-project/universe/issues/1418)

Platform: **MacOS**

Description
---
Create parent directory(`com.tari.universe` or `com.tari.universe.alpha`) when doesn't exist yet.

Motivation and Context
---
App panics when user denies keychain prompt on first run(fresh install). It happens because of:
```
failed to open file: Os { Code 2, kind: NotFound, message: "No such file or directory"}
```
file that app wants to open: `/com.tari.universe/credentials_backup.bin`

```
let mut file = OpenOptions::new()
            .write(true)
            .create(true)
            .truncate(true)
            .open(self.fallback_file())?;
file.write_all(&serialized)?;
```
Note from std file docs: `Depending on the platform, this function may fail if the full directory path does not exist.`

What process can a PR reviewer use to test or verify this change?
---
Clear `~/Local/Application Support/com.tari.universe` dir. Deny keychain access when prompted
