### PR TITLE
fix: aurora QR code x wallet config path

### DIFF
--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -139,7 +139,12 @@ impl InternalWallet {
             Some(p) => p.clone(),
             None => return Err(anyhow!("No config path found")),
         };
-        let passphrase = CredentialManager::default_with_dir(path)
+
+        let path_parent = path
+            .parent()
+            .ok_or_else(|| anyhow!("Failed to get parent directory of wallet config file"))?;
+
+        let passphrase = CredentialManager::default_with_dir(path_parent.to_path_buf())
             .get_credentials()?
             .tari_seed_passphrase;
 


### PR DESCRIPTION
Description
---
- per Brian's comment on the ticket the default path for CredentialManager didn't match up to the initial one when creating a new wallet (matched up to use parent)

Motivation and Context
---

- Fixes: https://github.com/tari-project/universe/issues/1566

How Has This Been Tested?
---
- locally, reset and removed all .alpha files, restarted and denied keychain access:

  ~~_waiting for header sync **again** for the video_~~ video is ginormous because it includes the sync process (wanted to show denying keychain access right in the beginning) don't think i'll get it under 10mb :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the wallet configuration process with improved error handling for passphrase retrieval, contributing to increased reliability and a smoother wallet setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->