### PR TITLE
feat: display mocked pending tx

### DIFF
--- a/src/components/transactions/history/HistoryList.tsx
+++ b/src/components/transactions/history/HistoryList.tsx
@@ -7,16 +7,20 @@ import { HistoryListItem } from './ListItem.tsx';
 import { initialFetchTxs, fetchTransactionsHistory } from '@app/store';
 import { useTranslation } from 'react-i18next';
 import { Typography } from '@app/components/elements/Typography.tsx';
+import { TransactionInfo } from '@app/types/app-status.ts';
 
 const HistoryList = () => {
     const { t } = useTranslation('wallet', { useSuspense: false });
     const is_transactions_history_loading = useWalletStore((s) => s.is_transactions_history_loading);
     const transactions = useWalletStore((s) => s.transactions);
+    const pendingTransactions = useWalletStore((s) => s.pending_transactions);
     const hasMore = useWalletStore((s) => s.has_more_transactions);
 
     useEffect(() => {
         initialFetchTxs();
     }, []);
+
+    const combinedTransactions = [...pendingTransactions, ...transactions] as TransactionInfo[];
 
     const handleNext = useCallback(async () => {
         if (!is_transactions_history_loading) {
@@ -26,18 +30,18 @@ const HistoryList = () => {
 
     return (
         <ListWrapper id="list">
-            {!is_transactions_history_loading && !transactions?.length && (
+            {!is_transactions_history_loading && !combinedTransactions?.length && (
                 <Typography variant="h6">{t('empty-tx')}</Typography>
             )}
             <InfiniteScroll
-                dataLength={transactions?.length || 0}
+                dataLength={combinedTransactions?.length || 0}
                 next={handleNext}
                 hasMore={hasMore}
                 loader={<CircularProgress />}
                 scrollableTarget="list"
             >
                 <ListItemWrapper>
-                    {transactions.map((tx, index) => (
+                    {combinedTransactions.map((tx, index) => (
                         <HistoryListItem key={tx.tx_id} item={tx} index={index} />
                     ))}
                 </ListItemWrapper>

--- a/src/components/transactions/history/ListItem.styles.ts
+++ b/src/components/transactions/history/ListItem.styles.ts
@@ -30,12 +30,24 @@ export const ContentWrapper = styled.div`
     place-items: stretch;
     justify-content: stretch;
     width: 100%;
-
     grid-template-areas:
-        'title . earnings'
-        'time . earnings';
+        'status title . earnings'
+        'status time . earnings';
+    grid-template-columns: auto 1fr auto 1fr;
 `;
-
+export const StatusWrapper = styled.div`
+    grid-area: status;
+    display: flex;
+    align-items: center;
+    margin-right: 8px;
+`;
+export const CircularProgressWrapper = styled.div`
+    height: 25px;
+    width: 25px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
 export const TitleWrapper = styled(Typography)`
     display: flex;
     color: ${({ theme }) => theme.palette.text.primary};

--- a/src/components/transactions/history/ListItem.tsx
+++ b/src/components/transactions/history/ListItem.tsx
@@ -14,17 +14,29 @@ import {
     ValueChangeWrapper,
     ValueWrapper,
     CurrencyText,
+    StatusWrapper,
+    CircularProgressWrapper,
 } from './ListItem.styles.ts';
 import { useUIStore } from '@app/store';
+import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
+import { TransactionStatus } from '@app/types/transactions.ts';
 
-const BaseItem = memo(function BaseItem({ title, time, value, type, chip, onClick }: BaseItemProps) {
+const BaseItem = memo(function BaseItem({ title, time, value, type, chip, status, onClick }: BaseItemProps) {
     // note re. isPositiveValue:
     // amounts in the tx response are always positive numbers but
     // if the transaction type is 'sent' it must be displayed as a negative amount, with a leading `-`
     const isPositiveValue = type !== 'sent';
+    const isPending = status === TransactionStatus.Broadcast;
     const displayTitle = title.length > 30 ? truncateMiddle(title, 8) : title;
     return (
         <ContentWrapper onClick={onClick}>
+            <StatusWrapper>
+                {isPending && (
+                    <CircularProgressWrapper>
+                        <CircularProgress />
+                    </CircularProgressWrapper>
+                )}
+            </StatusWrapper>
             <TitleWrapper title={title}>{displayTitle}</TitleWrapper>
             <TimeWrapper variant="p">{time}</TimeWrapper>
             <ValueWrapper>
@@ -82,7 +94,14 @@ const HistoryListItem = memo(function ListItem({ item, index }: HistoryListItemP
     }
 
     const baseItem = (
-        <BaseItem title={itemTitle} time={itemTime} value={earningsFormatted} type={itemType} onClick={handleTxClick} />
+        <BaseItem
+            title={itemTitle}
+            time={itemTime}
+            value={earningsFormatted}
+            type={itemType}
+            status={item?.status}
+            onClick={handleTxClick}
+        />
     );
     const itemHover = isMined ? <ItemHover item={item} /> : null;
     const itemExpand = !isMined ? <ItemExpand item={item} /> : null;

--- a/src/components/transactions/send/Send.tsx
+++ b/src/components/transactions/send/Send.tsx
@@ -5,7 +5,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useForm } from 'react-hook-form';
 import { FaArrowDown } from 'react-icons/fa6';
 
-import { setError as setStoreError } from '@app/store';
+import { addPendingTransaction, setError as setStoreError } from '@app/store';
 
 import { Button } from '@app/components/elements/buttons/Button.tsx';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
@@ -79,11 +79,14 @@ export function Send() {
     const handleSend = useCallback(
         async (data: SendInputs) => {
             try {
-                await invoke('send_one_sided_to_stealth_address', {
+                const payload = {
                     amount: data.amount,
                     destination: data.address,
                     paymentId: data.message,
-                });
+                };
+                await invoke('send_one_sided_to_stealth_address', payload);
+
+                addPendingTransaction(payload);
             } catch (error) {
                 setStoreError(`Error sending transaction: ${error}`);
                 setError(`root.invoke_error`, {

--- a/src/components/transactions/types.ts
+++ b/src/components/transactions/types.ts
@@ -13,5 +13,6 @@ export interface BaseItemProps {
     time: string;
     value: string;
     chip?: string;
+    status?: number;
     onClick?: () => void;
 }

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -1,6 +1,16 @@
 import { create } from './create';
 import { TransactionInfo, WalletBalance } from '../types/app-status.ts';
 
+interface PendingTransaction {
+    tx_id: number;
+    amount: number;
+    dest_address: string;
+    payment_id: string;
+    direction: number;
+    status: number;
+    timestamp: number;
+}
+
 interface WalletStoreState {
     tari_address_base58: string;
     tari_address_emoji: string;
@@ -8,6 +18,7 @@ interface WalletStoreState {
     calculated_balance?: number;
     coinbase_transactions: TransactionInfo[];
     transactions: TransactionInfo[];
+    pending_transactions: PendingTransaction[];
     is_reward_history_loading: boolean;
     has_more_coinbase_transactions: boolean;
     has_more_transactions: boolean;
@@ -20,6 +31,7 @@ const initialState: WalletStoreState = {
     tari_address_emoji: '',
     coinbase_transactions: [],
     transactions: [],
+    pending_transactions: [],
     has_more_coinbase_transactions: true,
     has_more_transactions: true,
     is_reward_history_loading: false,
@@ -30,3 +42,36 @@ const initialState: WalletStoreState = {
 export const useWalletStore = create<WalletStoreState>()(() => ({
     ...initialState,
 }));
+
+// Temporary solution until we use excess_sig to track pending transactions
+export const addPendingTransaction = (payload: { amount: string; destination: string; paymentId: string }) => {
+    const transaction: PendingTransaction = {
+        tx_id: Date.now(),
+        amount: Number(payload.amount.replace(/[Tt]$/, '000000')),
+        dest_address: payload.destination,
+        payment_id: payload.paymentId,
+        direction: 2,
+        status: 1,
+        timestamp: Date.now(),
+    };
+
+    useWalletStore.setState((state) => ({
+        pending_transactions: [transaction, ...state.pending_transactions],
+    }));
+};
+
+export const refreshPendingTransactions = () => {
+    useWalletStore.setState((state) => {
+        // Filter out pending transactions that have matching confirmed transactions
+        const updatedPendingTransactions = state.pending_transactions.filter((pending) => {
+            const isConfirmed = state.transactions.some(
+                (tx) => tx.amount === pending.amount && tx.payment_id === pending.payment_id
+            );
+            return !isConfirmed;
+        });
+
+        return {
+            pending_transactions: updatedPendingTransactions,
+        };
+    });
+};

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,6 +1,8 @@
 // from tari.rpc.rs - only the enum members we use for now
 
 export enum TransactionStatus {
+    // This transaction has been broadcast to the base layer network and is currently in one or more base node mempools.
+    Broadcast = 1,
     /// This transaction is mined and confirmed at the current base node's height
     MinedConfirmed = 6,
     /// This is faux transaction mainly for one-sided transaction outputs or wallet recovery outputs have been found


### PR DESCRIPTION
Description
---
For the first iteration, display mocked pending transaction which is replaced with the corresponding tx when it's mined.

![image](https://github.com/user-attachments/assets/9423a5c7-8d8f-478c-bb9f-a16f8e154f16)

Screencast:

https://github.com/user-attachments/assets/13c6e77b-5e33-4f09-92b8-a5fa9148ff24

