### PR TITLE
fix: exclude gpu devices while mining

### DIFF
--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -19,14 +19,9 @@ import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 const GpuDevices = () => {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const miningAllowed = useAppStateStore((s) => s.setupComplete);
-    const isCPUMining = useMiningMetricsStore((s) => s.cpu_mining_status.is_mining);
-    const isGPUMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
     const gpuDevices = useMiningMetricsStore((s) => s.gpu_devices);
 
-    const miningInitiated = useMiningStore((s) => s.miningInitiated);
     const isGpuMiningEnabled = useAppConfigStore((s) => s.gpu_mining_enabled);
-    const isMiningInProgress = isCPUMining || isGPUMining;
-    const isDisabled = isMiningInProgress || miningInitiated || !miningAllowed || !isGpuMiningEnabled;
     const excludedDevices = useMiningStore((s) => s.excludedGpuDevices);
     const setExcludedDevice = useMiningStore((s) => s.setExcludedGpuDevice);
 
@@ -69,8 +64,8 @@ const GpuDevices = () => {
                                     </Typography>
                                     <ToggleSwitch
                                         key={device.name}
-                                        checked={!excludedDevices.includes(i) && isGpuMiningEnabled}
-                                        disabled={isDisabled}
+                                        checked={!excludedDevices.includes(i)}
+                                        disabled={!miningAllowed || !isGpuMiningEnabled}
                                         onChange={() => handleSetExcludedDevice(i)}
                                     />
                                 </Stack>

--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 

--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -17,7 +17,6 @@ import { useAppConfigStore } from '@app/store/useAppConfigStore';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 
 const GpuDevices = () => {
-    const [isLoading, setIsLoading] = useState(false);
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const miningAllowed = useAppStateStore((s) => s.setupComplete);
     const gpuDevices = useMiningMetricsStore((s) => s.gpu_devices);
@@ -25,10 +24,10 @@ const GpuDevices = () => {
     const isGpuMiningEnabled = useAppConfigStore((s) => s.gpu_mining_enabled);
     const excludedDevices = useMiningStore((s) => s.excludedGpuDevices);
     const setExcludedDevice = useMiningStore((s) => s.setExcludedGpuDevice);
+    const isExcludingGpuDevices = useMiningStore((s) => s.isExcludingGpuDevices);
 
     const handleSetExcludedDevice = useCallback(
         async (device: number) => {
-            setIsLoading(true);
             if (!excludedDevices.includes(device)) {
                 excludedDevices.push(device);
                 await setExcludedDevice([...excludedDevices]);
@@ -36,7 +35,6 @@ const GpuDevices = () => {
                 excludedDevices.splice(excludedDevices.indexOf(device), 1);
                 await setExcludedDevice([...excludedDevices]);
             }
-            setIsLoading(false);
         },
         [excludedDevices, setExcludedDevice]
     );
@@ -68,7 +66,7 @@ const GpuDevices = () => {
                                     <ToggleSwitch
                                         key={device.name}
                                         checked={!excludedDevices.includes(i)}
-                                        disabled={isLoading || !miningAllowed || !isGpuMiningEnabled}
+                                        disabled={isExcludingGpuDevices || !miningAllowed || !isGpuMiningEnabled}
                                         onChange={() => handleSetExcludedDevice(i)}
                                     />
                                 </Stack>

--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 
@@ -17,6 +17,7 @@ import { useAppConfigStore } from '@app/store/useAppConfigStore';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 
 const GpuDevices = () => {
+    const [isLoading, setIsLoading] = useState(false);
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const miningAllowed = useAppStateStore((s) => s.setupComplete);
     const gpuDevices = useMiningMetricsStore((s) => s.gpu_devices);
@@ -27,6 +28,7 @@ const GpuDevices = () => {
 
     const handleSetExcludedDevice = useCallback(
         async (device: number) => {
+            setIsLoading(true);
             if (!excludedDevices.includes(device)) {
                 excludedDevices.push(device);
                 await setExcludedDevice([...excludedDevices]);
@@ -34,6 +36,7 @@ const GpuDevices = () => {
                 excludedDevices.splice(excludedDevices.indexOf(device), 1);
                 await setExcludedDevice([...excludedDevices]);
             }
+            setIsLoading(false);
         },
         [excludedDevices, setExcludedDevice]
     );
@@ -65,7 +68,7 @@ const GpuDevices = () => {
                                     <ToggleSwitch
                                         key={device.name}
                                         checked={!excludedDevices.includes(i)}
-                                        disabled={!miningAllowed || !isGpuMiningEnabled}
+                                        disabled={isLoading || !miningAllowed || !isGpuMiningEnabled}
                                         onChange={() => handleSetExcludedDevice(i)}
                                     />
                                 </Stack>

--- a/src/store/useMiningStore.ts
+++ b/src/store/useMiningStore.ts
@@ -12,6 +12,7 @@ interface State {
     miningInitiated: boolean;
     miningControlsEnabled: boolean;
     isChangingMode: boolean;
+    isExcludingGpuDevices: boolean;
     excludedGpuDevices: number[];
     counter: number;
     customLevelsDialogOpen: boolean;
@@ -35,6 +36,7 @@ const initialState: State = {
     hashrateReady: false,
     miningInitiated: false,
     isChangingMode: false,
+    isExcludingGpuDevices: false,
     miningControlsEnabled: true,
     network: 'unknown',
     excludedGpuDevices: [],
@@ -84,6 +86,7 @@ export const useMiningStore = create<MiningStoreState>()((set) => ({
             };
         }),
     setExcludedGpuDevice: async (excludedGpuDevices) => {
+        set({ isExcludingGpuDevices: true });
         const metricsState = useMiningMetricsStore.getState();
 
         if (metricsState.cpu_mining_status.is_mining || metricsState.gpu_mining_status.is_mining) {
@@ -111,5 +114,6 @@ export const useMiningStore = create<MiningStoreState>()((set) => ({
             console.info('Restarting mining...');
             await startMining();
         }
+        set({ isExcludingGpuDevices: false });
     },
 }));


### PR DESCRIPTION
Description
---
Allow user to enable/disable specific GPU devices when mining in progress. After each change mining is paused and restarted to apply changes.

What process can a PR reviewer use to test or verify this change?
---
1. Start mining if auto mining disabled
2. Go to **Mining** settings, **"GPU Mining devices"** specifically
3. Toggle off/on gpu devices separately

![image](https://github.com/user-attachments/assets/4068c91f-f86c-418b-a780-348351c12669)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GPU device settings for a more intuitive and responsive experience when excluding devices.
	- Mining activity now automatically resumes if it was active prior to making exclusion adjustments.
  
- **Refactor**
	- Simplified the underlying logic for managing GPU device exclusions, ensuring clearer toggle behavior in the settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->