### PR TITLE
fix: enable-mutli-engine-only-for-macos

### DIFF
--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -85,9 +85,14 @@ impl BinaryResolver {
     pub fn new() -> Self {
         let mut binary_manager = HashMap::<Binaries, BinaryManager>::new();
 
-        let gpu_miner_nextnet_regex = Regex::new(r"combined.*nextnet").ok();
+        let mut gpu_miner_nextnet_regex = Regex::new(r"opencl.*nextnet").ok();
 
-        let gpu_miner_testnet_regex = Regex::new(r"combined.*testnet").ok();
+        let mut gpu_miner_testnet_regex = Regex::new(r"opencl.*testnet").ok();
+
+        if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+            gpu_miner_nextnet_regex = Regex::new(r"combined.*nextnet").ok();
+            gpu_miner_testnet_regex = Regex::new(r"combined.*testnet").ok();
+        }
 
         let (tari_prerelease_prefix, gpuminer_specific_nanme) =
             match Network::get_current_or_user_setting_or_default() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined binary matching logic to ensure proper resolution across operating systems, with special handling for macOS on ARM-based devices for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->