### PR TITLE
fix: tor bridges error handling

### DIFF
--- a/public/locales/af/settings.json
+++ b/public/locales/af/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Aansoek Inligting",
   "applyInviteCode": "Pas Uitnodigingskode Toe",
   "cancel": "Cancel",
-  "gpu-engine": "Gpu Enjin",
   "change-language": "Verander taal",
   "confirm": "Bevestig",
   "confirm-action": "Bevestig aksie",
@@ -30,6 +29,7 @@
   "debug-info": "Ontfoutingsinligting",
   "disconnect": "Ontkoppel van Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Brugkonfigurasie is ongeldig",
     "invalid-control-port": "Beheerpoort konfigurasie is ongeldig"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU Myn toestelle",
   "gpu-device-enabled-description": "Aktiveer of deaktiveer spesifieke GPU toestel.",
   "gpu-device-no-found": "⚠️ Geen GPU toestelle gevind nie",
+  "gpu-engine": "Gpu Enjin",
   "gpu-mining-enabled": "GPU Mynbou",
   "gpu-unavailable": "⚠️ GPU gedeaktiveer omdat jou hardeware dit nie ondersteun nie",
   "hardware-status": "Hardeware status",

--- a/public/locales/cn/settings.json
+++ b/public/locales/cn/settings.json
@@ -5,7 +5,6 @@
   "application-info": "应用信息",
   "applyInviteCode": "应用邀请代码",
   "cancel": "取消",
-  "gpu-engine": "Gpu 引擎",
   "change-language": "更改语言",
   "confirm": "确认",
   "confirm-action": "确认操作",
@@ -30,6 +29,7 @@
   "debug-info": "调试信息",
   "disconnect": "断开与空投的连接",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "桥接配置无效",
     "invalid-control-port": "控制端口配置无效"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU 挖矿设备",
   "gpu-device-enabled-description": "启用或禁用特定的 GPU 设备。",
   "gpu-device-no-found": "⚠️ 未找到 GPU 设备",
+  "gpu-engine": "Gpu 引擎",
   "gpu-mining-enabled": "GPU 挖矿",
   "gpu-unavailable": "⚠️ GPU已禁用，因为您的硬件不支持",
   "hardware-status": "硬件状态",

--- a/public/locales/de/settings.json
+++ b/public/locales/de/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Anwendungsinformationen",
   "applyInviteCode": "Einladungscode anwenden",
   "cancel": "Abbrechen",
-  "gpu-engine": "GPU-Engine",
   "change-language": "Sprache",
   "confirm": "Bestätigen",
   "confirm-action": "Aktion bestätigen",
@@ -30,6 +29,7 @@
   "debug-info": "Debuggen",
   "disconnect": "Von Airdrop trennen",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Bridge-Konfiguration ist ungültig",
     "invalid-control-port": "Steuerport-Konfiguration ist ungültig"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU-Mining-Geräte",
   "gpu-device-enabled-description": "Bestimmtes GPU-Gerät aktivieren oder deaktivieren.",
   "gpu-device-no-found": "⚠️ Keine GPU-Geräte gefunden",
+  "gpu-engine": "GPU-Engine",
   "gpu-mining-enabled": "GPU-Mining",
   "gpu-unavailable": "⚠️ GPU deaktiviert, da deine Hardware dies nicht unterstützt",
   "hardware-status": "Hardware-Status",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Application Information",
   "applyInviteCode": "Apply Invite Code",
   "cancel": "Cancel",
-  "gpu-engine": "Gpu Engine",
   "change-language": "Language",
   "confirm": "Confirm",
   "confirm-action": "Confirm action",
@@ -30,6 +29,7 @@
   "debug-info": "Debug",
   "disconnect": "Disconnect from Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Bridge configuration is invalid",
     "invalid-control-port": "Control Port configuration is invalid"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU Mining devices",
   "gpu-device-enabled-description": "Enable or disable specific GPU device.",
   "gpu-device-no-found": "⚠️ No GPU devices found",
+  "gpu-engine": "Gpu Engine",
   "gpu-mining-enabled": "GPU Mining",
   "gpu-unavailable": "⚠️ GPU disabled because your hardware does not support it",
   "hardware-status": "Hardware status",

--- a/public/locales/fr/settings.json
+++ b/public/locales/fr/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informations sur l\"application",
   "applyInviteCode": "Appliquer le code d\"invitation",
   "cancel": "Cancel",
-  "gpu-engine": "Moteur GPU",
   "change-language": "Langue",
   "confirm": "Confirmer",
   "confirm-action": "Confirmer l\"action",
@@ -30,6 +29,7 @@
   "debug-info": "Déboguer",
   "disconnect": "Se déconnecter de l\"Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "La configuration du pont est invalide",
     "invalid-control-port": "La configuration du port de contrôle est invalide"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "Appareils de minage GPU",
   "gpu-device-enabled-description": "Activer ou désactiver un appareil GPU spécifique.",
   "gpu-device-no-found": "⚠️ Aucun appareil GPU trouvé",
+  "gpu-engine": "Moteur GPU",
   "gpu-mining-enabled": "Minage GPU",
   "gpu-unavailable": "⚠️ GPU désactivé car votre matériel ne le supporte pas",
   "hardware-status": "État du matériel",

--- a/public/locales/hi/settings.json
+++ b/public/locales/hi/settings.json
@@ -5,7 +5,6 @@
   "application-info": "एप्लिकेशन जानकारी",
   "applyInviteCode": "आमंत्रण कोड लागू करें",
   "cancel": "रद्द करें",
-  "gpu-engine": "जीपीयू इंजन",
   "change-language": "भाषा",
   "confirm": "पुष्टि करें",
   "confirm-action": "क्रिया की पुष्टि करें",
@@ -30,6 +29,7 @@
   "debug-info": "डीबग",
   "disconnect": "एयरड्रॉप से डिस्कनेक्ट करें",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "ब्रिज कॉन्फ़िगरेशन अमान्य है",
     "invalid-control-port": "कंट्रोल पोर्ट कॉन्फ़िगरेशन अमान्य है"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU माइनिंग डिवाइस",
   "gpu-device-enabled-description": "विशिष्ट GPU डिवाइस को सक्षम या अक्षम करें।",
   "gpu-device-no-found": "⚠️ कोई GPU डिवाइस नहीं मिला",
+  "gpu-engine": "जीपीयू इंजन",
   "gpu-mining-enabled": "जीपीयू माइनिंग",
   "gpu-unavailable": "⚠️ जीपीयू अक्षम है क्योंकि आपका हार्डवेयर इसे समर्थन नहीं करता",
   "hardware-status": "हार्डवेयर स्थिति",

--- a/public/locales/id/settings.json
+++ b/public/locales/id/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informasi Aplikasi",
   "applyInviteCode": "Terapkan Kode Undangan",
   "cancel": "Batal",
-  "gpu-engine": "Mesin Gpu",
   "change-language": "Bahasa",
   "confirm": "Konfirmasi",
   "confirm-action": "Konfirmasi tindakan",
@@ -30,6 +29,7 @@
   "debug-info": "Debug",
   "disconnect": "Putuskan dari Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Konfigurasi jembatan tidak valid",
     "invalid-control-port": "Konfigurasi Port Kontrol tidak valid"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "Perangkat Penambangan GPU",
   "gpu-device-enabled-description": "Aktifkan atau nonaktifkan perangkat GPU tertentu.",
   "gpu-device-no-found": "⚠️ Tidak ada perangkat GPU yang ditemukan",
+  "gpu-engine": "Mesin Gpu",
   "gpu-mining-enabled": "Penambangan GPU",
   "gpu-unavailable": "⚠️ GPU dinonaktifkan karena perangkat keras Anda tidak mendukungnya",
   "hardware-status": "Status perangkat keras",

--- a/public/locales/ja/settings.json
+++ b/public/locales/ja/settings.json
@@ -5,7 +5,6 @@
   "application-info": "アプリケーション情報",
   "applyInviteCode": "招待コードを適用",
   "cancel": "キャンセル",
-  "gpu-engine": "GPUエンジン",
   "change-language": "言語",
   "confirm": "確認",
   "confirm-action": "アクションを確認",
@@ -30,6 +29,7 @@
   "debug-info": "デバッグ",
   "disconnect": "エアドロップから切断",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "ブリッジ設定が無効です",
     "invalid-control-port": "コントロールポートの設定が無効です"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPUマイニングデバイス",
   "gpu-device-enabled-description": "特定のGPUデバイスを有効または無効にします。",
   "gpu-device-no-found": "⚠️ GPUデバイスが見つかりません",
+  "gpu-engine": "GPUエンジン",
   "gpu-mining-enabled": "GPUマイニング",
   "gpu-unavailable": "⚠️ ハードウェアがサポートしていないため、GPUが無効です",
   "hardware-status": "ハードウェアの状態",

--- a/public/locales/ko/settings.json
+++ b/public/locales/ko/settings.json
@@ -5,7 +5,6 @@
   "application-info": "애플리케이션 정보",
   "applyInviteCode": "초대 코드 적용",
   "cancel": "취소",
-  "gpu-engine": "GPU 엔진",
   "change-language": "언어",
   "confirm": "확인",
   "confirm-action": "작업 확인",
@@ -30,6 +29,7 @@
   "debug-info": "디버그",
   "disconnect": "에어드롭 연결 해제",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "브리지 구성 설정이 잘못되었습니다",
     "invalid-control-port": "제어 포트 구성 설정이 잘못되었습니다"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU 채굴 장치",
   "gpu-device-enabled-description": "특정 GPU 장치를 활성화하거나 비활성화합니다.",
   "gpu-device-no-found": "⚠️ GPU 장치를 찾을 수 없습니다",
+  "gpu-engine": "GPU 엔진",
   "gpu-mining-enabled": "GPU 채굴",
   "gpu-unavailable": "⚠️ 하드웨어가 지원하지 않아 GPU가 비활성화되었습니다",
   "hardware-status": "하드웨어 상태",

--- a/public/locales/pl/settings.json
+++ b/public/locales/pl/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informacje o aplikacji",
   "applyInviteCode": "Zastosuj Kod Zaproszenia",
   "cancel": "Anuluj",
-  "gpu-engine": "Silnik GPU",
   "change-language": "Zmień język",
   "confirm": "Potwierdź",
   "confirm-action": "Potwierdź działanie",
@@ -31,6 +30,7 @@
   "debug-info": "Informacje debugowania",
   "disconnect": "Odłącz od Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Konfiguracja mostu jest nieprawidłowa",
     "invalid-control-port": "Konfiguracja portu kontrolnego jest nieprawidłowa"
   },
@@ -40,6 +40,7 @@
   "gpu-device-enabled": "Urządzenia do kopania GPU",
   "gpu-device-enabled-description": "Włącz lub wyłącz konkretne urządzenie GPU.",
   "gpu-device-no-found": "⚠️ Nie znaleziono urządzeń GPU",
+  "gpu-engine": "Silnik GPU",
   "gpu-mining-enabled": "Wydobycie GPU",
   "gpu-unavailable": "⚠️ Kopanie GPU niedostępne ponieważ Twój sprzęt go nie obsługuje",
   "hardware-status": "Status sprzętu",

--- a/public/locales/ru/settings.json
+++ b/public/locales/ru/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Информация о приложении",
   "applyInviteCode": "Применить код приглашения",
   "cancel": "Отмена",
-  "gpu-engine": "Движок GPU",
   "change-language": "Язык",
   "confirm": "Подтвердить",
   "confirm-action": "Подтвердить действие",
@@ -30,6 +29,7 @@
   "debug-info": "Отладка",
   "disconnect": "Отключиться от Airdrop",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Конфигурация моста недействительна",
     "invalid-control-port": "Конфигурация порта управления недействительна"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "Устройства для майнинга на GPU",
   "gpu-device-enabled-description": "Включить или отключить конкретное устройство GPU.",
   "gpu-device-no-found": "⚠️ Устройства GPU не найдены",
+  "gpu-engine": "Движок GPU",
   "gpu-mining-enabled": "Майнинг на GPU",
   "gpu-unavailable": "⚠️ GPU отключен, так как ваше оборудование не поддерживает его",
   "hardware-status": "Состояние оборудования",

--- a/public/locales/tr/settings.json
+++ b/public/locales/tr/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Uygulama Bilgileri",
   "applyInviteCode": "Davet Kodunu Uygula",
   "cancel": "İptal",
-  "gpu-engine": "Gpu Motoru",
   "change-language": "Dil Değiştir",
   "confirm": "Onayla",
   "confirm-action": "İşlemi onayla",
@@ -30,6 +29,7 @@
   "debug-info": "Hata Ayıklama",
   "disconnect": "Airdrop\"tan Bağlantıyı Kes",
   "errors": {
+    "fetch-tor-bridges": "Failed to fetch Tor bridges. Check your internet connection or try again later.",
     "invalid-bridge": "Köprü yapılandırması geçersiz",
     "invalid-control-port": "Kontrol Portu yapılandırması geçersiz"
   },
@@ -39,6 +39,7 @@
   "gpu-device-enabled": "GPU Madencilik cihazları",
   "gpu-device-enabled-description": "Belirli bir GPU cihazını etkinleştir veya devre dışı bırak.",
   "gpu-device-no-found": "⚠️ GPU cihazı bulunamadı",
+  "gpu-engine": "Gpu Motoru",
   "gpu-mining-enabled": "GPU Madenciliği",
   "gpu-unavailable": "⚠️ Donanımınız desteklemediği için GPU devre dışı bırakıldı",
   "hardware-status": "Donanım durumu",

--- a/src/containers/floating/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
+++ b/src/containers/floating/Settings/sections/experimental/TorMarkup/TorMarkup.tsx
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useAppConfigStore } from '@app/store/useAppConfigStore.ts';
+import { setError } from '@app/store/actions';
 
 import { ToggleSwitch } from '@app/components/elements/ToggleSwitch.tsx';
 
@@ -116,7 +117,12 @@ export const TorMarkup = () => {
         const updated_use_bridges = !editedConfig?.use_bridges;
         let bridges = editedConfig?.bridges || [];
         if (updated_use_bridges && Number(bridges?.length) < 2) {
-            bridges = await invoke('fetch_tor_bridges');
+            try {
+                bridges = await invoke('fetch_tor_bridges');
+            } catch (error) {
+                console.error('Fetch Tor bridges error:', error);
+                setError(t('errors.fetch-tor-bridges'));
+            }
         }
 
         setEditedConfig((prev) => ({
@@ -124,7 +130,7 @@ export const TorMarkup = () => {
             use_bridges: updated_use_bridges,
             bridges,
         }));
-    }, [editedConfig?.bridges, editedConfig?.use_bridges]);
+    }, [editedConfig?.bridges, editedConfig?.use_bridges, t]);
 
     const toggleRandomControlPort = useCallback(() => {
         setEditedConfig((prev) => ({


### PR DESCRIPTION
Description
---
Tor Bridges switch wasn't handling errors at all(When couldn't fetch tor bridges from the external website). It just seemed unresponsive. I added try catch block with a proper notification to the user.

![Screenshot from 2025-04-08 11-32-09](https://github.com/user-attachments/assets/cd954a39-157c-4f9a-ba39-ee7c00eea1ad)

Error when fetching tor bridges:

https://github.com/user-attachments/assets/747c649d-0e49-4aad-a609-5f5a134cd7c5

Working properly:

https://github.com/user-attachments/assets/1b384050-1587-4ebf-87b9-08009833a2d3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a user-friendly error notification for when the system is unable to fetch Tor bridges, advising users to check their internet connection or try again later.
  - Enhanced localized error messages to ensure consistent, clear feedback across multiple language settings.

- **Refactor**
  - Improved error handling mechanisms to better manage connectivity issues during the Tor bridges fetching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->