### PR TITLE
chore: user friendly error message for deadlocks

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1430,7 +1430,7 @@ pub async fn start_mining<'r>(
             let err_msg = format!("Failed to acquire config read lock: {}", e);
             error!(target: LOG_TARGET, "{}", err_msg);
             sentry::capture_message(&err_msg, sentry::Level::Error);
-            return Err(e.to_string());
+            return Err("Initializing error, please try again".to_string());
         }
     };
 
@@ -1450,7 +1450,7 @@ pub async fn start_mining<'r>(
                 let err_msg = format!("Failed to acquire cpu_miner read lock: {}", e);
                 error!(target: LOG_TARGET, "{}", err_msg);
                 sentry::capture_message(&err_msg, sentry::Level::Error);
-                return Err(e.to_string());
+                return Err("Initializing error, please try again".to_string());
             }
         };
         cpu_miner.is_running().await
@@ -1463,7 +1463,7 @@ pub async fn start_mining<'r>(
                 let err_msg = format!("Failed to acquire gpu_miner read lock: {}", e);
                 error!(target: LOG_TARGET, "{}", err_msg);
                 sentry::capture_message(&err_msg, sentry::Level::Error);
-                return Err(e.to_string());
+                return Err("Initializing error, please try again".to_string());
             }
         };
         gpu_miner.is_running().await
@@ -1482,7 +1482,7 @@ pub async fn start_mining<'r>(
             let err_msg = format!("Failed to acquire cpu_miner_config read lock: {}", e);
             error!(target: LOG_TARGET, "{}", err_msg);
             sentry::capture_message(&err_msg, sentry::Level::Error);
-            return Err(e.to_string());
+            return Err("Initializing error, please try again".to_string());
         }
     };
     let tari_address = cpu_miner_config.tari_address.clone();
@@ -1501,7 +1501,7 @@ pub async fn start_mining<'r>(
                     let err_msg = format!("Failed to acquire cpu_miner write lock: {}", e);
                     error!(target: LOG_TARGET, "{}", err_msg);
                     sentry::capture_message(&err_msg, sentry::Level::Error);
-                    return Err(e.to_string());
+                    return Err("Initializing error, please try again".to_string());
                 }
             };
 
@@ -1546,7 +1546,7 @@ pub async fn start_mining<'r>(
             let err_msg = format!("Failed to acquire gpu_miner read lock: {}", e);
             error!(target: LOG_TARGET, "{}", err_msg);
             sentry::capture_message(&err_msg, sentry::Level::Error);
-            return Err(e.to_string());
+            return Err("Initializing error, please try again".to_string());
         }
     };
 
@@ -1582,7 +1582,7 @@ pub async fn start_mining<'r>(
                 let err_msg = format!("Failed to acquire gpu_miner write lock: {}", e);
                 error!(target: LOG_TARGET, "{}", err_msg);
                 sentry::capture_message(&err_msg, sentry::Level::Error);
-                return Err(e.to_string());
+                return Err("Initializing error, please try again".to_string());
             }
         };
 
@@ -1619,7 +1619,7 @@ pub async fn start_mining<'r>(
                     );
                     error!(target: LOG_TARGET, "{}", lock_err_msg);
                     sentry::capture_message(&lock_err_msg, sentry::Level::Error);
-                    return Err(e.to_string());
+                    return Err("Initializing error, please try again".to_string());
                 }
             };
 
@@ -1627,7 +1627,7 @@ pub async fn start_mining<'r>(
                 error!(target: LOG_TARGET, "Could not stop GPU miner: {}", stop_err);
             }
 
-            return Err(e.to_string());
+            return Err("Initializing error, please try again".to_string());
         }
     }
     if timer.elapsed() > MAX_ACCEPTABLE_COMMAND_TIME {


### PR DESCRIPTION
Description
---
Change error messaging to be more user friendly

Testing
---
Really difficult to reproduce this manually. Deadlock sometimes happen when starting the mining process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messaging during mining initialization. Users will now consistently see a clear notification—"Initializing error, please try again"—for any startup issues, ensuring a more uniform and user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->