### PR TITLE
fix(ui): twitter space copy colour

### DIFF
--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,6 +1,8 @@
 import * as m from 'motion/react-m';
 import styled from 'styled-components';
 
+// don't need theming for this file as the colours are the same in dark/light mode (black and white)
+
 export const BannerContent = styled(m.div)`
     position: fixed;
     top: 16px;
@@ -12,7 +14,7 @@ export const BannerContent = styled(m.div)`
     border-radius: 9999px;
     max-width: 30rem;
     background-color: #000;
-    color: ${({ theme }) => theme.palette.background.default};
+    color: #fff;
     cursor: pointer;
     pointer-events: all;
     &:hover {

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -1,14 +1,13 @@
-// import { X } from 'lucide-react';
 import { useAirdropStore } from '@app/store/useAirdropStore';
 import {
     BannerContent,
-    IconContainer,
     FlexWrapper,
+    IconContainer,
     LiveBadgePoint,
-    TimeBadge,
-    Title,
     LiveBadgeText,
     LiveBadgeWrapper,
+    TimeBadge,
+    Title,
     TitleContainer,
 } from './XSpaceBanner.style';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -37,10 +36,9 @@ const XSpaceEventBanner = () => {
 
             if (!latestXSpaceEvent.goingLive || latestXSpaceEvent.type !== XSpaceEventType.event) return;
             const currentDate = new Date();
-            setIsLive(
-                new Date(latestXSpaceEvent.visibilityEnd) >= currentDate &&
-                    new Date(latestXSpaceEvent.goingLive) <= currentDate
-            );
+            const visibilityDate = new Date(latestXSpaceEvent.visibilityEnd);
+            const goLiveDate = new Date(latestXSpaceEvent.goingLive);
+            setIsLive(visibilityDate >= currentDate && goLiveDate <= currentDate);
         };
 
         checkVisibility();
@@ -61,7 +59,7 @@ const XSpaceEventBanner = () => {
         if (!latestXSpaceEvent || isLive || !latestXSpaceEvent.goingLive) {
             return undefined;
         }
-        const dateFormatted = new Date(latestXSpaceEvent.goingLive)
+        return new Date(latestXSpaceEvent.goingLive)
             .toLocaleString('en-US', {
                 month: 'short',
                 day: 'numeric',
@@ -71,7 +69,6 @@ const XSpaceEventBanner = () => {
             })
             .replace(', ', ' @')
             .toUpperCase();
-        return dateFormatted;
     }, [latestXSpaceEvent, isLive]);
 
     if (!latestXSpaceEvent || !isVisible) {


### PR DESCRIPTION
Description
---

- fix banner text colour + added comment about styling not needing theming for the black and white styles
- small readability tweaks in date checks

Motivation and Context
---
- https://github.com/tari-project/universe/issues/1728

How Has This Been Tested?
---

locally: 

| dork mode| lit mode |
| --- | --- |
| ![Screenshot 2025-04-07 at 12 46 05](https://github.com/user-attachments/assets/e966ca77-cb72-4422-8bb2-47192231bc7e) | ![Screenshot 2025-04-07 at 12 46 31](https://github.com/user-attachments/assets/574cdb60-729a-491e-8147-6a7ba2502cff) |
| ![Screenshot 2025-04-07 at 12 47 08](https://github.com/user-attachments/assets/4c25d25b-9624-4d32-bbe9-082fb9d86029) | ![Screenshot 2025-04-07 at 12 47 17](https://github.com/user-attachments/assets/2cead3b6-e13f-4e73-aec4-4a145d70d5bd) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted banner appearance to use a static color for a consistent look in both dark and light modes.
  
- **Refactor**
  - Streamlined the logic for determining live status and formatting dates for events, enhancing code clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->