### PR TITLE
feat: add memory utilization to the telemetry_manager

### DIFF
--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -518,8 +518,6 @@ async fn get_telemetry_data(
         "wallet",
     );
 
-    println!("XXXXXXXXXXXXXXXXXX {:?}", extra_data.clone());
-
     Ok(TelemetryData {
         app_id: config_guard.anon_id().to_string(),
         block_height,

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -466,6 +466,11 @@ async fn get_telemetry_data(
         "total_memory".to_string(),
         system.total_memory().to_string(),
     );
+    let memory_utilization = (system.used_memory() as f64 / system.total_memory() as f64) * 100.0;
+    extra_data.insert(
+        "memory_utilization".to_string(),
+        memory_utilization.round().to_string()
+    );
     extra_data.insert("free_memory".to_string(), system.free_memory().to_string());
     if let Some(core_count) = system.physical_core_count() {
         extra_data.insert("physical_core_count".to_string(), core_count.to_string());
@@ -512,6 +517,8 @@ async fn get_telemetry_data(
         stats_collector.get_wallet_stats(),
         "wallet",
     );
+
+    println!("XXXXXXXXXXXXXXXXXX {:?}", extra_data.clone());
 
     Ok(TelemetryData {
         app_id: config_guard.anon_id().to_string(),

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -469,7 +469,7 @@ async fn get_telemetry_data(
     let memory_utilization = (system.used_memory() as f64 / system.total_memory() as f64) * 100.0;
     extra_data.insert(
         "memory_utilization".to_string(),
-        memory_utilization.round().to_string()
+        memory_utilization.round().to_string(),
     );
     extra_data.insert("free_memory".to_string(), system.free_memory().to_string());
     if let Some(core_count) = system.physical_core_count() {


### PR DESCRIPTION
[#1008](https://github.com/tari-project/universe/issues/1008)

Description
---
Add telemetry utilization to the telemetry data.

What process can a PR reviewer use to test or verify this change?
---
Not testable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced telemetry by adding memory utilization metrics, which now report the percentage of used memory relative to total available memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->