### PR TITLE
fix: missing update dialog when auto update disabled

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -208,6 +208,14 @@ pub async fn frontend_ready(app: tauri::AppHandle) {
             .emit("app_ready", setup_complete_value)
             .expect("Could not emit event 'app_ready'");
 
+        if let Err(e) = state
+            .updates_manager
+            .init_periodic_updates(app.clone())
+            .await
+        {
+            error!(target: LOG_TARGET, "Failed to init periodic updates: {}", e);
+        }
+
         let has_missing = missing_dependencies.is_some();
         let external_dependencies = missing_dependencies.clone();
         if has_missing {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -338,11 +338,6 @@ async fn setup_inner(
         return Ok(());
     }
 
-    state
-        .updates_manager
-        .init_periodic_updates(app.clone())
-        .await?;
-
     let data_dir = app
         .path()
         .app_local_data_dir()


### PR DESCRIPTION
#1546

Description
---
When `auto_update` is disabled, the update dialog did not appear during the initial app launch. This issue arose because the `AutoUpdateDialog` was setting up listeners for the `updates_event `after the event had already been emitted from the backend.

**Solution**: I resolved this issue by moving the `initialize_periodic_updates` function to the `frontend_ready` command. This change ensures that the frontend is already prepared to handle the event appropriately.

Testing
---
Run the app when newer version is available and `auto_update` is disabled. You should see the update dialog:
![image](https://github.com/user-attachments/assets/0aebfc05-ea58-4272-94ee-6a499e10ad25)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release refines how the app manages updates for a smoother experience. Key changes include:

- **Refactor**
  - Enhanced the update process with improved error feedback to better inform users if issues arise.
  
- **Chores**
  - Removed the automatic background update checks at startup, streamlining the launch process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->