### PR TITLE
refactor: remove rwlock from eventmanager

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -173,7 +173,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
     tauri::async_runtime::spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
 
-        &app_state
+        let _ = &app_state
             .events_manager
             .handle_internal_wallet_loaded_or_created(&move_app)
             .await;
@@ -186,7 +186,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                 vec![]
             }
         };
-        &app_state
+        let _ = &app_state
             .events_manager
             .handle_gpu_devices_update(&move_app, gpu_devices)
             .await;
@@ -201,7 +201,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
         let mut shutdown_signal = app_state.shutdown.to_signal();
 
         let current_block_height = node_status_watch_rx.borrow().block_height;
-        &app_state
+        let _ = &app_state
             .events_manager
             .wait_for_initial_wallet_scan(&move_app, current_block_height)
             .await;
@@ -214,10 +214,10 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                     if node_status.block_height > latest_updated_block_height {
                         while latest_updated_block_height < node_status.block_height {
                             latest_updated_block_height += 1;
-                            &app_state.events_manager.handle_new_block_height(&move_app, latest_updated_block_height).await;
+                            let _ = &app_state.events_manager.handle_new_block_height(&move_app, latest_updated_block_height).await;
                         }
                     } else {
-                        &app_state.events_manager.handle_base_node_update(&move_app, node_status.clone()).await;
+                        let _ = &app_state.events_manager.handle_base_node_update(&move_app, node_status.clone()).await;
                     }
                 },
                 _ = gpu_status_watch_rx.changed() => {
@@ -238,7 +238,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                         .status(node_status.sha_network_hashrate, node_status.block_reward, gpu_status.clone())
                         .await
                     {
-                        &app_state.events_manager.handle_gpu_mining_update(&move_app, gpu_status).await;
+                        let _ = &app_state.events_manager.handle_gpu_mining_update(&move_app, gpu_status).await;
                     } else {
                         let err_msg = "Error getting gpu miner status";
                         error!(target: LOG_TARGET, "{}", err_msg);
@@ -247,7 +247,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                 },
                 _ = cpu_miner_status_watch_rx.changed() => {
                     let cpu_status = cpu_miner_status_watch_rx.borrow().clone();
-                    &app_state.events_manager.handle_cpu_mining_update(&move_app, cpu_status.clone()).await;
+                    let _ = &app_state.events_manager.handle_cpu_mining_update(&move_app, cpu_status.clone()).await;
 
                     // Update systemtray data
                     let gpu_status: GpuMinerStatus = gpu_status_watch_rx.borrow().clone();
@@ -289,7 +289,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                         .node_manager
                         .list_connected_peers()
                         .await {
-                                    &app_state.events_manager.handle_connected_peers_update(&move_app, connected_peers).await;
+                            let _ = &app_state.events_manager.handle_connected_peers_update(&move_app, connected_peers).await;
                         } else {
                             let err_msg = "Error getting connected peers";
                             error!(target: LOG_TARGET, "{}", err_msg);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -172,17 +172,9 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
     let move_app = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
-        let events_manager = match try_read_with_retry(&app_state.events_manager, 3).await {
-            Ok(em) => em,
-            Err(e) => {
-                let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                error!(target: LOG_TARGET, "{}", err_msg);
-                sentry::capture_message(&err_msg, sentry::Level::Error);
-                return;
-            }
-        };
 
-        events_manager
+        &app_state
+            .events_manager
             .handle_internal_wallet_loaded_or_created(&move_app)
             .await;
         let gpu_devices = match HardwareStatusMonitor::current().get_gpu_devices().await {
@@ -194,7 +186,8 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                 vec![]
             }
         };
-        events_manager
+        &app_state
+            .events_manager
             .handle_gpu_devices_update(&move_app, gpu_devices)
             .await;
     });
@@ -202,22 +195,14 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
     let move_app = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
-        let events_manager = match try_read_with_retry(&app_state.events_manager, 3).await {
-            Ok(em) => em,
-            Err(e) => {
-                let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                error!(target: LOG_TARGET, "{}", err_msg);
-                sentry::capture_message(&err_msg, sentry::Level::Error);
-                return;
-            }
-        };
         let mut node_status_watch_rx = (*app_state.node_status_watch_rx).clone();
         let mut gpu_status_watch_rx = (*app_state.gpu_latest_status).clone();
         let mut cpu_miner_status_watch_rx = (*app_state.cpu_miner_status_watch_rx).clone();
         let mut shutdown_signal = app_state.shutdown.to_signal();
 
         let current_block_height = node_status_watch_rx.borrow().block_height;
-        events_manager
+        &app_state
+            .events_manager
             .wait_for_initial_wallet_scan(&move_app, current_block_height)
             .await;
 
@@ -229,29 +214,10 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                     if node_status.block_height > latest_updated_block_height {
                         while latest_updated_block_height < node_status.block_height {
                             latest_updated_block_height += 1;
-                            match try_read_with_retry(&app_state.events_manager, 3).await {
-                                Ok(em) => {
-                                    em.handle_new_block_height(&move_app, latest_updated_block_height).await;
-                                },
-                                Err(e) => {
-                                    let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                                    error!(target: LOG_TARGET, "{}", err_msg);
-                                    sentry::capture_message(&err_msg, sentry::Level::Error);
-                                    continue;
-                                }
-                            }
+                            &app_state.events_manager.handle_new_block_height(&move_app, latest_updated_block_height).await;
                         }
                     } else {
-                        match try_read_with_retry(&app_state.events_manager, 3).await {
-                            Ok(em) => {
-                                em.handle_base_node_update(&move_app, node_status.clone()).await;
-                            },
-                            Err(e) => {
-                                let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                                error!(target: LOG_TARGET, "{}", err_msg);
-                                sentry::capture_message(&err_msg, sentry::Level::Error);
-                            }
-                        }
+                        &app_state.events_manager.handle_base_node_update(&move_app, node_status.clone()).await;
                     }
                 },
                 _ = gpu_status_watch_rx.changed() => {
@@ -272,16 +238,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                         .status(node_status.sha_network_hashrate, node_status.block_reward, gpu_status.clone())
                         .await
                     {
-                        match try_read_with_retry(&app_state.events_manager, 3).await {
-                            Ok(em) => {
-                                em.handle_gpu_mining_update(&move_app, gpu_status).await;
-                            },
-                            Err(e) => {
-                                let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                                error!(target: LOG_TARGET, "{}", err_msg);
-                                sentry::capture_message(&err_msg, sentry::Level::Error);
-                            }
-                        }
+                        &app_state.events_manager.handle_gpu_mining_update(&move_app, gpu_status).await;
                     } else {
                         let err_msg = "Error getting gpu miner status";
                         error!(target: LOG_TARGET, "{}", err_msg);
@@ -290,18 +247,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                 },
                 _ = cpu_miner_status_watch_rx.changed() => {
                     let cpu_status = cpu_miner_status_watch_rx.borrow().clone();
-
-                    match try_read_with_retry(&app_state.events_manager, 3).await {
-                        Ok(em) => {
-                            em.handle_cpu_mining_update(&move_app, cpu_status.clone()).await;
-                        },
-                        Err(e) => {
-                            let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                            error!(target: LOG_TARGET, "{}", err_msg);
-                            sentry::capture_message(&err_msg, sentry::Level::Error);
-                            continue;
-                        }
-                    }
+                    &app_state.events_manager.handle_cpu_mining_update(&move_app, cpu_status.clone()).await;
 
                     // Update systemtray data
                     let gpu_status: GpuMinerStatus = gpu_status_watch_rx.borrow().clone();
@@ -343,16 +289,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                         .node_manager
                         .list_connected_peers()
                         .await {
-                            match try_read_with_retry(&app_state.events_manager, 3).await {
-                                Ok(em) => {
-                                    em.handle_connected_peers_update(&move_app, connected_peers).await;
-                                },
-                                Err(e) => {
-                                    let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
-                                    error!(target: LOG_TARGET, "{}", err_msg);
-                                    sentry::capture_message(&err_msg, sentry::Level::Error);
-                                }
-                            }
+                                    &app_state.events_manager.handle_connected_peers_update(&move_app, connected_peers).await;
                         } else {
                             let err_msg = "Error getting connected peers";
                             error!(target: LOG_TARGET, "{}", err_msg);
@@ -999,7 +936,7 @@ struct UniverseAppState {
     updates_manager: UpdatesManager,
     cached_p2pool_connections: Arc<RwLock<Option<Option<Connections>>>>,
     systemtray_manager: Arc<RwLock<SystemTrayManager>>,
-    events_manager: Arc<RwLock<EventsManager>>,
+    events_manager: Arc<EventsManager>,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -1124,7 +1061,7 @@ fn main() {
         updates_manager,
         cached_p2pool_connections: Arc::new(RwLock::new(None)),
         systemtray_manager: Arc::new(RwLock::new(SystemTrayManager::new())),
-        events_manager: Arc::new(RwLock::new(EventsManager::new(wallet_state_watch_rx))),
+        events_manager: Arc::new(EventsManager::new(wallet_state_watch_rx)),
     };
     let app_state_clone = app_state.clone();
     let app = tauri::Builder::default()


### PR DESCRIPTION
Description
---
EventManager has no mutable values on itself. It fires off events to the front end. I don't think we need to make any effort to lock it. It can be used pretty freely.

Motivation and Context
---
Removing overhead or complexity.

How Has This Been Tested?
---
Manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined event management by removing redundant error handling, resulting in a more direct processing flow.
  - Updated the internal structure to simplify how events and related updates are handled, ensuring improved operational consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->