### PR TITLE
fix: specific CSP sources

### DIFF
--- a/docs/tauri_config/tauri_config.md
+++ b/docs/tauri_config/tauri_config.md
@@ -1,0 +1,40 @@
+# Important notes re. `tauri.conf.json`
+
+---
+
+## Security x CSP considerations
+
+### Tower Animation
+
+Because the [`@tari-project/tari-tower`](https://www.npmjs.com/package/@tari-project/tari-tower) package inlines its assets and has three.js x WebGL scripts, we need CSP sources for it.
+
+- `worker-src` enables dynamic script loading
+- `blob:`, `'application/octet-stream'`, and `base64:` sources allow inlined textures and models
+- `script-src` and `script-src-elem`
+
+---
+
+### WS connections
+
+- `connect-src` allows secure socket communication
+- `wss://ut.tari.com` specific endpoint for airdrop ws
+
+---
+
+### Using [`styled-components`](https://styled-components.com)
+
+`styled-components` has no static export, so we need CSP sources to use it - [relevant issue conversation in Tauri repo](https://github.com/tauri-apps/tauri/discussions/8578#discussioncomment-8131586)
+
+- `'unsafe-inline'` in `style-src`
+- `dangerousDisableAssetCspModification` for style injection
+
+### Twitter Profile images
+
+because we added `img-src` for images (to handle the animation's inlined assets) we need to add a source for twitter (didn't want to leave it open-ended for just any images)
+
+- `https://*.twimg.com` - Twitter profile picture domain
+
+### Others worth noting i.e. don't remove
+
+- `'self'` - Local application connections
+- `tauri:` and `ipc:` - Internal Tauri and inter-process communication

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,9 +38,25 @@
             "capabilities": ["desktop-capability", "default", "migrated"],
             "dangerousDisableAssetCspModification": ["style-src"],
             "csp": {
-                "default-src": "'self' tauri: URL: blob: data: https:",
+                "default-src": "'self' tauri: https:",
                 "style-src": "'self' 'unsafe-inline'",
-                "connect-src": "https: wss://ut.tari.com tauri: ipc: http://ipc.localhost data: application/octet-stream base64"
+                "connect-src": [
+                    "'self'",
+                    "https:",
+                    "wss://ut.tari.com",
+                    "tauri:",
+                    "ipc:",
+                    "http://ipc.localhost",
+                    "data:",
+                    "blob:",
+                    "application/octet-stream",
+                    "base64"
+                ],
+                "script-src": "'self' 'unsafe-eval'",
+                "worker-src": "'self' blob: https://cdn.npmjs.com/@tari-project/tari-tower",
+                "img-src": "'self' data: blob: base64: https://*.twimg.com https://cdn.npmjs.com/@tari-project/tari-tower",
+                "object-src": "'self' data: blob:",
+                "script-src-elem": "'self' 'unsafe-inline' 'unsafe-eval'"
             },
             "pattern": {
                 "use": "isolation",


### PR DESCRIPTION
Description
---

- updated `app.security.csp` in `tauri.conf.json` to be more specific:
  - add worker, object, script, and img sources for tower animation resource loading
  - fixed formatting for connect-src
  - clearer descriptions in [the new docs file](https://github.com/tari-project/universe/pull/1721/files#diff-3a7b982dad0c6b9082b3c3a37ee3c8f18901d32e857befff482efc0f70f2778a)

- added docs for `tauri_config` (only includes CSP info right now) thanks ClaudeAi!

Motivation and Context
---

- gems borked https://github.com/tari-project/universe/issues/1718 and csp console errors

How Has This Been Tested?
---

- multiple local builds to check each config
- used airdrop dev site urls in local builds to check gem point ws was working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a guide detailing updated security recommendations and content management practices.
  
- **Chores**
  - Enhanced overall security settings to better control dynamic asset loading and secure communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->