### PR TITLE
feat: enable p2pool tiers

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -69,6 +69,7 @@ pub struct MaxUsageLevels {
 
 pub enum CpuMinerConnection {
     BuiltInProxy,
+    Benchmark,
 }
 
 #[derive(Debug, Serialize)]

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -28,13 +28,16 @@ use crate::process_watcher::ProcessWatcher;
 use crate::utils::math_utils::estimate_earning;
 use crate::xmrig_adapter::{XmrigAdapter, XmrigNodeConnection};
 use crate::CpuMinerConfig;
-use log::{debug, error, warn};
+use core::hash;
+use log::{debug, error, info, warn};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::ShutdownSignal;
 use tokio::sync::RwLock;
+use tokio::time::{sleep, timeout};
 
 const LOG_TARGET: &str = "tari::universe::cpu_miner";
 const ECO_MODE_CPU_USAGE: u32 = 30;
@@ -76,6 +79,7 @@ impl CpuMiner {
                     port: monero_port,
                 }
             }
+            CpuMinerConnection::Benchmark => XmrigNodeConnection::Benchmark,
         };
         let max_cpu_available = thread::available_parallelism();
         let max_cpu_available = match max_cpu_available {
@@ -123,6 +127,96 @@ impl CpuMiner {
         )
         .await?;
         Ok(())
+    }
+
+    pub async fn start_benchmarking(
+        &mut self,
+        app_shutdown: ShutdownSignal,
+        duration: Duration,
+        base_path: PathBuf,
+        config_path: PathBuf,
+        log_dir: PathBuf,
+    ) -> Result<u64, anyhow::Error> {
+        let mut lock = self.watcher.write().await;
+
+        let xmrig_node_connection = XmrigNodeConnection::Benchmark;
+        let max_cpu_available = thread::available_parallelism();
+        let max_cpu_available = match max_cpu_available {
+            Ok(available_cpus) => {
+                debug!(target:LOG_TARGET, "Available CPUs: {}", available_cpus);
+                u32::try_from(available_cpus.get()).unwrap_or(1)
+            }
+            Err(err) => {
+                error!("Available CPUs: Unknown, error: {}", err);
+                1
+            }
+        };
+
+        // let eco_mode_threads = cpu_miner_config
+        // .eco_mode_cpu_percentage
+        // .unwrap_or((ECO_MODE_CPU_USAGE * max_cpu_available) / 100u32);
+
+        // let cpu_max_percentage = match mode {
+        // MiningMode::Eco => Some(eco_mode_threads),
+        // MiningMode::Custom => {
+        // if custom_cpu_threads.unwrap_or(0) == max_cpu_available {
+        // None
+        // } else {
+        // custom_cpu_threads
+        // }
+        // }
+        // MiningMode::Ludicrous => None,
+        // };
+
+        lock.adapter.node_connection = Some(xmrig_node_connection);
+        lock.adapter.monero_address = Some("44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A".to_string());
+        lock.adapter.cpu_threads = Some(Some(1)); // Ludicrous mode
+        lock.adapter.extra_options = vec![];
+
+        let timeout_duration = duration + Duration::from_secs(10);
+        let res = match timeout(timeout_duration, async move {
+            lock.start(
+                app_shutdown.clone(),
+                base_path.clone(),
+                config_path.clone(),
+                log_dir.clone(),
+                Binaries::Xmrig,
+            )
+            .await?;
+            let status = lock.status_monitor.clone().unwrap();
+            let start_time = Instant::now();
+            let mut max_hashrate = 0f64;
+            loop {
+                if app_shutdown.is_triggered() {
+                    break;
+                }
+                sleep(Duration::from_secs(1)).await;
+                if let Ok(stats) = status.summary().await {
+                    dbg!(&stats);
+                    let hash_rate = stats.hashrate.total[0].unwrap_or_default();
+                    if hash_rate > max_hashrate {
+                        max_hashrate = hash_rate;
+                    }
+                    info!(target: LOG_TARGET, "Xmrig stats available");
+                    dbg!(start_time.elapsed());
+                    dbg!(duration);
+                    if start_time.elapsed() > duration {
+                        break;
+                    }
+                } else {
+                    warn!(target: LOG_TARGET, "Xmrig stats not available yet");
+                }
+            } // wait until we have stats from xmrig, so its started
+            Ok::<u64, anyhow::Error>(max_hashrate as u64)
+        })
+        .await
+        {
+            Ok(res) => Ok(res? * max_cpu_available as u64),
+            Err(_) => return Err(anyhow::anyhow!("Benchmarking timed out")),
+        };
+        let mut lock2 = self.watcher.write().await;
+        lock2.stop().await?;
+        res
     }
 
     pub async fn stop(&mut self) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -593,13 +593,39 @@ async fn setup_inner(
         telemetry_id = "unknown_miner_tari_universe".to_string();
     }
 
+    // Benchmark if needed.
+    progress.set_max(77).await;
+    // let mut cpu_miner_config = state.cpu_miner_config.read().await.clone();
+    // Clear out so we use default.
+    let _unused = telemetry_service
+        .send(
+            "starting-benchmarking".to_string(),
+            json!({
+                "service": "starting_benchmarking",
+                "percentage":75,
+            }),
+        )
+        .await;
+
+    let mut cpu_miner = state.cpu_miner.write().await;
+    let benchmarked_hashrate = cpu_miner
+        .start_benchmarking(
+            state.shutdown.to_signal(),
+            Duration::from_secs(30),
+            data_dir.clone(),
+            config_dir.clone(),
+            log_dir.clone(),
+        )
+        .await?;
+    drop(cpu_miner);
+
     if p2pool_enabled {
         let _unused = telemetry_service
             .send(
                 "starting-p2pool".to_string(),
                 json!({
                     "service": "starting_p2pool",
-                    "percentage":75,
+                    "percentage":77,
                 }),
             )
             .await;
@@ -612,6 +638,7 @@ async fn setup_inner(
         let p2pool_config = P2poolConfig::builder()
             .with_base_node(base_node_grpc)
             .with_stats_server_port(state.config.read().await.p2pool_stats_server_port())
+            .with_cpu_benchmark_hashrate(Some(benchmarked_hashrate))
             .build()?;
 
         state

--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -109,7 +109,13 @@ impl ProcessAdapter for P2poolAdapter {
         let pid_file_name = self.pid_file_name().to_string();
 
         args.push("--squad-prefix".to_string());
-        args.push("default".to_string());
+        let mut squad_prefix = "default";
+        if let Some(benchmark) = config.cpu_benchmark_hashrate {
+            if benchmark < 1000 {
+                squad_prefix = "mini";
+            }
+        }
+        args.push(squad_prefix.to_string());
         args.push("--num-squads".to_string());
         args.push("2".to_string());
         let mut envs = HashMap::new();

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -44,6 +44,7 @@ pub struct P2poolConfig {
     pub grpc_port: u16,
     pub stats_server_port: u16,
     pub base_node_address: String,
+    pub cpu_benchmark_hashrate: Option<u64>,
 }
 
 pub struct P2poolConfigBuilder {
@@ -70,6 +71,14 @@ impl P2poolConfigBuilder {
         self
     }
 
+    pub fn with_cpu_benchmark_hashrate(
+        &mut self,
+        cpu_benchmark_hashrate: Option<u64>,
+    ) -> &mut Self {
+        self.config.cpu_benchmark_hashrate = cpu_benchmark_hashrate;
+        self
+    }
+
     pub fn build(&self) -> Result<P2poolConfig, anyhow::Error> {
         let grpc_port = PortAllocator::new().assign_port_with_fallback();
 
@@ -77,6 +86,7 @@ impl P2poolConfigBuilder {
             grpc_port,
             stats_server_port: self.config.stats_server_port,
             base_node_address: self.config.base_node_address.clone(),
+            cpu_benchmark_hashrate: self.config.cpu_benchmark_hashrate,
         })
     }
 }
@@ -93,6 +103,7 @@ impl Default for P2poolConfig {
             grpc_port: 18145,
             stats_server_port: 19000,
             base_node_address: String::from("http://127.0.0.1:18142"),
+            cpu_benchmark_hashrate: None,
         }
     }
 }

--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -37,6 +37,7 @@ const LOG_TARGET: &str = "tari::universe::xmrig_adapter";
 
 pub enum XmrigNodeConnection {
     LocalMmproxy { host_name: String, port: u16 },
+    Benchmark,
 }
 
 impl XmrigNodeConnection {
@@ -49,6 +50,9 @@ impl XmrigNodeConnection {
                     // "--daemon-poll-interval=10000".to_string(),
                     "--coin=monero".to_string(),
                 ]
+            }
+            XmrigNodeConnection::Benchmark => {
+                vec!["--benchmark=1m".to_string()]
             }
         }
     }
@@ -128,13 +132,9 @@ impl ProcessAdapter for XmrigAdapter {
                 .as_ref()
                 .ok_or(anyhow::anyhow!("Monero address not set"))?
         ));
-        #[allow(clippy::collapsible_match)]
         // don't specify threads for ludicrous mode
-        #[allow(clippy::collapsible_match)]
-        if let Some(cpu_threads) = self.cpu_threads {
-            if let Some(cpu_threads) = cpu_threads {
-                args.push(format!("--threads={}", cpu_threads));
-            }
+        if let Some(Some(cpu_threads)) = self.cpu_threads {
+            args.push(format!("--threads={}", cpu_threads));
         }
         args.push("--verbose".to_string());
         for extra_option in &self.extra_options {


### PR DESCRIPTION
Adds a benchmarking step to setup where it runs xmrig with 1 thread and then multiplies it by the number of threads used in Custom Levels. This is not entirely accurate, but using all threads to get an accurate read makes the app unresponsive.

If the number is less than 1000, it will put the node in a "mini_x" pool instead of the "default_x" pool.