### PR TITLE
fix: use linux-native-sync-persistent for keyring

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1498,6 +1498,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3520,6 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8fe839464d4e4b37d756d7e910063696af79a7e877282cb1825e4ec5f10833"
 dependencies = [
  "byteorder",
+ "dbus-secret-service",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
@@ -3575,6 +3600,15 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "liblmdb-sys"
@@ -4291,12 +4325,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -4333,6 +4390,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,12 +29,12 @@ futures-lite = "2.3.0"
 futures-util = "0.3.30"
 jsonwebtoken = "9.3.0"
 keyring = { version = "3.0.5", features = [
-    "windows-native",
-    "apple-native",
-    "linux-native-sync-persistent",
+  "windows-native",
+  "apple-native",
+  "linux-native-sync-persistent",
 ] }
 libsqlite3-sys = { version = "0.25.1", features = [
-    "bundled",
+  "bundled",
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
@@ -61,7 +61,7 @@ tar = "0.4.26"
 tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0", features = [
-    "transactions",
+  "transactions",
 ] }
 tauri-plugin-single-instance = '2'
 tari_crypto = "0.21.0"
@@ -69,13 +69,13 @@ tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
-    "protocol-asset",
-    "isolation",
-    "macos-private-api",
-    "image-png",
-    "image-ico",
-    "tray-icon",
-    "devtools",          # TODO: Remove this before mainnet
+  "protocol-asset",
+  "isolation",
+  "macos-private-api",
+  "image-png",
+  "image-ico",
+  "tray-icon",
+  "devtools",          # TODO: Remove this before mainnet
 ] }
 tauri-plugin-cli = "2"
 tauri-plugin-os = "2"
@@ -123,18 +123,18 @@ airdrop-env = []
 telemetry-env = []
 airdrop-local = []
 custom-protocol = [
-    "tauri/custom-protocol",
+  "tauri/custom-protocol",
 ] # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 release-ci = ["tauri/custom-protocol"]
 release-ci-beta = ["tauri/custom-protocol"]
 
 [package.metadata.cargo-machete]
 ignored = [
-    "device_query",
-    "libsqlite3-sys",
-    "minotari_wallet_grpc_client",
-    "xz2",
-    "openssl",
+  "device_query",
+  "libsqlite3-sys",
+  "minotari_wallet_grpc_client",
+  "xz2",
+  "openssl",
 ]
 
 [profile.release]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,12 +29,12 @@ futures-lite = "2.3.0"
 futures-util = "0.3.30"
 jsonwebtoken = "9.3.0"
 keyring = { version = "3.0.5", features = [
-  "windows-native",
-  "apple-native",
-  "linux-native",
+    "windows-native",
+    "apple-native",
+    "linux-native-sync-persistent",
 ] }
 libsqlite3-sys = { version = "0.25.1", features = [
-  "bundled",
+    "bundled",
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
@@ -61,7 +61,7 @@ tar = "0.4.26"
 tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0", features = [
-  "transactions",
+    "transactions",
 ] }
 tauri-plugin-single-instance = '2'
 tari_crypto = "0.21.0"
@@ -69,13 +69,13 @@ tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v1
 tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.11.0-pre.0" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
-  "protocol-asset",
-  "isolation",
-  "macos-private-api",
-  "image-png",
-  "image-ico",
-  "tray-icon",
-  "devtools",          # TODO: Remove this before mainnet
+    "protocol-asset",
+    "isolation",
+    "macos-private-api",
+    "image-png",
+    "image-ico",
+    "tray-icon",
+    "devtools",          # TODO: Remove this before mainnet
 ] }
 tauri-plugin-cli = "2"
 tauri-plugin-os = "2"
@@ -123,18 +123,18 @@ airdrop-env = []
 telemetry-env = []
 airdrop-local = []
 custom-protocol = [
-  "tauri/custom-protocol",
+    "tauri/custom-protocol",
 ] # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 release-ci = ["tauri/custom-protocol"]
 release-ci-beta = ["tauri/custom-protocol"]
 
 [package.metadata.cargo-machete]
 ignored = [
-  "device_query",
-  "libsqlite3-sys",
-  "minotari_wallet_grpc_client",
-  "xz2",
-  "openssl",
+    "device_query",
+    "libsqlite3-sys",
+    "minotari_wallet_grpc_client",
+    "xz2",
+    "openssl",
 ]
 
 [profile.release]


### PR DESCRIPTION
Solves: [#1347](https://github.com/tari-project/universe/issues/1347)

Platform
---
**LINUX ONLY**

Description
---
Utilize `linux-native-sync-persistent` to ensure that storage remains intact between shutdowns.

Motivation and Context
---
Seed words were inaccessible after shutting down the Linux machine. The `linux-native` feature does not offer persistent storage, resulting in storage loss upon shutdown.

What process can a PR reviewer use to test or verify this change?
---
LINUX: Restart the machine and check if the seed words are accessible