### PR TITLE
fix: change theme default to system

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -285,7 +285,7 @@ impl AppConfig {
             config_file: None,
             created_at: None,
             mode: MiningMode::Eco,
-            display_mode: DisplayMode::Light,
+            display_mode: DisplayMode::System,
             mine_on_app_start: true,
             p2pool_enabled: true,
             last_binaries_update_timestamp: default_system_time(),
@@ -355,7 +355,7 @@ impl AppConfig {
                 self.config_version = config.version;
                 self.mode = MiningMode::from_str(&config.mode).unwrap_or(MiningMode::Eco);
                 self.display_mode =
-                    DisplayMode::from_str(&config.display_mode).unwrap_or(DisplayMode::Light);
+                    DisplayMode::from_str(&config.display_mode).unwrap_or(DisplayMode::System);
                 self.mine_on_app_start = config.mine_on_app_start;
                 self.p2pool_enabled = config.p2pool_enabled;
                 self.last_binaries_update_timestamp = config.last_binaries_update_timestamp;
@@ -842,7 +842,7 @@ fn default_mode() -> String {
 }
 
 fn default_display_mode() -> String {
-    "light".to_string()
+    "system".to_string()
 }
 
 fn default_false() -> bool {


### PR DESCRIPTION
Description
---
The theme defaults to Light mode, which can be a stark contrast if the user uses system defaults and the rest of the computer is in dark mode. Use system as the default theme to align with the rest of the computer.

Motivation and Context
---
Fixes: #1603 

How Has This Been Tested?
---
Locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now defaults to using your system's display settings, providing a more personalized and dynamic appearance based on your operating system's theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->