### PR TITLE
fix: abosulte path to sentry-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,12 +265,12 @@ jobs:
           path: "${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb"
 
       - name: Windows debug symbols - Upload to Sentry
-        if: startsWith(runner.os,'Windows')
+        if: ${{ ( startsWith(runner.os,'Windows') ) && ( env.SENTRY_AUTH_TOKEN != '' ) }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SYMBOLS_AUTH_TOKEN }}
         continue-on-error: true
         shell: bash
         run: |
           npm install @sentry/cli@2.42.2
-          sentry-cli debug-files check ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb
-          sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb
+          ./node_modules/@sentry/cli/bin/sentry-cli debug-files check ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb
+          ./node_modules/@sentry/cli/bin/sentry-cli debug-files upload --org tari-labs --project tari-universe ${{ github.workspace }}/src-tauri/target/release/tari_universe.pdb


### PR DESCRIPTION
Description
---
The npm install binaries weren't found to run sentry. Use an absolute path instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the Windows release process by ensuring that error tracking tasks run only when all required configurations are in place.
	- Updated tool handling for debug information uploads to enhance overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->