### PR TITLE
fix(ui): update airdrop login module copy again

### DIFF
--- a/public/locales/en/airdrop.json
+++ b/public/locales/en/airdrop.json
@@ -1,5 +1,4 @@
 {
-  "airdropGame": "Join Airdrop, Invite Friends, Win Gems",
   "bonus-gems-earned": "Bonus gems earned",
   "claimGems": "Claim Gems",
   "claimModalFieldLabel": "Optional",
@@ -32,9 +31,11 @@
   },
   "referral": "Invite a friend",
   "topTooltipText": "Get a Tari Airdrop by collecting gems. The more gems you earn, the larger your airdrop.",
-  "topTooltipTitle": "Join Airdrop, Invite Friends, Win Gems",
+  "topTooltipTitle": "Mine & Invite Friends to Earn Gems",
   "unclaimedGems": "Unclaimed Gems",
   "you-reached-your-giftinh-goal": "You reached your gifting goal!",
   "your-friend-accepted-gift": "One of your friends accepted your gift!",
-  "joinAirdrop": "LOG IN / SIGN UP"
+  "joinAirdrop": "Join Airdrop",
+  "loggedInTitle": "Airdrop Rewards",
+  "loggedOutTitle": "Mine & Invite Friends to Earn Gems"
 }

--- a/src/containers/main/Airdrop/AirdropGiftTracker/AirdropGiftTracker.tsx
+++ b/src/containers/main/Airdrop/AirdropGiftTracker/AirdropGiftTracker.tsx
@@ -20,7 +20,7 @@ export default function AirdropGiftTracker() {
     return (
         <Wrapper layout>
             <TitleWrapper>
-                <Title>{t('airdropGame')}</Title>
+                <Title>{isLoggedIn ? t('loggedInTitle') : t('loggedOutTitle')}</Title>
                 <InfoTooltip title={t('topTooltipTitle')} text={t('topTooltipText')} />
             </TitleWrapper>
 


### PR DESCRIPTION
We received an updated copy deck, just updating the test to reflect the latest approved copy. 

![CleanShot 2025-01-24 at 09 40 58@2x](https://github.com/user-attachments/assets/67d551e0-342e-4a49-94f5-13ca7e1055f2)

![CleanShot 2025-01-24 at 09 42 26@2x](https://github.com/user-attachments/assets/4bffe308-337a-4532-8b45-7523405c5630)
