### PR TITLE
fix: mining animation sync [DNM]

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -707,7 +707,7 @@ async fn setup_inner(
     let w_move_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = w_move_handle.state::<UniverseAppState>().clone();
-        let mut interval = time::interval(Duration::from_secs(5));
+        let mut interval = time::interval(Duration::from_secs(3));
         let mut shutdown_signal = app_state.shutdown.to_signal();
 
         loop {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -708,7 +708,7 @@ async fn setup_inner(
     let move_handle_block = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = move_handle_block.state::<UniverseAppState>().clone();
-        let mut interval: time::Interval = time::interval(Duration::from_secs(30));
+        let mut interval: time::Interval = time::interval(Duration::from_secs(15));
         let mut shutdown_signal = app_state.shutdown.to_signal();
         loop {
             select! {
@@ -727,7 +727,7 @@ async fn setup_inner(
     let w_move_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = w_move_handle.state::<UniverseAppState>().clone();
-        let mut interval = time::interval(Duration::from_secs(3));
+        let mut interval = time::interval(Duration::from_secs(5));
         let mut shutdown_signal = app_state.shutdown.to_signal();
 
         loop {

--- a/src/containers/main/Dashboard/MiningView/components/Earnings.tsx
+++ b/src/containers/main/Dashboard/MiningView/components/Earnings.tsx
@@ -31,6 +31,7 @@ export default function Earnings() {
     const { t } = useTranslation('mining-view', { useSuspense: false });
 
     const replayItem = useBlockchainVisualisationStore((s) => s.replayItem);
+    const currentItem = useBlockchainVisualisationStore((s) => s.currentItem);
     const earnings = useBlockchainVisualisationStore((s) => s.earnings);
     const recapData = useBlockchainVisualisationStore((s) => s.recapData);
 
@@ -65,11 +66,26 @@ export default function Earnings() {
             </RecapText>
         ) : null;
 
+    const currentText =
+        currentItem?.amount && currentItem.mined_in_block_height ? (
+            <RecapText>
+                <Trans
+                    ns="mining-view"
+                    i18nKey={'you-won-block'}
+                    values={{
+                        blockHeight: currentItem.mined_in_block_height,
+                    }}
+                    components={{ span: <span /> }}
+                />
+            </RecapText>
+        ) : null;
+
     return (
         <EarningsContainer>
             <AnimatePresence mode="wait">
                 {displayEarnings ? (
                     <EarningsWrapper variants={variants} initial="hidden" animate="visible" exit="hidden">
+                        {currentText}
                         {replayText}
                         {recapText}
                         <WinWrapper>

--- a/src/hooks/mining/useBlockInfo.ts
+++ b/src/hooks/mining/useBlockInfo.ts
@@ -12,7 +12,7 @@ export function useBlockInfo() {
     const setDisplayBlockTime = useBlockchainVisualisationStore((s) => s.setDisplayBlockTime);
     const setDebugBlockTime = useBlockchainVisualisationStore((s) => s.setDebugBlockTime);
     const displayBlockHeight = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
-    const block_time = useMiningMetricsStore((s) => s.base_node.block_time);
+    const block_time = useMiningMetricsStore((s) => s.block_time);
 
     const diff = useMemo(() => {
         const now = new Date();

--- a/src/hooks/mining/useMiningMetricsUpdater.ts
+++ b/src/hooks/mining/useMiningMetricsUpdater.ts
@@ -1,20 +1,12 @@
-import { useCallback, useDeferredValue } from 'react';
+import { useCallback } from 'react';
 import { MinerMetrics } from '@app/types/app-status';
-import { handleNewBlock, useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore.ts';
+
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 import { setAnimationState } from '@app/visuals.ts';
-import { refreshCoinbaseTransactions } from '@app/store/useWalletStore.ts';
 
-const TX_CHECK_INTERVAL = 1000 * 10 * 2; // 20s
 export default function useMiningMetricsUpdater() {
     const setMiningMetrics = useMiningMetricsStore((s) => s.setMiningMetrics);
-    const currentBlockHeight = useMiningMetricsStore((s) => s.base_node.block_height);
     const baseNodeConnected = useMiningMetricsStore((s) => s.base_node.is_connected);
-
-    const displayBlockHeight = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
-    const setDisplayBlockHeight = useBlockchainVisualisationStore((s) => s.setDisplayBlockHeight);
-
-    const deferredblock = useDeferredValue(currentBlockHeight);
 
     return useCallback(
         (metrics: MinerMetrics) => {
@@ -30,39 +22,9 @@ export default function useMiningMetricsUpdater() {
                     }
                 }
 
-                const blockHeight = metrics.base_node.block_height;
-                const isNewBlock = blockHeight > 0 && deferredblock > 0 && blockHeight > deferredblock;
-
-                if (!isNewBlock && blockHeight && !displayBlockHeight) {
-                    setMiningMetrics(metrics);
-                    return;
-                }
-
-                if (isNewBlock && !isMining) {
-                    setDisplayBlockHeight(blockHeight);
-                    setMiningMetrics(metrics);
-                    return;
-                }
-
-                if (isNewBlock && isMining) {
-                    const newBlockMiningTimeout = setTimeout(async () => {
-                        try {
-                            const latestTxs = await refreshCoinbaseTransactions();
-                            if (latestTxs?.length) {
-                                console.debug(latestTxs);
-                                await handleNewBlock(blockHeight, latestTxs[0]);
-                            }
-                        } finally {
-                            setMiningMetrics(metrics);
-                        }
-                    }, TX_CHECK_INTERVAL);
-
-                    return () => {
-                        clearTimeout(newBlockMiningTimeout);
-                    };
-                }
+                setMiningMetrics(metrics);
             }
         },
-        [baseNodeConnected, deferredblock, displayBlockHeight, setDisplayBlockHeight, setMiningMetrics]
+        [baseNodeConnected, setMiningMetrics]
     );
 }

--- a/src/hooks/mining/useMiningStatesSync.ts
+++ b/src/hooks/mining/useMiningStatesSync.ts
@@ -48,7 +48,8 @@ export function useMiningStatesSync() {
             const latestTxs = await refreshCoinbaseTransactions();
             handleNewBlock(newBlockHeight, latestTxs?.[0])
                 .then(() => {
-                    console.debug('new block THEN!');
+                    console.debug('new block THEN!', newBlockHeight);
+                    setDisplayBlockHeight(newBlockHeight);
                     prevTip.current = newBlockHeight;
                 })
                 .catch(() => {
@@ -56,7 +57,7 @@ export function useMiningStatesSync() {
                     handleNoAnimation(newBlockHeight, newBlockTime);
                 });
         },
-        [handleNoAnimation]
+        [handleNoAnimation, setDisplayBlockHeight]
     );
 
     useEffect(() => {
@@ -95,10 +96,8 @@ export function useMiningStatesSync() {
         const ul = listen('miner_metrics', ({ payload }: { payload: MinerMetrics }) => {
             const newBlockHeight = payload.base_node.block_height;
             const blockChanged = prevTip.current !== newBlockHeight;
-            console.debug('----');
-            console.debug(`prev | new`, prevTip.current, payload.base_node.block_height);
-            console.debug('----');
             if (!blockChanged) return;
+            console.debug(`prev | new`, prevTip.current, payload.base_node.block_height);
             const newBlockTime = payload.base_node.block_time;
             const isMining = payload.cpu?.mining.is_mining || payload.gpu?.mining.is_mining;
             if (!isMining && newBlockHeight && !displayBlockHeight) {

--- a/src/hooks/mining/useMiningStatesSync.ts
+++ b/src/hooks/mining/useMiningStatesSync.ts
@@ -40,12 +40,12 @@ export function useMiningStatesSync() {
 
     useEffect(() => {
         if (!setupComplete) return;
-        const ul = listen('miner_metrics', async ({ payload }) => {
+        const ul = listen('miner_metrics', ({ payload }) => {
             if (!payload) return;
             const payloadChanged = !deepEqual(payload as MinerMetrics, prevMetricsPayload.current);
             if (payloadChanged) {
                 prevMetricsPayload.current = payload as MinerMetrics;
-                await handleMiningMetrics(payload as MinerMetrics);
+                handleMiningMetrics(payload as MinerMetrics);
             }
         });
         return () => {

--- a/src/hooks/mining/useMiningStatesSync.ts
+++ b/src/hooks/mining/useMiningStatesSync.ts
@@ -1,8 +1,8 @@
 import { MinerMetrics, TariWalletDetails } from '@app/types/app-status';
 import { listen } from '@tauri-apps/api/event';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
-import { useWalletStore } from '@app/store/useWalletStore.ts';
+import { refreshCoinbaseTransactions, useWalletStore } from '@app/store/useWalletStore.ts';
 import { useAppStateStore } from '@app/store/appStateStore';
 
 import { useBlockInfo } from './useBlockInfo.ts';
@@ -11,17 +11,63 @@ import useMiningMetricsUpdater from './useMiningMetricsUpdater.ts';
 import useEarningsRecap from './useEarningsRecap.ts';
 import { deepEqual } from '@app/utils/objectDeepEqual.ts';
 
+import { handleNewBlock, useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore.ts';
+import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+
+const TX_CHECK_INTERVAL = 1000 * 10 * 2; // 20s
+
 export function useMiningStatesSync() {
     const handleMiningMetrics = useMiningMetricsUpdater();
+    const displayBlockHeight = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
+    const setDisplayBlockHeight = useBlockchainVisualisationStore((s) => s.setDisplayBlockHeight);
+    const setBlockHeight = useMiningMetricsStore((s) => s.setBlockHeight);
+    const setBlockTime = useMiningMetricsStore((s) => s.setBlockTime);
     const setWalletDetails = useWalletStore((s) => s.setWalletDetails);
     const setupProgress = useAppStateStore((s) => s.setupProgress);
     const setupComplete = useAppStateStore((s) => s.setupComplete);
     const prevMetricsPayload = useRef<MinerMetrics>();
     const prevWalletPayload = useRef<TariWalletDetails>();
+    const prevTip = useRef<number>();
 
     useBlockInfo();
     useUiMiningStateMachine();
     useEarningsRecap();
+
+    const handleChainTip = useCallback(
+        (metrics: MinerMetrics) => {
+            const isMining = metrics.cpu?.mining.is_mining || metrics.gpu?.mining.is_mining;
+            const newBlockHeight = metrics.base_node.block_height;
+
+            if (!isMining && newBlockHeight && !displayBlockHeight) {
+                setDisplayBlockHeight(newBlockHeight);
+                setBlockHeight(newBlockHeight);
+                setBlockTime(metrics.base_node.block_time);
+                return;
+            }
+
+            if (isMining) {
+                const newBlockMiningTimeout = setTimeout(async () => {
+                    try {
+                        const latestTxs = await refreshCoinbaseTransactions();
+                        if (latestTxs?.length) {
+                            await handleNewBlock(newBlockHeight, latestTxs[0]);
+                        }
+                    } catch (_) {
+                        setDisplayBlockHeight(newBlockHeight);
+                        setBlockHeight(newBlockHeight);
+                        setBlockTime(metrics.base_node.block_time);
+                    } finally {
+                        prevTip.current = newBlockHeight;
+                    }
+                }, TX_CHECK_INTERVAL);
+
+                return () => {
+                    clearTimeout(newBlockMiningTimeout);
+                };
+            }
+        },
+        [displayBlockHeight, setBlockHeight, setBlockTime, setDisplayBlockHeight]
+    );
 
     useEffect(() => {
         if (setupProgress < 0.75) return;
@@ -40,16 +86,21 @@ export function useMiningStatesSync() {
 
     useEffect(() => {
         if (!setupComplete) return;
-        const ul = listen('miner_metrics', ({ payload }) => {
+        const ul = listen('miner_metrics', ({ payload }: { payload: MinerMetrics }) => {
             if (!payload) return;
-            const payloadChanged = !deepEqual(payload as MinerMetrics, prevMetricsPayload.current);
+            const payloadChanged = !deepEqual(payload, prevMetricsPayload.current);
             if (payloadChanged) {
-                prevMetricsPayload.current = payload as MinerMetrics;
-                handleMiningMetrics(payload as MinerMetrics);
+                prevMetricsPayload.current = payload;
+                handleMiningMetrics(payload);
+            }
+
+            const blockChanged = prevTip.current !== payload.base_node.block_height;
+            if (blockChanged) {
+                handleChainTip(payload);
             }
         });
         return () => {
             ul.then((unlisten) => unlisten());
         };
-    }, [setupComplete, handleMiningMetrics]);
+    }, [setupComplete, handleMiningMetrics, handleChainTip]);
 }

--- a/src/hooks/mining/useMiningStatesSync.ts
+++ b/src/hooks/mining/useMiningStatesSync.ts
@@ -105,6 +105,7 @@ export function useMiningStatesSync() {
             const isMining = payload.cpu?.mining.is_mining || payload.gpu?.mining.is_mining;
             const newBlockHeight = payload.base_node.block_height;
             const blockChanged = prevTip.current !== newBlockHeight;
+
             if (!blockChanged || !isMining) return;
             console.debug(`prev | new`, prevTip.current, payload.base_node.block_height);
             const newBlockTime = payload.base_node.block_time;

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -55,7 +55,7 @@ export const useBlockchainVisualisationStore = create<BlockchainVisualisationSto
     setRecapCount: (recapCount) => set({ recapCount }),
 }));
 
-const handleWin = async ({ latestTx, canAnimate }: WinAnimation) => {
+const handleWin = ({ latestTx, canAnimate }: WinAnimation) => {
     const blockHeight = Number(latestTx?.mined_in_block_height);
     const earnings = latestTx.amount;
 
@@ -74,14 +74,14 @@ const handleWin = async ({ latestTx, canAnimate }: WinAnimation) => {
 
         return clearTimeout(winTimeout);
     } else {
-        return useBlockchainVisualisationStore.setState((curr) => ({
+        useBlockchainVisualisationStore.setState((curr) => ({
             recapIds: [...curr.recapIds, latestTx.tx_id],
             displayBlockHeight: blockHeight,
             earnings: undefined,
         }));
     }
 };
-const handleFail = async (blockHeight: number, canAnimate: boolean) => {
+const handleFail = (blockHeight: number, canAnimate: boolean) => {
     if (canAnimate) {
         useMiningStore.getState().setMiningControlsEnabled(false);
         setAnimationState('fail');
@@ -91,7 +91,7 @@ const handleFail = async (blockHeight: number, canAnimate: boolean) => {
         }, 1000);
         return clearTimeout(failTimeout);
     } else {
-        return useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight });
+        useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight });
     }
 };
 
@@ -119,11 +119,10 @@ export const handleNewBlock = async (newBlockHeight: number, latestTx?: Transact
     const documentIsVisible = document?.visibilityState === 'visible' || false;
     const canAnimate = !minimized && documentIsVisible;
     const latestTxBlock = latestTx?.mined_in_block_height;
-    console.debug(`latestTxBlock= `, latestTxBlock);
-    console.debug(`newBlockHeight= `, newBlockHeight);
+    console.debug(`latestTx | new`, latestTxBlock, newBlockHeight);
     if (latestTx && latestTxBlock === newBlockHeight) {
-        await handleWin({ latestTx, canAnimate });
+        handleWin({ latestTx, canAnimate });
     } else {
-        await handleFail(newBlockHeight, canAnimate);
+        handleFail(newBlockHeight, canAnimate);
     }
 };

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -111,21 +111,14 @@ export const handleWinReplay = (txItem: TransactionInfo) => {
         useBlockchainVisualisationStore.setState({ replayItem: undefined });
     }, 1500);
 };
-export const handleNewBlock = async (newBlockHeight: number, isMining?: boolean) => {
-    if (isMining) {
-        const txs = await useWalletStore.getState().refreshCoinbaseTransactions();
-        const minimized = await appWindow?.isMinimized();
-        const documentIsVisible = document?.visibilityState === 'visible' || false;
-        const canAnimate = !minimized && documentIsVisible;
-        const latestTx = txs?.[0];
-        const latestTxBlock = latestTx?.mined_in_block_height;
-
-        if (latestTx && latestTxBlock === newBlockHeight) {
-            await handleWin({ latestTx, canAnimate });
-        } else {
-            await handleFail(newBlockHeight, canAnimate);
-        }
+export const handleNewBlock = async (newBlockHeight: number, latestTx?: TransactionInfo) => {
+    const minimized = await appWindow?.isMinimized();
+    const documentIsVisible = document?.visibilityState === 'visible' || false;
+    const canAnimate = !minimized && documentIsVisible;
+    const latestTxBlock = latestTx?.mined_in_block_height;
+    if (latestTx && latestTxBlock === newBlockHeight) {
+        await handleWin({ latestTx, canAnimate });
     } else {
-        useBlockchainVisualisationStore.setState({ displayBlockHeight: newBlockHeight });
+        await handleFail(newBlockHeight, canAnimate);
     }
 };

--- a/src/store/useMiningMetricsStore.ts
+++ b/src/store/useMiningMetricsStore.ts
@@ -1,13 +1,23 @@
-import { MinerMetrics } from '@app/types/app-status';
+import { BaseNodeStatus, MinerMetrics } from '@app/types/app-status';
 import { create } from './create';
+
+interface BlockInfo {
+    block_height: number;
+    block_time: number;
+}
+type BaseNodeState = Omit<BaseNodeStatus, 'block_height' | 'block_time'> & { block_time?: number };
+type MiningMetricsState = Omit<MinerMetrics, 'base_node'> & { base_node: BaseNodeState } & BlockInfo;
 
 interface Actions {
     setMiningMetrics: (metrics: MinerMetrics) => void;
+    setBlockHeight: (block_height: BlockInfo['block_height']) => void;
+    setBlockTime: (block_time: BlockInfo['block_time']) => void;
 }
+type MiningMetricsStoreState = MiningMetricsState & Actions;
 
-type MiningMetricsStoreState = MinerMetrics & Actions;
-
-const initialState: MinerMetrics = {
+const initialState: MiningMetricsState = {
+    block_height: 0,
+    block_time: 0,
     cpu: {
         hardware: [],
         mining: {
@@ -29,14 +39,15 @@ const initialState: MinerMetrics = {
     sha_network_hash_rate: 0,
     randomx_network_hash_rate: 0,
     base_node: {
-        block_height: 0,
-        block_time: 0,
         is_connected: false,
         connected_peers: [],
+        block_time: 0,
     },
 };
 
 export const useMiningMetricsStore = create<MiningMetricsStoreState>()((set) => ({
     ...initialState,
     setMiningMetrics: (metrics) => set({ ...metrics }),
+    setBlockHeight: (block_height) => set({ block_height }),
+    setBlockTime: (block_time) => set({ block_time }),
 }));

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -102,5 +102,5 @@ export const useWalletStore = create<WalletStoreState>()((set, getState) => ({
 
 export const refreshCoinbaseTransactions = async () => {
     const limit = useWalletStore.getState().coinbase_transactions.length;
-    return useWalletStore.getState().fetchCoinbaseTransactions(false, Math.min(limit, 5), true);
+    return useWalletStore.getState().fetchCoinbaseTransactions(false, Math.max(limit, 5));
 };

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -102,5 +102,5 @@ export const useWalletStore = create<WalletStoreState>()((set, getState) => ({
 
 export const refreshCoinbaseTransactions = async () => {
     const limit = useWalletStore.getState().coinbase_transactions.length;
-    return useWalletStore.getState().fetchCoinbaseTransactions(false, Math.max(limit, 5), true);
+    return useWalletStore.getState().fetchCoinbaseTransactions(false, Math.min(limit, 5), true);
 };


### PR DESCRIPTION
Description
---
- bring down `wallet_details` emit interval to 3s
- split out the metrics state setter, so we can update `block_height` & `block_time` separately
- move new block check logic to where the listeners are so we can use refs on the previous metrics payload
- 


Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
