### PR TITLE
fix(ui): app stuck on shut down

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -17,9 +17,13 @@ import ThemeProvider from '../theme/ThemeProvider.tsx';
 import { useIsAppReady } from '@app/hooks/app/isAppReady.ts';
 import Splashscreen from '@app/containers/phase/Splashscreen/Splashscreen.tsx';
 
-const CurrentAppSection = memo(function CurrentAppSection() {
-    const isAppReady = useIsAppReady();
-    const isShuttingDown = useShuttingDown();
+const CurrentAppSection = memo(function CurrentAppSection({
+    isAppReady,
+    isShuttingDown,
+}: {
+    isAppReady?: boolean;
+    isShuttingDown?: boolean;
+}) {
     const isSettingUp = useAppStateStore((s) => !s.setupComplete);
 
     const currentSection = useMemo(() => {
@@ -80,7 +84,7 @@ export default function App() {
             <GlobalStyle $hideCanvas={!isAppReady || isShuttingDown} />
             <LazyMotion features={domAnimation} strict>
                 <FloatingElements />
-                <CurrentAppSection />
+                <CurrentAppSection isAppReady={isAppReady} isShuttingDown={isShuttingDown} />
             </LazyMotion>
         </ThemeProvider>
     );


### PR DESCRIPTION
Description
---

in #1457 i wanted the `isAppReady` & `isShutting` values for styling changes, so just called the hooks again, but this caused them to be mounted twice. the shut down hook includes the adds a `preventDefault` on `closeRequested`, _then_ calls our `exit_application` command so things froze up with it happening twice (including the state var having already been set to true)


- just removed the second references to the hooks in `CurrentAppSection` (the original place they were used) and passed down the values as props

Motivation and Context
---

- resolves https://github.com/tari-project/universe/issues/1595

How Has This Been Tested?
---

locally:

https://github.com/user-attachments/assets/bf1d0193-ad0b-4716-b9f6-c1b60a5b10ad



What process can a PR reviewer use to test or verify this change?
---
- same steps as ticket but it actually shuts down 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the application's state handling so that operational statuses (e.g., readiness and shutdown signals) are now provided by parent components instead of being determined internally. This change streamlines control flow, ensuring components receive accurate status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->