### PR TITLE
chore(ci): split out slower rpm packaging into separate jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   builds:
-    name: Building ${{ matrix.platform }}
+    name: Building ${{ matrix.platform }}${{ matrix.extra }}
     # best effort disabled by default
     continue-on-error: ${{ matrix.best_effort || false }}
     permissions:
@@ -34,9 +34,18 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-22.04'
-            args: ''
+            args: '--bundles deb,appimage,updater'
+            extra: '-x64'
           - platform: 'ubuntu-24.04-arm'
-            args: ''
+            args: '--bundles deb,appimage,updater'
+            best_effort: true
+          - platform: 'ubuntu-22.04'
+            args: '--bundles rpm'
+            extra: '-x64-rpm'
+            best_effort: true
+          - platform: 'ubuntu-24.04-arm'
+            args: '--bundles rpm'
+            extra: '-rpm'
             best_effort: true
           - platform: 'windows-latest'
             args: '--bundles msi,updater'


### PR DESCRIPTION
Description
Split out slower rpm packaging into separate jobs

Motivation and Context
Have other Linux package build and usable quicker for testing.

How Has This Been Tested?
Builds in local fork


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated build process to support additional Linux package formats, offering improved compatibility.
  - Expanded configuration settings for cross-platform builds, ensuring a more resilient and robust build pipeline.
  - Updated environment configurations to accommodate a broader set of beta features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->