### PR TITLE
feat: add space x event UI

### DIFF
--- a/src/components/svgs/XSpaceSvg.tsx
+++ b/src/components/svgs/XSpaceSvg.tsx
@@ -1,6 +1,6 @@
 export default function XSpaceSvg() {
     return (
-        <svg width="21" height="22" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="11" height="12" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 22">
             <path
                 d="M12.5 9.018 20.319.125h-1.852l-6.792 7.72L6.254.125H0L8.2 11.8 0 21.125h1.852L9.02 12.97l5.726 8.155H21M2.52 1.492h2.846l13.1 18.333h-2.847"
                 fill="#000"

--- a/src/components/svgs/XSpaceSvg.tsx
+++ b/src/components/svgs/XSpaceSvg.tsx
@@ -1,0 +1,12 @@
+export default function XSpaceSvg() {
+    return (
+        <svg width="21" height="22" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M12.5 9.018 20.319.125h-1.852l-6.792 7.72L6.254.125H0L8.2 11.8 0 21.125h1.852L9.02 12.97l5.726 8.155H21M2.52 1.492h2.846l13.1 18.333h-2.847"
+                fill="#000"
+                stroke="#000"
+                strokeWidth="0.6"
+            />
+        </svg>
+    );
+}

--- a/src/containers/floating/FloatingElements.tsx
+++ b/src/containers/floating/FloatingElements.tsx
@@ -15,6 +15,7 @@ import ReleaseNotesDialog from './ReleaseNotesDialog/ReleaseNotesDialog.tsx';
 import LudicrousCofirmationDialog from './LudicrousCofirmationDialog/LudicrousCofirmationDialog.tsx';
 import { memo } from 'react';
 import ResumeApplicationModal from './ResumeApplicationModal/ResumeApplicationModal.tsx';
+import XSpaceEventBanner from './XSpaceBanner/XSpaceBanner.tsx';
 
 const environment = import.meta.env.MODE;
 
@@ -34,6 +35,7 @@ const FloatingElements = memo(function FloatingElements() {
             <CriticalProblemDialog />
             <ReleaseNotesDialog />
             <ResumeApplicationModal />
+            <XSpaceEventBanner />
             {environment === 'development' && <AdminUI />}
         </FloatingTree>
     );

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,20 +1,17 @@
 import styled from 'styled-components';
 
-export const FloatingWrapper = styled.div`
+export const BannerContent = styled.div`
     position: fixed;
     top: 20px;
     right: 30px;
     z-index: 99999;
-`;
-
-export const BannerContent = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
     color: white;
-    padding: 0.5rem 1rem;
+    padding: 0.3rem 0.3rem;
     border-radius: 9999px;
-    max-width: 24rem;
+    max-width: 30rem;
     background-color: #000;
     color: #fff;
 `;
@@ -29,10 +26,12 @@ export const IconContainer = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: #000;
+    background-color: white;
     border-radius: 9999px;
     padding: 0.5rem;
     font-size: 0.875rem;
+    width: 1 rem;
+    height: 1 rem;
 `;
 
 export const Title = styled.span`
@@ -52,7 +51,7 @@ export const LiveBadgeWrapper = styled.div`
     padding: 4px 12px;
     border-radius: 9999px;
     font-size: 0.875rem;
-    gap: 0.5rem;
+    gap: 12px;
 `;
 
 export const LiveBadgeText = styled.div`
@@ -67,10 +66,12 @@ export const LiveBadgePoint = styled.div`
     height: 0.725rem;
 `;
 
-export const ScheduleBadge = styled.div`
-    background-color: #374151;
-    color: white;
+export const TimeBadge = styled.div`
+    background-color: white;
+    color: black;
+    font-weight: 1000;
     padding: 4px 12px;
     border-radius: 9999px;
     font-size: 0.875rem;
+    gap: 12px;
 `;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,3 +1,4 @@
+import * as m from 'motion/react-m';
 import styled from 'styled-components';
 
 export const BannerContent = styled.div`
@@ -34,13 +35,19 @@ export const IconContainer = styled.div`
     height: 1 rem;
 `;
 
-export const Title = styled.span`
-    font-weight: 500;
-    white-space: nowrap;
+export const TitleContainer = styled(m.div)`
+    display: flex;
+    align-items: center;
     overflow: hidden;
     text-overflow: ellipsis;
+`;
+
+export const Title = styled(m.span)`
+    font-weight: 500;
+    white-space: nowrap;
     max-width: 200px;
     font-size: 0.875rem;
+    width: 100%;
 `;
 
 export const LiveBadgeWrapper = styled.div`

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,7 +1,7 @@
 import * as m from 'motion/react-m';
 import styled from 'styled-components';
 
-export const BannerContent = styled.div`
+export const BannerContent = styled(m.div)`
     position: fixed;
     top: 16px;
     right: 32px;
@@ -15,9 +15,15 @@ export const BannerContent = styled.div`
     max-width: 30rem;
     background-color: #000;
     color: #fff;
+    cursor: pointer;
+    pointer-events: all;
+    &:hover {
+        transform: scale(1.05);
+    }
+    transition: all 0.2s ease-in-out;
 `;
 
-export const FlexWrapper = styled.div`
+export const FlexWrapper = styled(m.div)`
     display: flex;
     align-items: center;
     gap: 12px;
@@ -25,7 +31,7 @@ export const FlexWrapper = styled.div`
     column-gap: 12px;
 `;
 
-export const IconContainer = styled.div`
+export const IconContainer = styled(m.div)`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -55,7 +61,7 @@ export const Title = styled(m.span)`
     width: 100%;
 `;
 
-export const LiveBadgeWrapper = styled.div`
+export const LiveBadgeWrapper = styled(m.div)`
     display: flex;
     justify-content: space-evenly;
     align-items: center;
@@ -66,19 +72,19 @@ export const LiveBadgeWrapper = styled.div`
     gap: 12px;
 `;
 
-export const LiveBadgeText = styled.div`
+export const LiveBadgeText = styled(m.div)`
     color: white;
     font-weight: 700;
 `;
 
-export const LiveBadgePoint = styled.div`
+export const LiveBadgePoint = styled(m.div)`
     background-color: white;
     border-radius: 9999px;
     width: 0.725rem;
     height: 0.725rem;
 `;
 
-export const TimeBadge = styled.div`
+export const TimeBadge = styled(m.div)`
     background-color: white;
     color: black;
     font-weight: 1000;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 export const BannerContent = styled.div`
     position: fixed;
-    top: 20px;
-    right: 30px;
+    top: 16px;
+    right: 32px;
     z-index: 99999;
     display: flex;
     align-items: center;
@@ -17,10 +17,12 @@ export const BannerContent = styled.div`
     color: #fff;
 `;
 
-export const TextSection = styled.div`
+export const FlexWrapper = styled.div`
     display: flex;
     align-items: center;
     gap: 12px;
+    row-gap: 12px;
+    column-gap: 12px;
 `;
 
 export const IconContainer = styled.div`
@@ -38,6 +40,8 @@ export const IconContainer = styled.div`
 export const TitleContainer = styled(m.div)`
     display: flex;
     align-items: center;
+    justify-content: space-evenly;
+    row-gap: 12px;
     overflow: hidden;
     text-overflow: ellipsis;
 `;
@@ -46,6 +50,7 @@ export const Title = styled(m.span)`
     font-weight: 500;
     white-space: nowrap;
     max-width: 200px;
+    min-width: 100px;
     font-size: 0.875rem;
     width: 100%;
 `;
@@ -80,5 +85,4 @@ export const TimeBadge = styled.div`
     padding: 4px 12px;
     border-radius: 9999px;
     font-size: 0.875rem;
-    gap: 12px;
 `;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+
+export const FloatingWrapper = styled.div`
+    position: fixed;
+    top: 20px;
+    right: 30px;
+    z-index: 99999;
+`;
+
+export const BannerContent = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    max-width: 24rem;
+    background-color: #000;
+    color: #fff;
+`;
+
+export const TextSection = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+`;
+
+export const IconContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #000;
+    border-radius: 9999px;
+    padding: 0.5rem;
+    font-size: 0.875rem;
+`;
+
+export const Title = styled.span`
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+    font-size: 0.875rem;
+`;
+
+export const LiveBadgeWrapper = styled.div`
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    background-color: #ef4444;
+    padding: 4px 12px;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    gap: 0.5rem;
+`;
+
+export const LiveBadgeText = styled.div`
+    color: white;
+    font-weight: 700;
+`;
+
+export const LiveBadgePoint = styled.div`
+    background-color: white;
+    border-radius: 9999px;
+    width: 0.725rem;
+    height: 0.725rem;
+`;
+
+export const ScheduleBadge = styled.div`
+    background-color: #374151;
+    color: white;
+    padding: 4px 12px;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+`;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -1,0 +1,90 @@
+// import { X } from 'lucide-react';
+import { useAirdropStore } from '@app/store/useAirdropStore';
+import {
+    BannerContent,
+    IconContainer,
+    TextSection,
+    LiveBadgePoint,
+    ScheduleBadge,
+    Title,
+    LiveBadgeText,
+    LiveBadgeWrapper,
+    FloatingWrapper,
+} from './XSpaceBanner.style';
+import { useMemo } from 'react';
+
+const XSpaceEventBanner = () => {
+    // Truncate title if it's too long
+    let latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
+
+    console.log({ latestXSpaceEvent });
+
+    latestXSpaceEvent = {
+        id: 'id',
+        start: new Date(),
+        end: new Date(),
+        displayName: 'No new eventsdsfffffffffffffffffffffffffffffffffffffffffffffsdfsdf',
+    };
+
+    const isLive = useMemo(() => {
+        const currentDate = new Date();
+        if (latestXSpaceEvent) {
+            return latestXSpaceEvent.end >= currentDate && latestXSpaceEvent.start <= currentDate;
+        }
+        return false;
+    }, [latestXSpaceEvent]);
+
+    const displayedText = useMemo(() => {
+        if (!latestXSpaceEvent) {
+            return '';
+        }
+        const displayTitle =
+            latestXSpaceEvent.displayName.length > 40
+                ? `${latestXSpaceEvent.displayName.substring(0, 37)}...`
+                : latestXSpaceEvent.displayName;
+        return displayTitle;
+    }, [latestXSpaceEvent]);
+
+    const displayedDate = useMemo(() => {
+        if (!latestXSpaceEvent || isLive) {
+            return '';
+        }
+        return latestXSpaceEvent.start
+            .toLocaleString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                hour12: true,
+                timeZoneName: 'shortGeneric',
+            })
+            .replace(' at ', ' @ ')
+            .toUpperCase();
+    }, [latestXSpaceEvent, isLive]);
+
+    if (!latestXSpaceEvent) {
+        return undefined;
+    }
+
+    const liveBadge = (
+        <LiveBadgeWrapper>
+            <LiveBadgePoint />
+            <LiveBadgeText>LIVE</LiveBadgeText>
+        </LiveBadgeWrapper>
+    );
+    const displayDate = displayedDate ? <ScheduleBadge>{displayedDate}</ScheduleBadge> : null;
+
+    const someIcon = 'hey';
+    return (
+        <FloatingWrapper>
+            <BannerContent>
+                <TextSection>
+                    <IconContainer>{someIcon}</IconContainer>
+                    <Title>{displayedText}</Title>
+                </TextSection>
+                {isLive ? liveBadge : displayDate}
+            </BannerContent>
+        </FloatingWrapper>
+    );
+};
+
+export default XSpaceEventBanner;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -45,7 +45,7 @@ const XSpaceEventBanner = () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const containerWidth = (containerRef.current as any).clientWidth;
             setIsTextTooLong(titleWidth > containerWidth);
-            setTransitionPixelWidth((titleRef.current as any).scrollWidth / 3);
+            setTransitionPixelWidth(titleWidth / 2);
         }
     }, [latestXSpaceEvent]); // Re-run the effect when the event changes
 
@@ -122,7 +122,7 @@ const XSpaceEventBanner = () => {
                                 : {}
                         }
                     >
-                        {`${latestXSpaceEvent.text} ${isTextTooLong ? latestXSpaceEvent.text : ''} ${isTextTooLong ? latestXSpaceEvent.text : ''}`}
+                        {`${latestXSpaceEvent.text} ${isTextTooLong ? latestXSpaceEvent.text : ''}`}
                     </Title>
                 </TitleContainer>
                 {isLive ? liveBadge : displayDate}

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -13,13 +13,30 @@ import {
 } from './XSpaceBanner.style';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import XSpaceSvg from '@app/components/svgs/XSpaceSvg';
+import { XSpaceEventType } from '@app/types/ws';
+import { open } from '@tauri-apps/plugin-shell';
 
 const XSpaceEventBanner = () => {
     const latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
     const [isTextTooLong, setIsTextTooLong] = useState(false);
     const [transitionPixelWidth, setTransitionPixelWidth] = useState(0);
+    const [isVisible, setIsVisible] = useState(false);
     const titleRef = useRef(null);
     const containerRef = useRef(null);
+
+    useEffect(() => {
+        if (!latestXSpaceEvent) return;
+
+        const checkVisibility = () => {
+            const now = new Date();
+            const start = new Date(latestXSpaceEvent.visibilityStart);
+            setIsVisible(now >= start);
+        };
+
+        checkVisibility();
+        const interval = setInterval(checkVisibility, 30000); // check every 30 sec
+        return () => clearInterval(interval);
+    }, [latestXSpaceEvent]);
 
     useEffect(() => {
         if (titleRef.current && containerRef.current) {
@@ -28,23 +45,27 @@ const XSpaceEventBanner = () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const containerWidth = (containerRef.current as any).clientWidth;
             setIsTextTooLong(titleWidth > containerWidth);
-            setTransitionPixelWidth((titleRef.current as any).scrollWidth / 2);
+            setTransitionPixelWidth((titleRef.current as any).scrollWidth / 3);
         }
     }, [latestXSpaceEvent]); // Re-run the effect when the event changes
 
     const isLive = useMemo(() => {
         const currentDate = new Date();
         if (latestXSpaceEvent) {
-            return new Date(latestXSpaceEvent.end) >= currentDate && new Date(latestXSpaceEvent.start) <= currentDate;
+            if (!latestXSpaceEvent.goingLive || latestXSpaceEvent.type !== XSpaceEventType.event) return false;
+            return (
+                new Date(latestXSpaceEvent.visibilityEnd) >= currentDate &&
+                new Date(latestXSpaceEvent.goingLive) <= currentDate
+            );
         }
         return false;
     }, [latestXSpaceEvent]);
 
     const displayedDate = useMemo(() => {
-        if (!latestXSpaceEvent || isLive) {
-            return '';
+        if (!latestXSpaceEvent || isLive || !latestXSpaceEvent.goingLive) {
+            return undefined;
         }
-        const dateFormatted = new Date(latestXSpaceEvent.start)
+        const dateFormatted = new Date(latestXSpaceEvent.goingLive)
             .toLocaleString('en-US', {
                 month: 'short',
                 day: 'numeric',
@@ -57,18 +78,24 @@ const XSpaceEventBanner = () => {
         return dateFormatted;
     }, [latestXSpaceEvent, isLive]);
 
-    if (!latestXSpaceEvent) {
+    if (!latestXSpaceEvent || !isVisible) {
         return undefined;
     }
+
     const liveBadge = (
         <LiveBadgeWrapper>
             <LiveBadgePoint />
             <LiveBadgeText>LIVE</LiveBadgeText>
         </LiveBadgeWrapper>
     );
+
     const displayDate = displayedDate ? <TimeBadge>{displayedDate}</TimeBadge> : null;
     return (
-        <BannerContent>
+        <BannerContent
+            onClick={() => {
+                open(latestXSpaceEvent.link);
+            }}
+        >
             <FlexWrapper>
                 <IconContainer>
                     <XSpaceSvg></XSpaceSvg>
@@ -88,14 +115,14 @@ const XSpaceEventBanner = () => {
                                 ? {
                                       repeat: Infinity,
                                       repeatType: 'loop',
-                                      duration: 5,
+                                      duration: 10,
                                       delay: 2,
                                       ease: 'linear',
                                   }
                                 : {}
                         }
                     >
-                        {`${latestXSpaceEvent.displayName} ${isTextTooLong ? latestXSpaceEvent.displayName : ''}`}
+                        {`${latestXSpaceEvent.text} ${isTextTooLong ? latestXSpaceEvent.text : ''} ${isTextTooLong ? latestXSpaceEvent.text : ''}`}
                     </Title>
                 </TitleContainer>
                 {isLive ? liveBadge : displayDate}

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -9,6 +9,7 @@ import {
     Title,
     LiveBadgeText,
     LiveBadgeWrapper,
+    TitleContainer,
 } from './XSpaceBanner.style';
 import { useMemo } from 'react';
 import XSpaceSvg from '@app/components/svgs/XSpaceSvg';
@@ -23,17 +24,6 @@ const XSpaceEventBanner = () => {
             return latestXSpaceEvent.end >= currentDate && latestXSpaceEvent.start <= currentDate;
         }
         return false;
-    }, [latestXSpaceEvent]);
-
-    const displayedText = useMemo(() => {
-        if (!latestXSpaceEvent) {
-            return '';
-        }
-        const displayTitle =
-            latestXSpaceEvent.displayName.length > 40
-                ? `${latestXSpaceEvent.displayName.substring(0, 37)}...`
-                : latestXSpaceEvent.displayName;
-        return displayTitle;
     }, [latestXSpaceEvent]);
 
     const displayedDate = useMemo(() => {
@@ -71,7 +61,23 @@ const XSpaceEventBanner = () => {
                 <IconContainer>
                     <XSpaceSvg></XSpaceSvg>
                 </IconContainer>
-                <Title>{displayedText}</Title>
+                <TitleContainer>
+                    <Title
+                        animate={{
+                            x: ['0%', '-100%'],
+                        }}
+                        transition={{
+                            repeat: Infinity,
+                            repeatType: 'loop',
+                            duration: 10,
+                            delay: 2,
+                            velocity: 0.3,
+                            ease: 'linear',
+                        }}
+                    >
+                        {latestXSpaceEvent.displayName}
+                    </Title>
+                </TitleContainer>
             </TextSection>
             {isLive ? liveBadge : displayDate}
         </BannerContent>

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -5,26 +5,17 @@ import {
     IconContainer,
     TextSection,
     LiveBadgePoint,
-    ScheduleBadge,
+    TimeBadge,
     Title,
     LiveBadgeText,
     LiveBadgeWrapper,
-    FloatingWrapper,
 } from './XSpaceBanner.style';
 import { useMemo } from 'react';
+import XSpaceSvg from '@app/components/svgs/XSpaceSvg';
 
 const XSpaceEventBanner = () => {
     // Truncate title if it's too long
-    let latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
-
-    console.log({ latestXSpaceEvent });
-
-    latestXSpaceEvent = {
-        id: 'id',
-        start: new Date(),
-        end: new Date(),
-        displayName: 'No new eventsdsfffffffffffffffffffffffffffffffffffffffffffffsdfsdf',
-    };
+    const latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
 
     const isLive = useMemo(() => {
         const currentDate = new Date();
@@ -49,16 +40,17 @@ const XSpaceEventBanner = () => {
         if (!latestXSpaceEvent || isLive) {
             return '';
         }
-        return latestXSpaceEvent.start
+        const dateFormatted = new Date(latestXSpaceEvent.start)
             .toLocaleString('en-US', {
                 month: 'short',
                 day: 'numeric',
                 hour: 'numeric',
                 hour12: true,
-                timeZoneName: 'shortGeneric',
+                timeZoneName: 'short',
             })
-            .replace(' at ', ' @ ')
+            .replace(', ', ' @')
             .toUpperCase();
+        return dateFormatted;
     }, [latestXSpaceEvent, isLive]);
 
     if (!latestXSpaceEvent) {
@@ -71,19 +63,18 @@ const XSpaceEventBanner = () => {
             <LiveBadgeText>LIVE</LiveBadgeText>
         </LiveBadgeWrapper>
     );
-    const displayDate = displayedDate ? <ScheduleBadge>{displayedDate}</ScheduleBadge> : null;
+    const displayDate = displayedDate ? <TimeBadge>{displayedDate}</TimeBadge> : null;
 
-    const someIcon = 'hey';
     return (
-        <FloatingWrapper>
-            <BannerContent>
-                <TextSection>
-                    <IconContainer>{someIcon}</IconContainer>
-                    <Title>{displayedText}</Title>
-                </TextSection>
-                {isLive ? liveBadge : displayDate}
-            </BannerContent>
-        </FloatingWrapper>
+        <BannerContent>
+            <TextSection>
+                <IconContainer>
+                    <XSpaceSvg></XSpaceSvg>
+                </IconContainer>
+                <Title>{displayedText}</Title>
+            </TextSection>
+            {isLive ? liveBadge : displayDate}
+        </BannerContent>
     );
 };
 

--- a/src/hooks/airdrop/stateHelpers/useXSpaceEventRefresh.ts
+++ b/src/hooks/airdrop/stateHelpers/useXSpaceEventRefresh.ts
@@ -1,21 +1,21 @@
+import { useAppStateStore } from '@app/store/appStateStore';
 import { useAirdropStore } from '@app/store/useAirdropStore';
 import { XSpaceEvent } from '@app/types/ws';
 import { useEffect } from 'react';
 
 export function useXSpaceEventRefresh() {
-    const userDetails = useAirdropStore((state) => state.userDetails);
-    const setLatestXSpaceEvent = useAirdropStore((state) => state.setLatestXSpaceEvent);
+    const setupComplete = useAppStateStore((state) => state.setupComplete);
 
     const backendInMemoryConfig = useAirdropStore((s) => s.backendInMemoryConfig);
     useEffect(() => {
         if (!backendInMemoryConfig?.airdropApiUrl) return;
-        if (userDetails) return; //user logged in, data will arrive through websocket
+        if (!setupComplete) return; //user logged in, data will arrive through websocket
 
         fetchLatestXSpaceEvent(backendInMemoryConfig?.airdropApiUrl).then((data) => {
             if (data === undefined) {
                 return;
             }
-            setLatestXSpaceEvent(data);
+            useAirdropStore.setState({ latestXSpaceEvent: data });
         });
         const interval = setInterval(
             () => {
@@ -23,13 +23,13 @@ export function useXSpaceEventRefresh() {
                     if (data === undefined) {
                         return;
                     }
-                    setLatestXSpaceEvent(data);
+                    useAirdropStore.setState({ latestXSpaceEvent: data });
                 });
             },
             1000 * 60 * 60
         );
         return () => clearInterval(interval);
-    }, [backendInMemoryConfig?.airdropApiUrl, setLatestXSpaceEvent, userDetails]);
+    }, [backendInMemoryConfig?.airdropApiUrl, setupComplete]);
 }
 
 async function fetchLatestXSpaceEvent(airdropApiUrl: string) {

--- a/src/hooks/airdrop/stateHelpers/useXSpaceEventRefresh.ts
+++ b/src/hooks/airdrop/stateHelpers/useXSpaceEventRefresh.ts
@@ -1,0 +1,50 @@
+import { useAirdropStore } from '@app/store/useAirdropStore';
+import { XSpaceEvent } from '@app/types/ws';
+import { useEffect } from 'react';
+
+export function useXSpaceEventRefresh() {
+    const userDetails = useAirdropStore((state) => state.userDetails);
+    const setLatestXSpaceEvent = useAirdropStore((state) => state.setLatestXSpaceEvent);
+
+    const backendInMemoryConfig = useAirdropStore((s) => s.backendInMemoryConfig);
+    useEffect(() => {
+        if (!backendInMemoryConfig?.airdropApiUrl) return;
+        if (userDetails) return; //user logged in, data will arrive through websocket
+
+        fetchLatestXSpaceEvent(backendInMemoryConfig?.airdropApiUrl).then((data) => {
+            if (data === undefined) {
+                return;
+            }
+            setLatestXSpaceEvent(data);
+        });
+        const interval = setInterval(
+            () => {
+                fetchLatestXSpaceEvent(backendInMemoryConfig?.airdropApiUrl).then((data) => {
+                    if (data === undefined) {
+                        return;
+                    }
+                    setLatestXSpaceEvent(data);
+                });
+            },
+            1000 * 60 * 60
+        );
+        return () => clearInterval(interval);
+    }, [backendInMemoryConfig?.airdropApiUrl, setLatestXSpaceEvent, userDetails]);
+}
+
+async function fetchLatestXSpaceEvent(airdropApiUrl: string) {
+    const response = await fetch(`${airdropApiUrl}/miner/x-space-events/latest`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+    if (!response.ok) {
+        console.error('Fetching latest x-space-events was not successful');
+        return undefined;
+    }
+
+    const data: XSpaceEvent | null = await response.json();
+
+    return data;
+}

--- a/src/hooks/airdrop/useAirdropSyncState.ts
+++ b/src/hooks/airdrop/useAirdropSyncState.ts
@@ -1,9 +1,11 @@
 import { useAirdropTokensRefresh } from './stateHelpers/useAirdropTokensRefresh';
 import { useAirdropUserPointsListener } from './stateHelpers/useAirdropUserPointsListener';
 import { useGetReferralQuestPoints } from './stateHelpers/useGetReferralQuestPoints';
+import { useXSpaceEventRefresh } from './stateHelpers/useXSpaceEventRefresh';
 
 export const useAirdropSyncState = () => {
     useAirdropTokensRefresh();
+    useXSpaceEventRefresh();
     useAirdropUserPointsListener();
     useGetReferralQuestPoints();
 };

--- a/src/hooks/airdrop/useWebsocket.ts
+++ b/src/hooks/airdrop/useWebsocket.ts
@@ -9,6 +9,8 @@ import { useBlockchainVisualisationStore } from '@app/store/useBlockchainVisuali
 import { useAppStateStore } from '@app/store/appStateStore';
 import { MINING_EVENT_INTERVAL_MS, useShellOfSecretsStore } from '@app/store/useShellOfSecretsStore';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+import { GLOBAL_EVENT_NAME } from '@app/types/ws';
+import { useHandleWsGlobalEvent } from './ws/useHandleWsGlobalEvent';
 
 const MINING_EVENT_NAME = 'mining-status';
 
@@ -27,6 +29,8 @@ export const useWebsocket = () => {
     const appId = useAppConfigStore((state) => state.anon_id);
     const isConnectedToNetwork = useMiningMetricsStore((state) => state.isNodeConnected);
     const handleWsUserIdEvent = useHandleWsUserIdEvent();
+    const handleWsGlobalEvent = useHandleWsGlobalEvent();
+
     const [connectedSocket, setConnectedSocket] = useState(false);
     const height = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
     const applicationsVersions = useAppStateStore((state) => state.applications_versions);
@@ -114,6 +118,7 @@ export const useWebsocket = () => {
                 setConnectedSocket(true);
                 socket.emit('auth', airdropToken);
                 socket.on(userId as string, handleWsUserIdEvent);
+                socket.on(GLOBAL_EVENT_NAME, handleWsGlobalEvent);
             });
 
             socket.on('connect_error', (_e) => {

--- a/src/hooks/airdrop/ws/useHandleWsGlobalEvent.ts
+++ b/src/hooks/airdrop/ws/useHandleWsGlobalEvent.ts
@@ -1,0 +1,18 @@
+import { useAirdropStore } from '@app/store/useAirdropStore';
+import { WebsocketEventNames, WebsocketGlobalEvent } from '@app/types/ws';
+
+export const useHandleWsGlobalEvent = () => {
+    const setLatestXSpaceEvent = useAirdropStore((state) => state.setLatestXSpaceEvent);
+
+    return (event: string) => {
+        const eventParsed = JSON.parse(event) as WebsocketGlobalEvent;
+        switch (eventParsed.name) {
+            case WebsocketEventNames.X_SPACE_EVENT:
+                setLatestXSpaceEvent(eventParsed.data);
+                break;
+            default:
+                // eslint-disable-next-line no-console
+                console.log('Unknown global event', eventParsed);
+        }
+    };
+};

--- a/src/hooks/airdrop/ws/useHandleWsGlobalEvent.ts
+++ b/src/hooks/airdrop/ws/useHandleWsGlobalEvent.ts
@@ -2,13 +2,11 @@ import { useAirdropStore } from '@app/store/useAirdropStore';
 import { WebsocketEventNames, WebsocketGlobalEvent } from '@app/types/ws';
 
 export const useHandleWsGlobalEvent = () => {
-    const setLatestXSpaceEvent = useAirdropStore((state) => state.setLatestXSpaceEvent);
-
     return (event: string) => {
         const eventParsed = JSON.parse(event) as WebsocketGlobalEvent;
         switch (eventParsed.name) {
             case WebsocketEventNames.X_SPACE_EVENT:
-                setLatestXSpaceEvent(eventParsed.data);
+                useAirdropStore.setState({ latestXSpaceEvent: eventParsed.data });
                 break;
             default:
                 // eslint-disable-next-line no-console

--- a/src/hooks/airdrop/ws/useHandleWsUserIdEvent.ts
+++ b/src/hooks/airdrop/ws/useHandleWsUserIdEvent.ts
@@ -1,7 +1,7 @@
 import { useShellOfSecretsStore } from '@app/store/useShellOfSecretsStore';
 import { WebsocketEventNames, WebsocketUserEvent } from '@app/types/ws';
 import { useGetSosReferrals } from '../stateHelpers/useGetSosReferrals';
-import { setFlareAnimationType, setUserGems } from '@app/store';
+import { setFlareAnimationType, setUserGems, useAirdropStore } from '@app/store';
 
 export const useHandleWsUserIdEvent = () => {
     const setTotalBonusTimeMs = useShellOfSecretsStore((state) => state.setTotalBonusTimeMs);
@@ -50,6 +50,9 @@ export const useHandleWsUserIdEvent = () => {
                 break;
             case WebsocketEventNames.MINING_STATUS_USER_UPDATE:
                 setTotalBonusTimeMs(eventParsed.data.totalTimeBonusMs);
+                break;
+            case WebsocketEventNames.X_SPACE_EVENT:
+                useAirdropStore.setState({ latestXSpaceEvent: eventParsed.data });
                 break;
             default:
                 // eslint-disable-next-line no-console

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -82,6 +82,16 @@ export interface ReferralQuestPoints {
     pointsPerReferral: number;
     pointsForClaimingReferral: number;
 }
+
+interface XSpaceEvent {
+    start: Date;
+    end: Date;
+    displayName: string;
+    id: string;
+}
+
+//////////////////////////////////////////
+
 interface MiningPoint {
     blockHeight: string;
     reward: number;
@@ -99,6 +109,7 @@ export interface AirdropStoreState {
     bonusTiers?: BonusTier[];
     referralQuestPoints?: ReferralQuestPoints;
     miningRewardPoints?: MiningPoint;
+    latestXSpaceEvent?: XSpaceEvent;
 }
 
 const initialState: AirdropStoreState = {
@@ -110,6 +121,12 @@ const initialState: AirdropStoreState = {
     referralQuestPoints: undefined,
     bonusTiers: undefined,
     flareAnimationType: undefined,
+    latestXSpaceEvent: {
+        id: 'id',
+        start: new Date(),
+        end: new Date(),
+        displayName: 'No new events ',
+    },
 };
 
 export const useAirdropStore = create<AirdropStoreState>()(() => ({ ...initialState }));

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -109,7 +109,7 @@ export interface AirdropStoreState {
     bonusTiers?: BonusTier[];
     referralQuestPoints?: ReferralQuestPoints;
     miningRewardPoints?: MiningPoint;
-    latestXSpaceEvent?: XSpaceEvent;
+    latestXSpaceEvent?: XSpaceEvent | null;
 }
 
 const initialState: AirdropStoreState = {
@@ -121,12 +121,7 @@ const initialState: AirdropStoreState = {
     referralQuestPoints: undefined,
     bonusTiers: undefined,
     flareAnimationType: undefined,
-    latestXSpaceEvent: {
-        id: 'id',
-        start: new Date(),
-        end: new Date(),
-        displayName: 'No new events ',
-    },
+    latestXSpaceEvent: null,
 };
 
 export const useAirdropStore = create<AirdropStoreState>()(() => ({ ...initialState }));

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -1,3 +1,4 @@
+import { XSpaceEvent } from '@app/types/ws';
 import { create } from './create';
 
 export const GIFT_GEMS = 5000;
@@ -81,13 +82,6 @@ export type AnimationType = 'GoalComplete' | 'FriendAccepted' | 'BonusGems';
 export interface ReferralQuestPoints {
     pointsPerReferral: number;
     pointsForClaimingReferral: number;
-}
-
-interface XSpaceEvent {
-    start: Date;
-    end: Date;
-    displayName: string;
-    id: string;
 }
 
 //////////////////////////////////////////

--- a/src/types/ws.ts
+++ b/src/types/ws.ts
@@ -72,18 +72,6 @@ export interface UserScoreUpdate {
     };
 }
 
-export interface UserScoreUpdate {
-    name: WebsocketEventNames.USER_SCORE_UPDATE;
-    data: {
-        userId: string;
-        userPoints?: {
-            gems: number;
-            shells: number;
-            hammers: number;
-        };
-    };
-}
-
 interface XSpaceEventUpdate {
     name: WebsocketEventNames.X_SPACE_EVENT;
     data: XSpaceEvent | null;

--- a/src/types/ws.ts
+++ b/src/types/ws.ts
@@ -89,10 +89,19 @@ interface XSpaceEventUpdate {
     data: XSpaceEvent | null;
 }
 
+export enum XSpaceEventType {
+    link = 'link',
+    event = 'event',
+}
+
 export interface XSpaceEvent {
-    start: Date;
-    end: Date;
-    displayName: string;
+    text: string;
+    visibilityEnd: Date;
+    visibilityStart: Date;
+    goingLive?: Date | null;
+    link: string;
+    isVisible: boolean;
+    type: XSpaceEventType;
     id: string;
 }
 

--- a/src/types/ws.ts
+++ b/src/types/ws.ts
@@ -1,3 +1,5 @@
+export const GLOBAL_EVENT_NAME = 'global-event';
+
 export enum WebsocketEventNames {
     COMPLETED_QUEST = 'completed_quest',
     MINING_STATUS_CREW_UPDATE = 'mining_status_crew_update',
@@ -5,6 +7,7 @@ export enum WebsocketEventNames {
     REFERRAL_INSTALL_REWARD = 'referral_install_reward',
     MINING_STATUS_USER_UPDATE = 'mining_status_user_update',
     USER_SCORE_UPDATE = 'user_score_update',
+    X_SPACE_EVENT = 'x_space_event',
 }
 
 interface QuestCompletedEvent {
@@ -69,10 +72,37 @@ export interface UserScoreUpdate {
     };
 }
 
+export interface UserScoreUpdate {
+    name: WebsocketEventNames.USER_SCORE_UPDATE;
+    data: {
+        userId: string;
+        userPoints?: {
+            gems: number;
+            shells: number;
+            hammers: number;
+        };
+    };
+}
+
+interface XSpaceEventUpdate {
+    name: WebsocketEventNames.X_SPACE_EVENT;
+    data: XSpaceEvent | null;
+}
+
+export interface XSpaceEvent {
+    start: Date;
+    end: Date;
+    displayName: string;
+    id: string;
+}
+
 export type WebsocketUserEvent =
     | UserScoreUpdate
     | ReferralInstallRewardEvent
     | QuestCompletedEvent
     | MiningStatusCrewUpdateEvent
     | MiningStatusUserUpdateEvent
-    | MiningStatusCrewDisconnectedEvent;
+    | MiningStatusCrewDisconnectedEvent
+    | XSpaceEventUpdate;
+
+export type WebsocketGlobalEvent = XSpaceEventUpdate;


### PR DESCRIPTION
Description
---

Adds twitter post banner to the right top part of universe UI

How Has This Been Tested?
---


Locally, with local airdrop instance.

What process can a PR reviewer use to test or verify this change?
---

Can be tested locally connection to airdrop DEV.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new SVG icon enhancing the visual design.
	- Added a floating event banner that displays current event details, live status, and clickable links. The banner smartly handles long event titles with animated scrolling.
	- Enabled real-time updates and automatic refresh for live event information.
	- Enhanced WebSocket functionality to manage global events alongside user-specific events.
	- Expanded event handling capabilities to include new XSpace event types and structures.
	- Introduced new styled components for improved banner interface design.
	- Added a new hook to manage WebSocket global events effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->