### PR TITLE
chore: upload debug symbols when the release is generated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,9 +267,10 @@ jobs:
       - name: Windows debug symbols - Upload to Sentry
         if: startsWith(runner.os,'Windows')
         env:
-          AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
         continue-on-error: true
         shell: bash
         run: |
           npm install @sentry/cli
-          sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release
+          sentry-cli debug-files check ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb
+          sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,3 +263,13 @@ jobs:
         with:
           name: tari_universe.pdb
           path: "${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb"
+
+      - name: Windows debug symbols - Upload to Sentry
+        if: startsWith(runner.os,'Windows')
+        env:
+          AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          npm install @sentry/cli
+          sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,10 +268,9 @@ jobs:
         if: startsWith(runner.os,'Windows')
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
-          SENTRY_CLI_VERSION: 2.42.2
         continue-on-error: true
         shell: bash
         run: |
-          npm install @sentry/cli
+          npm install @sentry/cli@2.42.2
           sentry-cli debug-files check ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb
           sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,7 @@ jobs:
         if: startsWith(runner.os,'Windows')
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
+          SENTRY_CLI_VERSION: 2.42.2
         continue-on-error: true
         shell: bash
         run: |


### PR DESCRIPTION
Description
---
Upload windows debug symbols directly to sentry when the release is finished.

Motivation and Context
---
More debugging power

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced our error tracking process by automating the upload of Windows debug symbols to our monitoring service.
	- Updated the installation command for Sentry CLI to version `2.42.2` for improved upload functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->