### PR TITLE
chore: rename xtrgpuminer to glytex

### DIFF
--- a/src-tauri/binaries_versions_esmeralda.json
+++ b/src-tauri/binaries_versions_esmeralda.json
@@ -5,7 +5,7 @@
         "minotari_node": "=1.12.2-pre.0",
         "wallet": "=1.12.2-pre.0",
         "sha-p2pool": "=0.22.3",
-        "xtrgpuminer": "=0.2.16",
+        "glytex": "=0.2.16",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/binaries_versions_nextnet.json
+++ b/src-tauri/binaries_versions_nextnet.json
@@ -5,7 +5,7 @@
         "minotari_node": "=1.12.2-rc.0",
         "wallet": "=1.12.2-rc.0",
         "sha-p2pool": "=0.22.3",
-        "xtrgpuminer": "=0.2.16",
+        "glytex": "=0.2.16",
         "tor": "=13.5.7"
     }
 }

--- a/src-tauri/src/binaries/binaries_list.rs
+++ b/src-tauri/src/binaries/binaries_list.rs
@@ -43,7 +43,7 @@ impl Binaries {
             Binaries::MinotariNode => "minotari_node",
             Binaries::Wallet => "wallet",
             Binaries::ShaP2pool => "sha-p2pool",
-            Binaries::GpuMiner => "xtrgpuminer",
+            Binaries::GpuMiner => "glytex",
             Binaries::Tor => "tor",
         }
     }
@@ -55,7 +55,7 @@ impl Binaries {
             "minotari_node" => Binaries::MinotariNode,
             "wallet" => Binaries::Wallet,
             "sha-p2pool" => Binaries::ShaP2pool,
-            "xtrgpuminer" => Binaries::GpuMiner,
+            "glytex" => Binaries::GpuMiner,
             "tor" => Binaries::Tor,
             _ => panic!("Unknown binary name: {}", name),
         }
@@ -84,7 +84,7 @@ impl Binaries {
                 PathBuf::from(file_name)
             }
             Binaries::GpuMiner => {
-                let file_name = "xtrgpuminer";
+                let file_name = "glytex";
                 PathBuf::from(file_name)
             }
             Binaries::Tor => {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -94,7 +94,7 @@ impl BinaryResolver {
             gpu_miner_testnet_regex = Regex::new(r"combined.*testnet").ok();
         }
 
-        let (tari_prerelease_prefix, gpuminer_specific_nanme) =
+        let (tari_prerelease_prefix, gpuminer_specific_name) =
             match Network::get_current_or_user_setting_or_default() {
                 Network::NextNet => ("rc", gpu_miner_nextnet_regex),
                 Network::Esmeralda => ("pre", gpu_miner_testnet_regex),
@@ -119,9 +119,9 @@ impl BinaryResolver {
                 Binaries::GpuMiner.name().to_string(),
                 None,
                 Box::new(GithubReleasesAdapter {
-                    repo: "tarigpuminer".to_string(),
-                    owner: "stringhandler".to_string(),
-                    specific_name: gpuminer_specific_nanme,
+                    repo: "glytex".to_string(),
+                    owner: "tari-project".to_string(),
+                    specific_name: gpuminer_specific_name,
                 }),
                 None,
                 true,

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -217,7 +217,7 @@ impl ProcessAdapter for GpuMinerAdapter {
         }
 
         #[cfg(target_os = "windows")]
-        add_firewall_rule("xtrgpuminer.exe".to_string(), binary_version_path.clone())?;
+        add_firewall_rule("glytex.exe".to_string(), binary_version_path.clone())?;
 
         Ok((
             ProcessInstance {
@@ -241,11 +241,11 @@ impl ProcessAdapter for GpuMinerAdapter {
     }
 
     fn name(&self) -> &str {
-        "xtrgpuminer"
+        "glytex"
     }
 
     fn pid_file_name(&self) -> &str {
-        "xtrgpuminer_pid"
+        "glytex_pid"
     }
 }
 


### PR DESCRIPTION
Description
---
Use the new glytex repository within the tari-projects organization.

Fixes: #504 

Motivation and Context
---
Org control. And updated naming

How Has This Been Tested?
---
Locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Rebranded the GPU miner component from its previous identifier to **glytex**, updating executable names, process identifiers, and configuration settings.
	- Adjusted external repository and ownership details to align with the new naming convention.
	- Introduced conditional compilation for macOS to include necessary imports.
- **Chores**
	- Added a new job step to the GitHub Actions workflow for uploading Windows debug symbols to Sentry.
- **Style**
	- Added attributes to suppress warnings for unused code related to the `FrontendReadyChannel` struct and its method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->