### PR TITLE
chore: improve deadlocks detection

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -172,7 +172,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
     let move_app = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
-        let events_manager = match try_read_with_retry(&app_state.events_manager, 3).await {
+        let events_manager = match try_read_with_retry(&app_state.events_manager, 6).await {
             Ok(em) => em,
             Err(e) => {
                 let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
@@ -202,7 +202,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
     let move_app = app.clone();
     tauri::async_runtime::spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
-        let events_manager = match try_read_with_retry(&app_state.events_manager, 3).await {
+        let events_manager = match try_read_with_retry(&app_state.events_manager, 6).await {
             Ok(em) => em,
             Err(e) => {
                 let err_msg = format!("Failed to acquire events_manager read lock: {}", e);
@@ -229,7 +229,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                     if node_status.block_height > latest_updated_block_height {
                         while latest_updated_block_height < node_status.block_height {
                             latest_updated_block_height += 1;
-                            match try_read_with_retry(&app_state.events_manager, 3).await {
+                            match try_read_with_retry(&app_state.events_manager, 6).await {
                                 Ok(em) => {
                                     em.handle_new_block_height(&move_app, latest_updated_block_height).await;
                                 },
@@ -242,7 +242,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                             }
                         }
                     } else {
-                        match try_read_with_retry(&app_state.events_manager, 3).await {
+                        match try_read_with_retry(&app_state.events_manager, 6).await {
                             Ok(em) => {
                                 em.handle_base_node_update(&move_app, node_status.clone()).await;
                             },
@@ -258,7 +258,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                     let gpu_status: GpuMinerStatus = gpu_status_watch_rx.borrow().clone();
                     let node_status: BaseNodeStatus = node_status_watch_rx.borrow().clone();
 
-                    let gpu_miner = match try_read_with_retry(&app_state.gpu_miner, 3).await {
+                    let gpu_miner = match try_read_with_retry(&app_state.gpu_miner, 6).await {
                         Ok(gm) => gm,
                         Err(e) => {
                             let err_msg = format!("Failed to acquire gpu_miner read lock: {}", e);
@@ -272,7 +272,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                         .status(node_status.sha_network_hashrate, node_status.block_reward, gpu_status.clone())
                         .await
                     {
-                        match try_read_with_retry(&app_state.events_manager, 3).await {
+                        match try_read_with_retry(&app_state.events_manager, 6).await {
                             Ok(em) => {
                                 em.handle_gpu_mining_update(&move_app, gpu_status).await;
                             },
@@ -291,7 +291,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                 _ = cpu_miner_status_watch_rx.changed() => {
                     let cpu_status = cpu_miner_status_watch_rx.borrow().clone();
 
-                    match try_read_with_retry(&app_state.events_manager, 3).await {
+                    match try_read_with_retry(&app_state.events_manager, 6).await {
                         Ok(em) => {
                             em.handle_cpu_mining_update(&move_app, cpu_status.clone()).await;
                         },
@@ -312,7 +312,7 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
                             + gpu_status.estimated_earnings) as f64,
                     };
 
-                    match try_write_with_retry(&app_state.systemtray_manager, 3).await {
+                    match try_write_with_retry(&app_state.systemtray_manager, 6).await {
                         Ok(mut sm) => {
                             sm.update_tray(systray_data);
                         },

--- a/src-tauri/src/utils/locks_utils.rs
+++ b/src-tauri/src/utils/locks_utils.rs
@@ -27,7 +27,7 @@ use tokio::{
     time::sleep,
 };
 
-const LOCK_RETRY_DELAY: Duration = Duration::from_millis(100);
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 pub async fn try_read_with_retry<T>(
     lock: &RwLock<T>,


### PR DESCRIPTION
This pull request includes several changes to improve the efficiency and reliability of the mining process in the `src-tauri/src/commands.rs` file, as well as adjustments to lock retry mechanisms in `src-tauri/src/main.rs` and `src-tauri/src/utils/locks_utils.rs`. The most important changes include removing the use of retry mechanisms for read and write locks, simplifying the mining start process, and increasing the lock retry delay.

Improvements to mining process:

* [`src-tauri/src/commands.rs`](diffhunk://#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dccL1401-R1400): Removed the use of `try_read_with_retry` and `try_write_with_retry` for acquiring read and write locks for `start_mining` and `stop_mining`, replacing them with direct `read().await` and `write().await` calls. 

Adjustments to lock retry mechanisms:

* [`src-tauri/src/main.rs`](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L175-R175): Increased the retry count for acquiring locks from 3 to 6 in the `initialize_frontend_updates` function to improve the reliability of lock acquisition. [[1]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L175-R175) [[2]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L205-R205) [[3]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L232-R232) [[4]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L245-R245) [[5]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L261-R261) [[6]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L275-R275) [[7]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L294-R294) [[8]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L315-R315)
* [`src-tauri/src/utils/locks_utils.rs`](diffhunk://#diff-a87f5f05db1d221f9aa3c9745252ae59daef1efe2df59fd001fd7e43d4b37f31L30-R30): Increased the lock retry delay from 100 milliseconds to 500 milliseconds to provide more time between retry attempts, potentially reducing contention issues.

These changes aim to streamline the mining process and improve the overall stability and performance of the application.