### PR TITLE
fix(ui): remove wasm related csp config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "react-infinite-scroll-component": "^6.1.0",
                 "react-markdown": "^9.1.0",
                 "socket.io-client": "^4.8.1",
-                "styled-components": "^6.1.14",
+                "styled-components": "^6.1.16",
                 "use-sync-external-store": "^1.4.0",
                 "uuid": "^11.1.0",
                 "vite-tsconfig-paths": "^5.1.4",
@@ -8110,9 +8110,9 @@
             }
         },
         "node_modules/styled-components": {
-            "version": "6.1.15",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
-            "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
+            "version": "6.1.16",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.16.tgz",
+            "integrity": "sha512-KpWB6ORAWGmbWM10cDJfEV6sXc/uVkkkQV3SLwTNQ/E/PqWgNHIoMSLh1Lnk2FkB9+JHK7uuMq1i+9ArxDD7iQ==",
             "license": "MIT",
             "dependencies": {
                 "@emotion/is-prop-valid": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "react-infinite-scroll-component": "^6.1.0",
         "react-markdown": "^9.1.0",
         "socket.io-client": "^4.8.1",
-        "styled-components": "^6.1.14",
+        "styled-components": "^6.1.16",
         "use-sync-external-store": "^1.4.0",
         "uuid": "^11.1.0",
         "vite-tsconfig-paths": "^5.1.4",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,19 +35,12 @@
     },
     "app": {
         "security": {
-            "capabilities": [
-                "desktop-capability",
-                "default",
-                "migrated"
-            ],
-            "dangerousDisableAssetCspModification": [
-                "style-src"
-            ],
+            "capabilities": ["desktop-capability", "default", "migrated"],
+            "dangerousDisableAssetCspModification": ["style-src"],
             "csp": {
-                "default-src": "'self' asset: tauri: URL: blob: data: https:",
-                "script-src": "'wasm-unsafe-eval'",
+                "default-src": "'self' tauri: URL: blob: data: https:",
                 "style-src": "'self' 'unsafe-inline'",
-                "connect-src": "https: wss://ut.tari.com tauri: ipc: http://ipc.localhost https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm https://unpkg.com/@lottiefiles/dotlottie-web@0.40.1/dist/dotlottie-player.wasm data: application/octet-stream base64"
+                "connect-src": "https: wss://ut.tari.com tauri: ipc: http://ipc.localhost data: application/octet-stream base64"
             },
             "pattern": {
                 "use": "isolation",


### PR DESCRIPTION
Description
---

- bump styled-components
- remove unnecessary CSP config items 

Motivation and Context
---
- wasm CSP breaks old mac builds

How Has This Been Tested?
---

- created local builds with updates - only to ensure that it still builds as normal, i can't confirm with certainty that this resolves the issue on older macs