### PR TITLE
feat: turn off lock screen disconnects

### DIFF
--- a/src-tauri/src/utils/system_status.rs
+++ b/src-tauri/src/utils/system_status.rs
@@ -59,20 +59,12 @@ impl SystemStatus {
         if let Ok(event) = power_monitor.event_receiver().try_recv() {
             info!(target: LOG_TARGET, "Power event: {:?}", event);
             match event {
-                PowerState::ScreenLocked => {
-                    info!(target: LOG_TARGET, "Screen locked");
-                    self.sleep_mode_watcher_sender.send(true)?;
-                }
                 PowerState::Suspend => {
                     info!(target: LOG_TARGET, "Suspend");
                     self.sleep_mode_watcher_sender.send(true)?;
                 }
                 PowerState::Resume => {
                     info!(target: LOG_TARGET, "Resume");
-                    self.sleep_mode_watcher_sender.send(false)?;
-                }
-                PowerState::ScreenUnlocked => {
-                    info!(target: LOG_TARGET, "Screen unlocked");
                     self.sleep_mode_watcher_sender.send(false)?;
                 }
                 _ => {


### PR DESCRIPTION
Description
---
System was set to disconnect from network when lockscreen was applied. Lock screen should be safe to use.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated power event processing to focus on sleep and wake transitions. The system now omits notifications for screen lock and unlock events, streamlining the internal handling without affecting core suspend/resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->