### PR TITLE
perf: lower xmrig retry time from 5 to 1 seconds

### DIFF
--- a/src-tauri/src/xmrig_adapter.rs
+++ b/src-tauri/src/xmrig_adapter.rs
@@ -49,6 +49,8 @@ impl XmrigNodeConnection {
                     format!("--url={}:{}", host_name, port),
                     // "--daemon-poll-interval=10000".to_string(),
                     "--coin=monero".to_string(),
+                    // We are using a local daemon, so retry as soon as possible
+                    "--retry-pause=1".to_string(),
                 ]
             }
             XmrigNodeConnection::Benchmark => {


### PR DESCRIPTION
let the rabbit tell you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced local connection handling now includes a brief 1-second pause before retrying, improving stability when establishing local node connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->