### PR TITLE
fix: gpu devices state

### DIFF
--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -144,6 +144,11 @@ export const setGpuMiningEnabled = async (enabled: boolean) => {
                 await toggleDeviceExclusion(device.device_index, false);
             }
         }
+        if (!enabled && gpuDevices.some((device) => !device.settings.is_excluded)) {
+            for (const device of gpuDevices) {
+                await toggleDeviceExclusion(device.device_index, true);
+            }
+        }
     } catch (e) {
         console.error('Could not set GPU mining enabled', e);
         setError('Could not change GPU mining enabled');


### PR DESCRIPTION
### [ Summary ]
- Fixed the issue when disabling gpu mining didn't persisted between app restart

### [ Additional notes ]
- There was discussion about the behavior of the relation between toggling gpu devices and gpu mining
- Option one 
![image](https://github.com/user-attachments/assets/5d7fe879-98ee-4fca-89a8-bb8aba0dd37c)
 - Option two 
![image](https://github.com/user-attachments/assets/875ad11a-604e-4199-94d0-d76f847ecf30)
- We opted for option one for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved GPU mining management: When GPU mining is disabled, active GPU devices are now automatically excluded to streamline device configuration and enhance overall system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->