### PR TITLE
fix: animation block sync

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -11,7 +11,7 @@ const config: KnipConfig = {
         duplicates: 'error',
     },
     ignoreBinaries: ['commitlint'],
-    ignoreDependencies: ['babel-plugin-styled-components'], // needed by plugins
+    ignoreDependencies: ['babel-plugin-styled-components', 'prettier-eslint'], // needed by plugins and prettier for CI
     ignoreExportsUsedInFile: true,
 };
 

--- a/src/components/AdminUI/groups/OtherUIGroup.tsx
+++ b/src/components/AdminUI/groups/OtherUIGroup.tsx
@@ -20,8 +20,8 @@ export function OtherUIGroup() {
             pending_outgoing_balance: 0,
         },
     };
-    const addDummyBlocks = () => {
-        for (let i = 0; i < 1000; i++) {
+    const addDummyBlocks = (count = 1000) => {
+        for (let i = 0; i < count; i++) {
             handleNewBlock({
                 ...dummyNewBlock,
                 block_height: dummyNewBlock.block_height + i,
@@ -39,7 +39,7 @@ export function OtherUIGroup() {
                 <Button onClick={() => setShowWidget(!showWidget)} $isActive={showWidget}>
                     SoS Widget
                 </Button>
-                <Button onClick={addDummyBlocks}>Add New Dummy Blocks</Button>
+                <Button onClick={() => addDummyBlocks()}>Add New Dummy Blocks</Button>
                 <Button
                     onClick={() => setAdminShow(adminShow === 'orphanChainWarning' ? null : 'orphanChainWarning')}
                     $isActive={adminShow === 'orphanChainWarning'}

--- a/src/components/AdminUI/groups/OtherUIGroup.tsx
+++ b/src/components/AdminUI/groups/OtherUIGroup.tsx
@@ -3,12 +3,31 @@ import { useUIStore } from '@app/store/useUIStore';
 import { useShellOfSecretsStore } from '../../../store/useShellOfSecretsStore';
 import { Button, ButtonGroup, CategoryLabel } from '../styles';
 
-import { setAdminShow, setFlareAnimationType } from '@app/store';
+import { handleNewBlock, setAdminShow, setFlareAnimationType, useBlockchainVisualisationStore } from '@app/store';
 
 export function OtherUIGroup() {
     const adminShow = useUIStore((s) => s.adminShow);
     const showWidget = useShellOfSecretsStore((s) => s.showWidget);
     const setShowWidget = useShellOfSecretsStore((s) => s.setShowWidget);
+    const height = useBlockchainVisualisationStore((s) => s.displayBlockHeight);
+    const dummyNewBlock = {
+        block_height: height || 4000,
+        coinbase_transaction: undefined,
+        balance: {
+            available_balance: 333748143307,
+            timelocked_balance: 13904199881,
+            pending_incoming_balance: 0,
+            pending_outgoing_balance: 0,
+        },
+    };
+    const addDummyBlocks = () => {
+        for (let i = 0; i < 1000; i++) {
+            handleNewBlock({
+                ...dummyNewBlock,
+                block_height: dummyNewBlock.block_height + i,
+            });
+        }
+    };
 
     return (
         <>
@@ -20,6 +39,7 @@ export function OtherUIGroup() {
                 <Button onClick={() => setShowWidget(!showWidget)} $isActive={showWidget}>
                     SoS Widget
                 </Button>
+                <Button onClick={addDummyBlocks}>Add New Dummy Blocks</Button>
                 <Button
                     onClick={() => setAdminShow(adminShow === 'orphanChainWarning' ? null : 'orphanChainWarning')}
                     $isActive={adminShow === 'orphanChainWarning'}

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -126,6 +126,7 @@ export const handleWinReplay = (txItem: TransactionInfo) => {
 };
 
 let newBlockDebounceTimeout: NodeJS.Timeout | undefined = undefined;
+const BLOCK_DEBOUNCE_DELAY = 200;
 let latestBlockPayload:
     | {
           block_height: number;
@@ -171,5 +172,5 @@ export const handleNewBlock = async (payload: {
             latestBlockPayload = undefined;
         }
         newBlockDebounceTimeout = undefined;
-    }, 200);
+    }, BLOCK_DEBOUNCE_DELAY);
 };


### PR DESCRIPTION
Description
---
Fixes: #1594 
Add debounce for `handleNewBlock` to add only latest block within 200ms.

Motivation and Context
---
Sometimes app syncs during animation is active which sends lots of `New Block Height` events which causes animation to crash.

By introducing debounce we can take only take latest value which is the only relevant.

How Has This Been Tested?
---
In dev build click `Add New Dummy Blocks` in admin panel while mining. Previously this would cause animation to crash but now it should work as expected.

What process can a PR reviewer use to test or verify this change?
---
same as above

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive button that allows users to add dummy blocks, enhancing the blockchain visualization experience.

- **Refactor**
  - Optimized block processing by implementing a debouncing mechanism to ensure smooth and efficient updates during blockchain interactions.
  
- **Chores**
  - Expanded the list of ignored dependencies in the configuration to include `prettier-eslint` for CI purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->