### PR TITLE
feat: fallback to tcp after tor download failes

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::binaries::{Binaries, BinaryResolver};
 use crate::credential_manager::{Credential, KEYRING_ACCESSED};
 use crate::gpu_miner::EngineType;
 use semver::Version;
@@ -719,8 +720,14 @@ impl AppConfig {
         }
     }
 
-    pub fn use_tor(&self) -> bool {
-        self.use_tor
+    pub async fn use_tor(&self) -> bool {
+        let is_tor_files_exisits = BinaryResolver::current()
+            .read()
+            .await
+            .resolve_path_to_binary_files(Binaries::Tor)
+            .is_ok();
+
+        self.use_tor && is_tor_files_exisits
     }
 
     pub async fn set_use_tor(&mut self, use_tor: bool) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -721,13 +721,13 @@ impl AppConfig {
     }
 
     pub async fn use_tor(&self) -> bool {
-        let is_tor_files_exisits = BinaryResolver::current()
+        let is_tor_files_exists = BinaryResolver::current()
             .read()
             .await
             .resolve_path_to_binary_files(Binaries::Tor)
             .is_ok();
 
-        self.use_tor && is_tor_files_exisits
+        self.use_tor && is_tor_files_exists
     }
 
     pub async fn set_use_tor(&mut self, use_tor: bool) -> Result<(), anyhow::Error> {

--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -41,7 +41,7 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
     async fn fetch_releases_list(&self) -> Result<Vec<VersionDownloadInfo>, Error> {
         let platform = get_platform_name();
         let cdn_tor_bundle_url = format!(
-            "https://cdn-universe.tari.com/torwser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz",
+            "https://cdn-universe.tari.com/torbrowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz",
             platform
         );
         let mut cdn_responded = false;
@@ -74,7 +74,7 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
         let version = VersionDownloadInfo {
             version: "13.5.7".parse().expect("Bad tor version"),
             assets: vec![VersionAsset {
-                url: format!("https://dist.torproject.org/torowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz", platform),
+                url: format!("https://dist.torproject.org/torbrowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz", platform),
                 name: format!("tor-expert-bundle-{}-13.5.7.tar.gz", platform),
             }]
         };

--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -41,7 +41,7 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
     async fn fetch_releases_list(&self) -> Result<Vec<VersionDownloadInfo>, Error> {
         let platform = get_platform_name();
         let cdn_tor_bundle_url = format!(
-            "https://cdn-universe.tari.com/torbrowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz",
+            "https://cdn-universe.tari.com/torwser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz",
             platform
         );
         let mut cdn_responded = false;
@@ -74,7 +74,7 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
         let version = VersionDownloadInfo {
             version: "13.5.7".parse().expect("Bad tor version"),
             assets: vec![VersionAsset {
-                url: format!("https://dist.torproject.org/torbrowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz", platform),
+                url: format!("https://dist.torproject.org/torowser/13.5.7/tor-expert-bundle-{}-13.5.7.tar.gz", platform),
                 name: format!("tor-expert-bundle-{}-13.5.7.tar.gz", platform),
             }]
         };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -430,8 +430,15 @@ async fn setup_inner(
             }
             Err(e) => {
                 error!(target: LOG_TARGET, "Could not initialize tor: {:?}", e);
-                let _unused = state.config.write().await.set_use_tor(false).await;
-                app.restart();
+                let _unused = state
+                    .config
+                    .write()
+                    .await
+                    .set_use_tor(false)
+                    .await
+                    .is_ok_and(|_| {
+                        app.restart();
+                    });
             }
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -350,7 +350,7 @@ async fn setup_inner(
     let cpu_miner_config = state.cpu_miner_config.read().await;
     let app_config = state.config.read().await;
 
-    let use_tor = app_config.use_tor();
+    let use_tor = app_config.use_tor().await;
     let p2pool_enabled = app_config.p2pool_enabled();
     drop(app_config);
 
@@ -430,8 +430,15 @@ async fn setup_inner(
             }
             Err(e) => {
                 error!(target: LOG_TARGET, "Could not initialize tor: {:?}", e);
-                let _unused = state.config.write().await.set_use_tor(false).await;
-                app.restart();
+                let _unused = state
+                    .config
+                    .write()
+                    .await
+                    .set_use_tor(false)
+                    .await
+                    .is_ok_and(|_| {
+                        app.restart();
+                    });
             }
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -430,15 +430,8 @@ async fn setup_inner(
             }
             Err(e) => {
                 error!(target: LOG_TARGET, "Could not initialize tor: {:?}", e);
-                let _unused = state
-                    .config
-                    .write()
-                    .await
-                    .set_use_tor(false)
-                    .await
-                    .is_ok_and(|_| {
-                        app.restart();
-                    });
+                let _unused = state.config.write().await.set_use_tor(false).await;
+                app.restart();
             }
         }
     }

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -430,7 +430,7 @@ async fn get_telemetry_data(
     );
     extra_data.insert(
         "config_tor_enabled".to_string(),
-        config_guard.use_tor().to_string(),
+        config_guard.use_tor().await.to_string(),
     );
     let mut squad = None;
     if let Some(stats) = p2pool_stats.as_ref() {

--- a/src-tauri/src/utils/shutdown_utils.rs
+++ b/src-tauri/src/utils/shutdown_utils.rs
@@ -154,7 +154,7 @@ pub async fn resume_all_processes(app_handle: tauri::AppHandle) -> Result<(), an
         .app_log_dir()
         .expect("Could not get log dir");
 
-    let use_tor = state.config.read().await.use_tor();
+    let use_tor = state.config.read().await.use_tor().await;
     let p2pool_enabled = state.config.read().await.p2pool_enabled();
     let mut stage_total = 5;
     let mut stage_progress = 0;


### PR DESCRIPTION
## Should fix #1516 

## Waiting for #1664 

### [ Summary ]
- Handled tor download failure with changing `use_tor` to `false` and then restarting the app


### [ Testing ]
- Delete tor binaries
- Go to `adapter_tor` and change url's for downloading tor binaries so it won't be able to
- Build the app from this branch 
- Ensure you have enabled `use_tor` in `app_config`
- Launch the app and it should restart with setting `use_tor` flag to false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the startup process with enhanced error handling.
- **Bug Fixes**
  - If Tor fails to initialize, the app automatically disables Tor support and restarts, ensuring a smoother experience.
  - Removed an unnecessary startup delay for improved responsiveness.
- **Improvements**
  - Added informational logging for successful Tor initialization and detailed error logging for failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->