### PR TITLE
fix: app stuck on shutting down

### DIFF
--- a/src/hooks/app/useShuttingDown.ts
+++ b/src/hooks/app/useShuttingDown.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { resetAllStores } from '@app/store/create.ts';
-import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 const appWindow = getCurrentWindow();
 
@@ -8,10 +7,9 @@ export function useShuttingDown() {
     const [isShuttingDown, setIsShuttingDown] = useState(false);
 
     useEffect(() => {
-        const ul = appWindow.onCloseRequested(async (event) => {
+        const ul = appWindow.onCloseRequested(async () => {
             if (!isShuttingDown) {
                 setIsShuttingDown(true);
-                event.preventDefault();
             }
         });
         return () => {
@@ -23,7 +21,6 @@ export function useShuttingDown() {
         if (isShuttingDown) {
             setTimeout(async () => {
                 resetAllStores();
-                await invoke('exit_application');
             }, 250);
         }
     }, [isShuttingDown]);


### PR DESCRIPTION
Description
---
Fixes #1297 
Sometimes app is stuck on shutting down screen. This is caused by deadlock between handling same event on the frontend and backend.


Motivation and Context
---
Fix breaking bug.

How Has This Been Tested?
---
I couldn't recreate this bug - tried reset setting before closing but it's still exit without hanging up.
This implementation didn't caused any issue but it's required to test this PR by someone who can recreate this.

What process can a PR reviewer use to test or verify this change?
---
Close app in various stages and check if anything strange happens.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
