### PR TITLE
fix(update): update called multiple times

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -186,6 +186,13 @@ pub async fn close_splashscreen(app: tauri::AppHandle) {
 
 #[tauri::command]
 pub async fn frontend_ready(app: tauri::AppHandle) {
+    static FRONTEND_READY_CALLED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+    if FRONTEND_READY_CALLED.load(Ordering::SeqCst) {
+        return;
+    }
+    FRONTEND_READY_CALLED.store(true, Ordering::SeqCst);
+
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         let state = app_handle.state::<UniverseAppState>().clone();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -312,11 +312,6 @@ async fn setup_inner(
         return Ok(());
     }
 
-    state
-        .updates_manager
-        .init_periodic_updates(app.clone())
-        .await?;
-
     let data_dir = app
         .path()
         .app_local_data_dir()

--- a/src-tauri/src/updates_manager.rs
+++ b/src-tauri/src/updates_manager.rs
@@ -92,14 +92,18 @@ impl UpdatesManager {
     pub async fn init_periodic_updates(&self, app: tauri::AppHandle) -> Result<(), anyhow::Error> {
         let app_clone = app.clone();
         let self_clone = self.clone();
+
         tauri::async_runtime::spawn(async move {
             let mut interval = time::interval(Duration::from_secs(3600));
+
             loop {
                 if self_clone.app_shutdown.is_triggered() && self_clone.app_shutdown.is_triggered()
                 {
                     break;
                 };
+
                 interval.tick().await;
+
                 if let Err(e) = self_clone.try_update(app_clone.clone(), false, false).await {
                     error!(target: LOG_TARGET, "Error checking for updates: {:?}", e);
                 }


### PR DESCRIPTION
Description
---
try_update was called mupltiple times due to bad merge or something

```
2025-04-02 08:34:50.049086300 INFO  try_update: Update available: "0.9.834" // src\updates_manager.rs:121
2025-04-02 08:34:50.049155500 INFO  try_update: Auto update is enabled. Proceeding with update // src\updates_manager.rs:137
2025-04-02 08:34:50.057237700 INFO  try_update: Update available: "0.9.834" // src\updates_manager.rs:121
2025-04-02 08:34:50.057298300 INFO  try_update: Auto update is enabled. Proceeding with update // src\updates_manager.rs:137
```

* I removed redundant `init_periodic_updates` from `setup_inner` method since it was removed from there some time ago.
* Ensure we handle `FRONTEND_READY` event once on the backend(react dev mode always triggers it twice)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated startup routines to ensure key operations execute only once, enhancing overall stability.
  
- **Chores**
  - Removed the automatic periodic update feature from the initial setup.
  - Improved error reporting during the update process for better diagnostic visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->