### PR TITLE
fix: add application/octet-stream and base64 to CSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.9.811",
     "type": "module",
     "scripts": {
-        "dev": "vite dev --mode development",
+        "dev": "vite dev",
         "build": "tsc && vite build",
         "preview": "vite preview",
         "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,19 +35,13 @@
     },
     "app": {
         "security": {
-            "capabilities": [
-                "desktop-capability",
-                "default",
-                "migrated"
-            ],
-            "dangerousDisableAssetCspModification": [
-                "style-src"
-            ],
+            "capabilities": ["desktop-capability", "default", "migrated"],
+            "dangerousDisableAssetCspModification": ["style-src"],
             "csp": {
                 "default-src": "'self' asset: tauri: URL: blob: data: https:",
                 "script-src": "'wasm-unsafe-eval'",
                 "style-src": "'self' 'unsafe-inline'",
-                "connect-src": "https: wss://ut.tari.com tauri: ipc: http://ipc.localhost https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm https://unpkg.com/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm"
+                "connect-src": "https: wss://ut.tari.com tauri: ipc: http://ipc.localhost https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm https://unpkg.com/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm data: application/octet-stream base64"
             },
             "pattern": {
                 "use": "isolation",
@@ -83,9 +77,7 @@
     "plugins": {
         "updater": {
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYxNUJBOEFEQkQ4RjJBMjYKUldRbUtvKzlyYWhiOFJIUmFFditENVV3d3hRbjNlZm1DMi9aMjluRUpVdHhQTytadTV3ODN3bUMK",
-            "endpoints": [
-                "https://raw.githubusercontent.com/tari-project/universe/main/.updater/alpha-latest.json"
-            ],
+            "endpoints": ["https://raw.githubusercontent.com/tari-project/universe/main/.updater/alpha-latest.json"],
             "windows": {
                 "installMode": "passive"
             }


### PR DESCRIPTION
Description
---

tower animation `.buf` files are inlined (no way around this with lib mode) 
- added `application/octet-stream` & `base64` to `data` optin for `connect-src` in CPS config

Motivation and Context
---
- animation broken on 0.9.12

How Has This Been Tested?
---

- locally (dev) and with local builds
