### PR TITLE
chore(quick load): address validation command

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -43,6 +43,7 @@ use crate::p2pool::models::{Connections, P2poolStats};
 use crate::progress_tracker_old::ProgressTracker;
 use crate::tasks_tracker::TasksTrackers;
 use crate::tor_adapter::TorConfig;
+use crate::utils::address_utils::verify_send;
 use crate::utils::app_flow_utils::FrontendReadyChannel;
 use crate::wallet_adapter::TransactionInfo;
 use crate::wallet_manager::WalletManagerError;
@@ -61,6 +62,7 @@ use std::sync::atomic::Ordering;
 use std::thread::{available_parallelism, sleep};
 use std::time::{Duration, Instant, SystemTime};
 use tari_common::configuration::Network;
+use tari_common_types::tari_address::TariAddressFeatures;
 use tauri::ipc::InvokeError;
 use tauri::{Manager, PhysicalPosition, PhysicalSize};
 use tauri_plugin_sentry::sentry;
@@ -1804,4 +1806,14 @@ pub async fn send_one_sided_to_stealth_address(
         warn!(target: LOG_TARGET, "send_one_sided_to_stealth_address took too long: {:?}", timer.elapsed());
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn verify_address_for_send(
+    address: String,
+    sending_method: Option<TariAddressFeatures>,
+) -> Result<(), String> {
+    let sending_method = sending_method.unwrap_or(TariAddressFeatures::ONE_SIDED);
+
+    verify_send(address, sending_method)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1368,6 +1368,7 @@ fn main() {
             commands::set_selected_engine,
             commands::frontend_ready,
             commands::send_one_sided_to_stealth_address,
+            commands::verify_address_for_send,
         ])
         .build(tauri::generate_context!())
         .inspect_err(

--- a/src-tauri/src/utils/address_utils.rs
+++ b/src-tauri/src/utils/address_utils.rs
@@ -71,14 +71,20 @@ mod tests {
     fn test_verify_tari_address_invalid_format() {
         let result = verify_tari_address("invalid_address");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Invalid address format");
+        match result {
+            Err(e) => assert_eq!(e, "Invalid address format"),
+            _ => panic!("Expected an error but got success"),
+        }
     }
 
     #[test]
     fn test_verify_tari_address_invalid_network() {
         let result = verify_tari_address(NEXTNET_ONE_SIDED_ADDRESSS);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Invalid network");
+        match result {
+            Err(e) => assert_eq!(e, "Invalid network"),
+            _ => panic!("Expected an error but got success"),
+        }
     }
 
     #[test]
@@ -120,9 +126,10 @@ mod tests {
         let sending_method = TariAddressFeatures::INTERACTIVE;
         let result = verify_send(ESME_ONE_SIDED_ADDRESS.to_string(), sending_method);
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            "Address does not support feature Interactive,"
-        );
+
+        match result {
+            Err(e) => assert_eq!(e, "Address does not support feature Interactive,"),
+            _ => panic!("Expected an error but got success"),
+        }
     }
 }

--- a/src-tauri/src/utils/address_utils.rs
+++ b/src-tauri/src/utils/address_utils.rs
@@ -1,0 +1,128 @@
+// Copyright 2025. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::str::FromStr;
+use tari_common::configuration::Network;
+use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
+
+pub fn verify_tari_address(address: &str) -> Result<TariAddress, String> {
+    let tari_address =
+        TariAddress::from_str(address).map_err(|_| "Invalid address format".to_string())?;
+    println!(
+        "aaaaaaappp {:?}",
+        Network::get_current_or_user_setting_or_default()
+    );
+    if tari_address.network() != Network::get_current_or_user_setting_or_default() {
+        return Err("Invalid network".to_string());
+    }
+    Ok(tari_address)
+}
+
+pub fn verify_send(address: String, sending_method: TariAddressFeatures) -> Result<(), String> {
+    let tari_address = verify_tari_address(&address)?;
+
+    if !tari_address.features().contains(sending_method) {
+        return Err(format!(
+            "Address does not support feature {}",
+            sending_method
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ESME_ONE_SIDED_ADDRESS: &str = "f25eNHz2YnBVKHaqNuacGyDFB321RwwCnTr4vb2SjQCgDZVXyNNthc7zftQKRDu6evLjvSUD8W5akpPMdhS4HQ9kF3g";
+    const ESME_INTERACTIVE_ADDRESS: &str = "f45eNHz2YnBVKHaqNuacGyDFB321RwwCnTr4vb2SjQCgDZVXyNNthc7zftQKRDu6evLjvSUD8W5akpPMdhS4HQ9kF31";
+    const ESME_INTERACTIVE_EMOJI_ADDRESS: &str = "🍗🌊😇🦀🚽💈🎠🍚🦂🌕🎩💨👂🏰📜👞🎵🐬🐚💄🚨🔋🐀🐯💻👗🐊👠🦀🐝🚦🍌🎋🎼🍗🎮🎉👗🐮🎨👾🔧🤖💋🐾💨🎃🍀🦂🐀🐬🔱🥝👕🎳⏰🎃🐉💍🙈🍉🔱🎣🐢👒🍊👅";
+    const ESME_ONE_SIDED_EMOJI_ADDRESS: &str = "🍗📟😇🦀🚽💈🎠🍚🦂🌕🎩💨👂🏰📜👞🎵🐬🐚💄🚨🔋🐀🐯💻👗🐊👠🦀🐝🚦🍌🎋🎼🍗🎮🎉👗🐮🎨👾🔧🤖💋🐾💨🎃🍀🦂🐀🐬🔱🥝👕🎳⏰🎃🐉💍🙈🍉🔱🎣🐢👒🍊💦";
+    const NEXTNET_ONE_SIDED_ADDRESSS: &str = "32FZ9MmtkbcxNwF1Qia1RykS2i3ycaJC5er32xaFi1fpkNKjKvVo6VFPKjoigSME76EmsaDPZLXu2e3ivp5MWSU54j1";
+
+    #[test]
+    fn test_verify_tari_address_valid() {
+        assert!(verify_tari_address(ESME_ONE_SIDED_ADDRESS).is_ok());
+        assert!(verify_tari_address(ESME_INTERACTIVE_ADDRESS).is_ok());
+        assert!(verify_tari_address(ESME_INTERACTIVE_EMOJI_ADDRESS).is_ok());
+        assert!(verify_tari_address(ESME_ONE_SIDED_EMOJI_ADDRESS).is_ok());
+    }
+
+    #[test]
+    fn test_verify_tari_address_invalid_format() {
+        let result = verify_tari_address("invalid_address");
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), "Invalid address format");
+    }
+
+    #[test]
+    fn test_verify_tari_address_invalid_network() {
+        let result = verify_tari_address(NEXTNET_ONE_SIDED_ADDRESSS);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), "Invalid network");
+    }
+
+    #[test]
+    fn test_verify_send_valid() {
+        assert!(verify_send(
+            ESME_ONE_SIDED_ADDRESS.to_string(),
+            TariAddressFeatures::ONE_SIDED,
+        )
+        .is_ok());
+        assert!(verify_send(
+            ESME_ONE_SIDED_EMOJI_ADDRESS.to_string(),
+            TariAddressFeatures::ONE_SIDED,
+        )
+        .is_ok());
+        assert!(verify_send(
+            ESME_INTERACTIVE_ADDRESS.to_string(),
+            TariAddressFeatures::ONE_SIDED,
+        )
+        .is_ok());
+        assert!(verify_send(
+            ESME_INTERACTIVE_EMOJI_ADDRESS.to_string(),
+            TariAddressFeatures::ONE_SIDED,
+        )
+        .is_ok());
+        assert!(verify_send(
+            ESME_INTERACTIVE_ADDRESS.to_string(),
+            TariAddressFeatures::INTERACTIVE,
+        )
+        .is_ok());
+        assert!(verify_send(
+            ESME_INTERACTIVE_EMOJI_ADDRESS.to_string(),
+            TariAddressFeatures::INTERACTIVE,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_send_invalid_feature() {
+        let sending_method = TariAddressFeatures::INTERACTIVE;
+        let result = verify_send(ESME_ONE_SIDED_ADDRESS.to_string(), sending_method);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            "Address does not support feature Interactive,"
+        );
+    }
+}

--- a/src-tauri/src/utils/address_utils.rs
+++ b/src-tauri/src/utils/address_utils.rs
@@ -27,10 +27,6 @@ use tari_common_types::tari_address::{TariAddress, TariAddressFeatures};
 pub fn verify_tari_address(address: &str) -> Result<TariAddress, String> {
     let tari_address =
         TariAddress::from_str(address).map_err(|_| "Invalid address format".to_string())?;
-    println!(
-        "aaaaaaappp {:?}",
-        Network::get_current_or_user_setting_or_default()
-    );
     if tari_address.network() != Network::get_current_or_user_setting_or_default() {
         return Err("Invalid network".to_string());
     }

--- a/src-tauri/src/utils/address_utils.rs
+++ b/src-tauri/src/utils/address_utils.rs
@@ -71,14 +71,14 @@ mod tests {
     fn test_verify_tari_address_invalid_format() {
         let result = verify_tari_address("invalid_address");
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap(), "Invalid address format");
+        assert_eq!(result.unwrap_err(), "Invalid address format");
     }
 
     #[test]
     fn test_verify_tari_address_invalid_network() {
         let result = verify_tari_address(NEXTNET_ONE_SIDED_ADDRESSS);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap(), "Invalid network");
+        assert_eq!(result.unwrap_err(), "Invalid network");
     }
 
     #[test]
@@ -121,7 +121,7 @@ mod tests {
         let result = verify_send(ESME_ONE_SIDED_ADDRESS.to_string(), sending_method);
         assert!(result.is_err());
         assert_eq!(
-            result.err().unwrap(),
+            result.unwrap_err(),
             "Address does not support feature Interactive,"
         );
     }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+pub mod address_utils;
 pub mod app_flow_utils;
 pub mod file_utils;
 pub mod formatting_utils;
@@ -29,7 +30,6 @@ pub mod macos_utils;
 pub mod math_utils;
 pub mod network_status;
 pub mod platform_utils;
-pub mod address_utils;
 
 pub mod system_status;
 #[cfg(windows)]

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -29,6 +29,7 @@ pub mod macos_utils;
 pub mod math_utils;
 pub mod network_status;
 pub mod platform_utils;
+pub mod address_utils;
 
 pub mod system_status;
 #[cfg(windows)]

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -104,4 +104,8 @@ declare module '@tauri-apps/api/core' {
         payload: { level: 'log' | 'error' | 'warn' | 'info'; message: string }
     ): Promise<ApplicationsVersions>;
     function invoke(param: 'sign_ws_data', payload: { data: string }): Promise<SignData>;
+    function invoke(
+        param: 'verify_address_for_send',
+        payload: { address: string; sendingMethod?: number }
+    ): Promise<void>;
 }


### PR DESCRIPTION
Address validation method for send 

```
try {
    await invoke('verify_address_for_send', {address});
console.log("address validated");
} catch (error) {
    console.error('Error verifying address:', error);
}
```
