### PR TITLE
feat(quick-load): show background node sync status

### DIFF
--- a/public/locales/af/settings.json
+++ b/public/locales/af/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Aansoek Inligting",
   "applyInviteCode": "Pas Uitnodigingskode Toe",
   "cancel": "Cancel",
-  "gpu-engine": "Gpu Enjin",
   "change-language": "Verander taal",
   "confirm": "Bevestig",
   "confirm-action": "Bevestig aksie",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU Myn toestelle",
   "gpu-device-enabled-description": "Aktiveer of deaktiveer spesifieke GPU toestel.",
   "gpu-device-no-found": "⚠️ Geen GPU toestelle gevind nie",
+  "gpu-engine": "Gpu Enjin",
   "gpu-mining-enabled": "GPU Mynbou",
   "gpu-unavailable": "⚠️ GPU gedeaktiveer omdat jou hardeware dit nie ondersteun nie",
   "hardware-status": "Hardeware status",
@@ -56,6 +56,7 @@
   "inviteCode": "Uitnodigingskode",
   "is-on-orphan-chain": "Dit lyk of jy aan \"n vurk gekoppel is, en nie die hoofketting nie. Enige blokke wat jy wen, mag ongeldig verklaar word.",
   "last-block-added-time": "Tyd toe laaste blok by ketting gevoeg was",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Verslae",
   "low-hash-rate-warning": "Jou hash rate is baie laag. Probeer om alle toepassings behalwe Tari Universe te sluit",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Mynwerkers",
   "mining-toggle-warning": "Mynbou sal gepauseer word terwyl die veranderinge in werking tree.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Voer Monero-adres in",
     "title": "Monero-adres"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero Saadwoorde",
   "network": "Netwerk",
   "no-entry-guard": "Geen Toegangsbewaarder verbind nie!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Nie aan die Tari Netwerk gekoppel nie",
   "open-logs-directory": "Maak verslag lêer oop",
   "p2pool-chain-tip": "Punt van kettings",
@@ -157,10 +163,5 @@
   "visual-mode": "Visuele modus",
   "yes": "Yes",
   "your-feedback": "Beskryf asseblief u probleem",
-  "your-reference": "U verwysing",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "U verwysing"
 }

--- a/public/locales/cn/settings.json
+++ b/public/locales/cn/settings.json
@@ -5,7 +5,6 @@
   "application-info": "应用信息",
   "applyInviteCode": "应用邀请代码",
   "cancel": "取消",
-  "gpu-engine": "Gpu 引擎",
   "change-language": "更改语言",
   "confirm": "确认",
   "confirm-action": "确认操作",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU 挖矿设备",
   "gpu-device-enabled-description": "启用或禁用特定的 GPU 设备。",
   "gpu-device-no-found": "⚠️ 未找到 GPU 设备",
+  "gpu-engine": "Gpu 引擎",
   "gpu-mining-enabled": "GPU 挖矿",
   "gpu-unavailable": "⚠️ GPU已禁用，因为您的硬件不支持",
   "hardware-status": "硬件状态",
@@ -56,6 +56,7 @@
   "inviteCode": "邀请代码",
   "is-on-orphan-chain": "您似乎连接到了一个分叉，而不是主链。您赢得的任何区块可能会被作废。",
   "last-block-added-time": "最后添加到链的块时间",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "日志",
   "low-hash-rate-warning": "您的哈希率非常低。尝试关闭除Tari Universe以外的所有应用程序",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "矿工",
   "mining-toggle-warning": "更改生效时，挖矿将暂停。",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "输入 Monero 地址",
     "title": "Monero 地址"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero 种子词",
   "network": "网络",
   "no-entry-guard": "未连接入口守卫！",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "未连接到Tari网络",
   "open-logs-directory": "打开日志目录",
   "p2pool-chain-tip": "链尖端",
@@ -157,10 +163,5 @@
   "visual-mode": "视觉模式",
   "yes": "是",
   "your-feedback": "请描述您的问题，包括您的Telegram账号（如果有），以便我们能够联系您并提供更新。",
-  "your-reference": "您的参考号：<br/><bold>{{logRef}}</bold>",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "您的参考号：<br/><bold>{{logRef}}</bold>"
 }

--- a/public/locales/de/settings.json
+++ b/public/locales/de/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Anwendungsinformationen",
   "applyInviteCode": "Einladungscode anwenden",
   "cancel": "Abbrechen",
-  "gpu-engine": "GPU-Engine",
   "change-language": "Sprache",
   "confirm": "Bestätigen",
   "confirm-action": "Aktion bestätigen",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU-Mining-Geräte",
   "gpu-device-enabled-description": "Bestimmtes GPU-Gerät aktivieren oder deaktivieren.",
   "gpu-device-no-found": "⚠️ Keine GPU-Geräte gefunden",
+  "gpu-engine": "GPU-Engine",
   "gpu-mining-enabled": "GPU-Mining",
   "gpu-unavailable": "⚠️ GPU deaktiviert, da deine Hardware dies nicht unterstützt",
   "hardware-status": "Hardware-Status",
@@ -56,6 +56,7 @@
   "inviteCode": "Einladungscode",
   "is-on-orphan-chain": "Sie scheinen mit einem Fork verbunden zu sein und nicht mit der Hauptkette. Alle gewonnenen Blöcke könnten ungültig werden.",
   "last-block-added-time": "Letzte Blockzeit, die zur Kette hinzugefügt wurde",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Protokolle",
   "low-hash-rate-warning": "Ihre Hashrate ist sehr niedrig. Versuchen Sie, alle Apps außer Tari Universe zu schließen",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Miner",
   "mining-toggle-warning": "Mining wird pausiert, während die Änderungen wirksam werden.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Gib die Monero-Adresse ein",
     "title": "Monero-Adresse"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero Seed-Wörter",
   "network": "Netzwerk",
   "no-entry-guard": "Kein Eingangswächter verbunden!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Nicht mit dem Tari-Netzwerk verbunden",
   "open-logs-directory": "Protokollverzeichnis öffnen",
   "p2pool-chain-tip": "Spitze der Ketten",
@@ -157,10 +163,5 @@
   "visual-mode": "Visueller Modus",
   "yes": "Ja",
   "your-feedback": "Beschreibe dein Problem, einschließlich deines Telegram-Namens, falls vorhanden, damit wir dich mit Updates kontaktieren können.",
-  "your-reference": "Dein Verweis:<br/><bold>{{logRef}}</bold>",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Dein Verweis:<br/><bold>{{logRef}}</bold>"
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Application Information",
   "applyInviteCode": "Apply Invite Code",
   "cancel": "Cancel",
-  "gpu-engine": "Gpu Engine",
   "change-language": "Language",
   "confirm": "Confirm",
   "confirm-action": "Confirm action",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU Mining devices",
   "gpu-device-enabled-description": "Enable or disable specific GPU device.",
   "gpu-device-no-found": "⚠️ No GPU devices found",
+  "gpu-engine": "Gpu Engine",
   "gpu-mining-enabled": "GPU Mining",
   "gpu-unavailable": "⚠️ GPU disabled because your hardware does not support it",
   "hardware-status": "Hardware status",
@@ -56,6 +56,7 @@
   "inviteCode": "Invite Code",
   "is-on-orphan-chain": "You seem to be connected to a fork, and not the main chain. Any blocks you win might be invalidated.",
   "last-block-added-time": "Last block added to chain time",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Logs",
   "low-hash-rate-warning": "Your hash rate is very low. Try closing all apps other than Tari Universe",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Miners",
   "mining-toggle-warning": "Mining will be paused while the changes take effect.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Enter Monero address",
     "title": "Monero address"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero Seed Words",
   "network": "Network",
   "no-entry-guard": "No Entry Guard connected!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Not connected to the Tari Network",
   "open-logs-directory": "Open logs directory",
   "p2pool-chain-tip": "Tip of chains",
@@ -157,10 +163,5 @@
   "visual-mode": "Visual mode",
   "yes": "Yes",
   "your-feedback": "Describe your issue, including your Telegram handle if you have one, so that we can contact you with updates.",
-  "your-reference": "Your reference:<br/><bold>{{logRef}}</bold>",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Your reference:<br/><bold>{{logRef}}</bold>"
 }

--- a/public/locales/fr/settings.json
+++ b/public/locales/fr/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informations sur l\"application",
   "applyInviteCode": "Appliquer le code d\"invitation",
   "cancel": "Cancel",
-  "gpu-engine": "Moteur GPU",
   "change-language": "Langue",
   "confirm": "Confirmer",
   "confirm-action": "Confirmer l\"action",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "Appareils de minage GPU",
   "gpu-device-enabled-description": "Activer ou désactiver un appareil GPU spécifique.",
   "gpu-device-no-found": "⚠️ Aucun appareil GPU trouvé",
+  "gpu-engine": "Moteur GPU",
   "gpu-mining-enabled": "Minage GPU",
   "gpu-unavailable": "⚠️ GPU désactivé car votre matériel ne le supporte pas",
   "hardware-status": "État du matériel",
@@ -56,6 +56,7 @@
   "inviteCode": "Code d\"invitation",
   "is-on-orphan-chain": "Vous semblez être connecté à une branche secondaire, et non à la chaîne principale. Tout bloc que vous gagnez pourrait être invalidé.",
   "last-block-added-time": "Heure du dernier bloc ajouté à la chaîne",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Journaux",
   "low-hash-rate-warning": "Votre hashrate est très bas. Essayez de fermer toutes les applications sauf Tari Universe",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Mineurs",
   "mining-toggle-warning": "Le minage sera suspendu pendant que les modifications prennent effet.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Entrez l\"adresse Monero",
     "title": "Adresse Monero"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Mots de récupération Monero",
   "network": "Réseau",
   "no-entry-guard": "Aucun Entry Guard connecté !",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Non connecté au réseau Tari",
   "open-logs-directory": "Ouvrir le répertoire des journaux",
   "p2pool-chain-tip": "Pointe des chaînes",
@@ -157,10 +163,5 @@
   "visual-mode": "Mode visuel",
   "yes": "Yes",
   "your-feedback": "Veuillez décrire votre problème",
-  "your-reference": "Votre référence :<br/><bold>{{logRef}}</bold>",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Votre référence :<br/><bold>{{logRef}}</bold>"
 }

--- a/public/locales/hi/settings.json
+++ b/public/locales/hi/settings.json
@@ -5,7 +5,6 @@
   "application-info": "एप्लिकेशन जानकारी",
   "applyInviteCode": "आमंत्रण कोड लागू करें",
   "cancel": "रद्द करें",
-  "gpu-engine": "जीपीयू इंजन",
   "change-language": "भाषा",
   "confirm": "पुष्टि करें",
   "confirm-action": "क्रिया की पुष्टि करें",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU माइनिंग डिवाइस",
   "gpu-device-enabled-description": "विशिष्ट GPU डिवाइस को सक्षम या अक्षम करें।",
   "gpu-device-no-found": "⚠️ कोई GPU डिवाइस नहीं मिला",
+  "gpu-engine": "जीपीयू इंजन",
   "gpu-mining-enabled": "जीपीयू माइनिंग",
   "gpu-unavailable": "⚠️ जीपीयू अक्षम है क्योंकि आपका हार्डवेयर इसे समर्थन नहीं करता",
   "hardware-status": "हार्डवेयर स्थिति",
@@ -56,6 +56,7 @@
   "inviteCode": "आमंत्रण कोड",
   "is-on-orphan-chain": "आप एक फोर्क से जुड़े हुए प्रतीत होते हैं, और मुख्य चेन से नहीं। आपके द्वारा जीते गए किसी भी ब्लॉक को अमान्य किया जा सकता है।",
   "last-block-added-time": "श्रृंखला में जोड़ा गया अंतिम ब्लॉक समय",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "लॉग्स",
   "low-hash-rate-warning": "आपकी हैश रेट बहुत कम है। Tari Universe के अलावा सभी ऐप्स को बंद करने का प्रयास करें",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "माइनर्स",
   "mining-toggle-warning": "परिवर्तनों के प्रभावी होने के दौरान माइनिंग रोक दी जाएगी।",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "मोनरो पता दर्ज करें",
     "title": "मोनरो पता"
@@ -71,6 +73,10 @@
   "monero-seed-words": "मोनरो सीड शब्द",
   "network": "नेटवर्क",
   "no-entry-guard": "कोई एंट्री गार्ड कनेक्ट नहीं है!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Tari नेटवर्क से जुड़ा नहीं",
   "open-logs-directory": "लॉग्स निर्देशिका खोलें",
   "p2pool-chain-tip": "श्रृंखलाओं की नोक",
@@ -157,10 +163,5 @@
   "visual-mode": "दृश्य मोड",
   "yes": "हाँ",
   "your-feedback": "कृपया अपनी समस्या का वर्णन करें",
-  "your-reference": "आपका संदर्भ",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "आपका संदर्भ"
 }

--- a/public/locales/id/settings.json
+++ b/public/locales/id/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informasi Aplikasi",
   "applyInviteCode": "Terapkan Kode Undangan",
   "cancel": "Batal",
-  "gpu-engine": "Mesin Gpu",
   "change-language": "Bahasa",
   "confirm": "Konfirmasi",
   "confirm-action": "Konfirmasi tindakan",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "Perangkat Penambangan GPU",
   "gpu-device-enabled-description": "Aktifkan atau nonaktifkan perangkat GPU tertentu.",
   "gpu-device-no-found": "⚠️ Tidak ada perangkat GPU yang ditemukan",
+  "gpu-engine": "Mesin Gpu",
   "gpu-mining-enabled": "Penambangan GPU",
   "gpu-unavailable": "⚠️ GPU dinonaktifkan karena perangkat keras Anda tidak mendukungnya",
   "hardware-status": "Status perangkat keras",
@@ -56,6 +56,7 @@
   "inviteCode": "Kode Undangan",
   "is-on-orphan-chain": "Anda tampaknya terhubung ke cabang, bukan rantai utama. Blok yang Anda menangkan mungkin akan dibatalkan.",
   "last-block-added-time": "Waktu blok terakhir ditambahkan ke rantai",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Log",
   "low-hash-rate-warning": "Hashrate Anda sangat rendah. Coba tutup semua aplikasi selain Tari Universe",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Penambang",
   "mining-toggle-warning": "Penambangan akan dijeda saat perubahan diterapkan.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Masukkan alamat Monero",
     "title": "Alamat Monero"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Kata Kunci Pemulihan Monero",
   "network": "Jaringan",
   "no-entry-guard": "Tidak ada Penjaga Masuk yang terhubung!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Tidak terhubung ke Jaringan Tari",
   "open-logs-directory": "Buka direktori log",
   "p2pool-chain-tip": "Ujung rantai",
@@ -157,10 +163,5 @@
   "visual-mode": "Mode visual",
   "yes": "Ya",
   "your-feedback": "Silakan jelaskan masalah Anda",
-  "your-reference": "Referensi Anda",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Referensi Anda"
 }

--- a/public/locales/ja/settings.json
+++ b/public/locales/ja/settings.json
@@ -5,7 +5,6 @@
   "application-info": "アプリケーション情報",
   "applyInviteCode": "招待コードを適用",
   "cancel": "キャンセル",
-  "gpu-engine": "GPUエンジン",
   "change-language": "言語",
   "confirm": "確認",
   "confirm-action": "アクションを確認",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPUマイニングデバイス",
   "gpu-device-enabled-description": "特定のGPUデバイスを有効または無効にします。",
   "gpu-device-no-found": "⚠️ GPUデバイスが見つかりません",
+  "gpu-engine": "GPUエンジン",
   "gpu-mining-enabled": "GPUマイニング",
   "gpu-unavailable": "⚠️ ハードウェアがサポートしていないため、GPUが無効です",
   "hardware-status": "ハードウェアの状態",
@@ -56,6 +56,7 @@
   "inviteCode": "招待コード",
   "is-on-orphan-chain": "フォークに接続されているようです。メインチェーンではありません。獲得したブロックは無効になる可能性があります。",
   "last-block-added-time": "最後のブロックがチェーンに追加された時間",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "ログ",
   "low-hash-rate-warning": "ハッシュレートが非常に低いです。Tari Universe以外のすべてのアプリを閉じてみてください",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "マイナー",
   "mining-toggle-warning": "変更が適用される間、マイニングは一時停止されます。",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Moneroアドレスを入力",
     "title": "Moneroアドレス"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero シードワード",
   "network": "ネットワーク",
   "no-entry-guard": "エントリーガードが接続されていません！",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Tariネットワークに接続されていません",
   "open-logs-directory": "ログディレクトリを開く",
   "p2pool-chain-tip": "チェーンの先端",
@@ -157,10 +163,5 @@
   "visual-mode": "ビジュアルモード",
   "yes": "はい",
   "your-feedback": "問題を説明してください",
-  "your-reference": "あなたの参照",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "あなたの参照"
 }

--- a/public/locales/ko/settings.json
+++ b/public/locales/ko/settings.json
@@ -5,7 +5,6 @@
   "application-info": "애플리케이션 정보",
   "applyInviteCode": "초대 코드 적용",
   "cancel": "취소",
-  "gpu-engine": "GPU 엔진",
   "change-language": "언어",
   "confirm": "확인",
   "confirm-action": "작업 확인",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU 채굴 장치",
   "gpu-device-enabled-description": "특정 GPU 장치를 활성화하거나 비활성화합니다.",
   "gpu-device-no-found": "⚠️ GPU 장치를 찾을 수 없습니다",
+  "gpu-engine": "GPU 엔진",
   "gpu-mining-enabled": "GPU 채굴",
   "gpu-unavailable": "⚠️ 하드웨어가 지원하지 않아 GPU가 비활성화되었습니다",
   "hardware-status": "하드웨어 상태",
@@ -56,6 +56,7 @@
   "inviteCode": "초대 코드",
   "is-on-orphan-chain": "당신은 포크에 연결된 것 같으며, 메인 체인이 아닙니다. 당신이 획득한 블록은 무효화될 수 있습니다.",
   "last-block-added-time": "마지막 블록 체인 추가 시간",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "로그",
   "low-hash-rate-warning": "해시레이트가 매우 낮습니다. Tari Universe 외의 모든 앱을 닫아보세요",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "마이너",
   "mining-toggle-warning": "변경 사항이 적용되는 동안 채굴이 일시 중지됩니다.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "모네로 주소 입력",
     "title": "모네로 주소"
@@ -71,6 +73,10 @@
   "monero-seed-words": "모네로 시드 단어",
   "network": "네트워크",
   "no-entry-guard": "엔트리 가드가 연결되지 않았습니다!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Tari 네트워크에 연결되지 않음",
   "open-logs-directory": "로그 디렉토리 열기",
   "p2pool-chain-tip": "체인의 끝",
@@ -157,10 +163,5 @@
   "visual-mode": "시각 모드",
   "yes": "예",
   "your-feedback": "문제를 설명해 주세요",
-  "your-reference": "귀하의 참조",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "귀하의 참조"
 }

--- a/public/locales/pl/settings.json
+++ b/public/locales/pl/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Informacje o aplikacji",
   "applyInviteCode": "Zastosuj Kod Zaproszenia",
   "cancel": "Anuluj",
-  "gpu-engine": "Silnik GPU",
   "change-language": "Zmień język",
   "confirm": "Potwierdź",
   "confirm-action": "Potwierdź działanie",
@@ -40,6 +39,7 @@
   "gpu-device-enabled": "Urządzenia do kopania GPU",
   "gpu-device-enabled-description": "Włącz lub wyłącz konkretne urządzenie GPU.",
   "gpu-device-no-found": "⚠️ Nie znaleziono urządzeń GPU",
+  "gpu-engine": "Silnik GPU",
   "gpu-mining-enabled": "Wydobycie GPU",
   "gpu-unavailable": "⚠️ Kopanie GPU niedostępne ponieważ Twój sprzęt go nie obsługuje",
   "hardware-status": "Status sprzętu",
@@ -57,6 +57,7 @@
   "inviteCode": "Kod Zaproszenia",
   "is-on-orphan-chain": "Wygląda na to, że jesteś połączony z rozwidleniem, a nie z głównym łańcuchem. Wszelkie wygrane bloki mogą zostać unieważnione.",
   "last-block-added-time": "Czas dodania ostatniego bloku do łańcucha",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Logi",
   "low-hash-rate-warning": "Twój hash rate jest bardzo niski. Spróbuj zamknąć wszystkie aplikacje poza Tari Universe",
   "mine-on-app-start": {
@@ -65,6 +66,7 @@
   },
   "miners": "Górnicy",
   "mining-toggle-warning": "Wydobycie zostanie wstrzymane, gdy zmiany wejdą w życie.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Wprowadź address Monero",
     "title": "Address Monero"
@@ -72,6 +74,10 @@
   "monero-seed-words": "Słowa kluczowe Monero",
   "network": "Sieć",
   "no-entry-guard": "Brak połączenia z Entry Guardami!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Nie połączono z siecią Tari",
   "not-connected-to-tari-network": null,
   "open-logs-directory": "Otwórz katalog logów",
@@ -159,10 +165,5 @@
   "visual-mode": "Tryb wizualny",
   "yes": "Tak",
   "your-feedback": "Proszę opisać swój problem",
-  "your-reference": "Twoje odniesienie",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Twoje odniesienie"
 }

--- a/public/locales/ru/settings.json
+++ b/public/locales/ru/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Информация о приложении",
   "applyInviteCode": "Применить код приглашения",
   "cancel": "Отмена",
-  "gpu-engine": "Движок GPU",
   "change-language": "Язык",
   "confirm": "Подтвердить",
   "confirm-action": "Подтвердить действие",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "Устройства для майнинга на GPU",
   "gpu-device-enabled-description": "Включить или отключить конкретное устройство GPU.",
   "gpu-device-no-found": "⚠️ Устройства GPU не найдены",
+  "gpu-engine": "Движок GPU",
   "gpu-mining-enabled": "Майнинг на GPU",
   "gpu-unavailable": "⚠️ GPU отключен, так как ваше оборудование не поддерживает его",
   "hardware-status": "Состояние оборудования",
@@ -56,6 +56,7 @@
   "inviteCode": "Код приглашения",
   "is-on-orphan-chain": "Похоже, что Вы подключены к форку, а не к основной цепочке. Любые выигранные Вами блоки могут быть аннулированы.",
   "last-block-added-time": "Время добавления последнего блока в цепь",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Логи",
   "low-hash-rate-warning": "Ваш хешрейт очень низкий. Попробуйте закрыть все приложения, кроме Tari Universe",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Майнеры",
   "mining-toggle-warning": "Майнинг будет приостановлен, пока изменения вступят в силу.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Введите адрес Monero",
     "title": "Адрес Monero"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Секретные слова Monero",
   "network": "Сеть",
   "no-entry-guard": "Нет подключения к Entry Guard!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Не подключено к сети Tari",
   "open-logs-directory": "Открыть папку с логами",
   "p2pool-chain-tip": "Конец цепей",
@@ -157,10 +163,5 @@
   "visual-mode": "Визуальный режим",
   "yes": "Да",
   "your-feedback": "Пожалуйста, опишите Вашу проблему",
-  "your-reference": "Ваша ссылка",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Ваша ссылка"
 }

--- a/public/locales/tr/settings.json
+++ b/public/locales/tr/settings.json
@@ -5,7 +5,6 @@
   "application-info": "Uygulama Bilgileri",
   "applyInviteCode": "Davet Kodunu Uygula",
   "cancel": "İptal",
-  "gpu-engine": "Gpu Motoru",
   "change-language": "Dil Değiştir",
   "confirm": "Onayla",
   "confirm-action": "İşlemi onayla",
@@ -39,6 +38,7 @@
   "gpu-device-enabled": "GPU Madencilik cihazları",
   "gpu-device-enabled-description": "Belirli bir GPU cihazını etkinleştir veya devre dışı bırak.",
   "gpu-device-no-found": "⚠️ GPU cihazı bulunamadı",
+  "gpu-engine": "Gpu Motoru",
   "gpu-mining-enabled": "GPU Madenciliği",
   "gpu-unavailable": "⚠️ Donanımınız desteklemediği için GPU devre dışı bırakıldı",
   "hardware-status": "Donanım durumu",
@@ -56,6 +56,7 @@
   "inviteCode": "Davet Kodu",
   "is-on-orphan-chain": "Bir çatal ile bağlantılı görünüyorsunuz, ana zincirle değil. Kazandığınız bloklar geçersiz kılınabilir.",
   "last-block-added-time": "Zincir zamanına eklenen son blok",
+  "local-node-sync-progress": "Local node syncing progress",
   "logs": "Günlükler",
   "low-hash-rate-warning": "Hashrate\"iniz çok düşük. Tari Evreni dışındaki tüm uygulamaları kapatmayı deneyin",
   "mine-on-app-start": {
@@ -64,6 +65,7 @@
   },
   "miners": "Madenciler",
   "mining-toggle-warning": "Değişiklikler etkili olana kadar madencilik duraklatılacak.",
+  "minotari-node": "Minotari Node",
   "monero-address": {
     "placeholder": "Monero adresini girin",
     "title": "Monero Adresi"
@@ -71,6 +73,10 @@
   "monero-seed-words": "Monero Seed Kelimeleri",
   "network": "Ağ",
   "no-entry-guard": "Giriş Koruması bağlı değil!",
+  "node-connection-address": "Connection address",
+  "node-public-address": "Public address",
+  "node-public-key": "Public key",
+  "node-type": "Type",
   "not-connected-to-tari": "Tari Ağına Bağlı Değil",
   "open-logs-directory": "Günlükler dizinini açın",
   "p2pool-chain-tip": "Zincir ucu",
@@ -157,10 +163,5 @@
   "visual-mode": "Görsel mod",
   "yes": "Evet",
   "your-feedback": "Lütfen sorununuzu açıklayın",
-  "your-reference": "Referansınız",
-  "minotari-node": "Minotari Node",
-  "node-type": "Type",
-  "node-public-key": "Public key",
-  "node-public-address": "Public address",
-  "node-connection-address": "Connection address"
+  "your-reference": "Referansınız"
 }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -66,7 +66,7 @@ pub enum EventType {
     ConfigUILoaded,
     ConfigWalletLoaded,
     ConfigMiningLoaded,
-    BackgroundNodeSyncUpdate
+    BackgroundNodeSyncUpdate,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -66,6 +66,7 @@ pub enum EventType {
     ConfigUILoaded,
     ConfigWalletLoaded,
     ConfigMiningLoaded,
+    BackgroundNodeSyncUpdate
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -481,7 +481,10 @@ impl EventsEmitter {
         }
     }
 
-    pub async fn emit_background_node_sync_update(app_handle: &AppHandle, payload: HashMap::<String, String>) {
+    pub async fn emit_background_node_sync_update(
+        app_handle: &AppHandle,
+        payload: HashMap<String, String>,
+    ) {
         let _unused = FrontendReadyChannel::current().wait_for_ready().await;
         let event = Event {
             event_type: EventType::BackgroundNodeSyncUpdate,

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -480,4 +480,15 @@ impl EventsEmitter {
             error!(target: LOG_TARGET, "Failed to emit NodeTypeUpdate event: {:?}", e);
         }
     }
+
+    pub async fn emit_background_node_sync_update(app_handle: &AppHandle, payload: HashMap::<String, String>) {
+        let _unused = FrontendReadyChannel::current().wait_for_ready().await;
+        let event = Event {
+            event_type: EventType::BackgroundNodeSyncUpdate,
+            payload,
+        };
+        if let Err(e) = app_handle.emit(BACKEND_STATE_UPDATE, event) {
+            error!(target: LOG_TARGET, "Failed to emit BackgroundNodeSyncUpdate event: {:?}", e);
+        }
+    }
 }

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -335,7 +335,11 @@ impl EventsManager {
         EventsEmitter::emit_wallet_config_loaded(app, payload).await;
     }
 
-    pub async fn handle_background_node_sync_update(&self, app: &AppHandle, progress_params: HashMap::<String, String>) {
+    pub async fn handle_background_node_sync_update(
+        &self,
+        app: &AppHandle,
+        progress_params: HashMap<String, String>,
+    ) {
         EventsEmitter::emit_background_node_sync_update(app, progress_params).await;
     }
 }

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -334,4 +334,8 @@ impl EventsManager {
         let payload = ConfigWallet::content().await;
         EventsEmitter::emit_wallet_config_loaded(app, payload).await;
     }
+
+    pub async fn handle_background_node_sync_update(&self, app: &AppHandle, progress_params: HashMap::<String, String>) {
+        EventsEmitter::emit_background_node_sync_update(app, progress_params).await;
+    }
 }

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -22,8 +22,6 @@
 
 use crate::node::node_manager::NodeType;
 use crate::process_adapter::{HealthStatus, StatusMonitor};
-use crate::progress_trackers::progress_plans::ProgressSetupNodePlan;
-use crate::progress_trackers::progress_stepper::ChanneledStepUpdate;
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
 use minotari_node_grpc_client::grpc::{
@@ -218,7 +216,8 @@ impl NodeAdapterService {
                     "tip_height".to_string(),
                     sync_progress.tip_height.to_string(),
                 );
-            } else if sync_progress.state == SyncState::Block as i32 {
+            }
+            if sync_progress.state == SyncState::Block as i32 {
                 percentage = sync_progress.local_height as f64 / sync_progress.tip_height as f64;
                 progress_params.insert("step".to_string(), "Block".to_string());
                 progress_params.insert(

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -191,7 +191,8 @@ impl NodeAdapterService {
                     "required_peers".to_string(),
                     self.required_sync_peers.to_string(),
                 );
-            } else if sync_progress.state == SyncState::Header as i32 {
+            }
+            if sync_progress.state == SyncState::Header as i32 {
                 percentage = sync_progress.local_height as f64 / sync_progress.tip_height as f64;
                 progress_params.insert("step".to_string(), "Header".to_string());
                 progress_params.insert(

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -223,7 +223,7 @@ impl NodeAdapterService {
                 progress_params.insert("step".to_string(), "Block".to_string());
                 progress_params.insert(
                     "local_header_height".to_string(),
-                    sync_progress.local_height.to_string(),
+                    sync_progress.tip_height.to_string(),
                 );
                 progress_params.insert(
                     "tip_header_height".to_string(),

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -35,7 +35,6 @@ use tokio::sync::RwLock;
 use tokio::{fs, select};
 use tokio_util::task::TaskTracker;
 
-use crate::events_manager::EventsManager;
 use crate::node::node_adapter::{
     NodeAdapter, NodeAdapterService, NodeIdentity, NodeStatusMonitorError,
 };

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -475,8 +475,8 @@ impl NodeManager {
             let current_service = self.get_current_service().await?;
             match current_service
                 .wait_synced(
-                    &progress_params_tx,
-                    &progress_percentage_tx,
+                    progress_params_tx,
+                    progress_percentage_tx,
                     self.shutdown.clone(),
                 )
                 .await

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -20,6 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,11 +29,13 @@ use log::{error, info, warn};
 use serde::Serialize;
 use tari_common::configuration::Network;
 use tari_shutdown::ShutdownSignal;
-use tokio::sync::watch::Sender;
+use tauri::{AppHandle, Manager};
+use tokio::sync::watch::{self, Sender};
 use tokio::sync::RwLock;
 use tokio::{fs, select};
 use tokio_util::task::TaskTracker;
 
+use crate::events_manager::EventsManager;
 use crate::node::node_adapter::{
     NodeAdapter, NodeAdapterService, NodeIdentity, NodeStatusMonitorError,
 };
@@ -40,10 +43,9 @@ use crate::process_adapter::ProcessAdapter;
 use crate::process_stats_collector::ProcessStatsCollectorBuilder;
 use crate::process_watcher::ProcessWatcher;
 use crate::process_watcher::ProcessWatcherStats;
-use crate::progress_trackers::progress_stepper::ChanneledStepUpdate;
 use crate::setup::setup_manager::SetupManager;
 use crate::tasks_tracker::TasksTrackers;
-use crate::{LocalNodeAdapter, RemoteNodeAdapter};
+use crate::{LocalNodeAdapter, RemoteNodeAdapter, UniverseAppState};
 
 const LOG_TARGET: &str = "tari::universe::minotari_node_manager";
 
@@ -134,6 +136,7 @@ impl NodeManager {
         use_tor: bool,
         tor_control_port: Option<u16>,
         remote_grpc_address: Option<String>,
+        app_handle: AppHandle,
     ) -> Result<(), NodeManagerError> {
         let shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
         let task_tracker = TasksTrackers::current().node_phase.get_task_tracker().await;
@@ -186,10 +189,11 @@ impl NodeManager {
                 )
                 .await?;
 
-                self.switch_to_local_after_remote(shutdown_signal).await?;
+                self.switch_to_local_after_remote(shutdown_signal, app_handle)
+                    .await?;
             }
         }
-        // println!("====== grpc: {:?}", self.get_grpc_address().await);
+
         self.wait_ready().await?;
         Ok(())
     }
@@ -290,6 +294,7 @@ impl NodeManager {
         base_path: PathBuf,
         config_path: PathBuf,
         log_path: PathBuf,
+        app_handle: AppHandle,
     ) -> Result<(), anyhow::Error> {
         let shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
         let task_tracker = TasksTrackers::current().node_phase.get_task_tracker().await;
@@ -355,7 +360,8 @@ impl NodeManager {
                         .await?;
                 }
 
-                self.switch_to_local_after_remote(shutdown_signal).await?;
+                self.switch_to_local_after_remote(shutdown_signal, app_handle)
+                    .await?;
             }
         }
 
@@ -365,10 +371,43 @@ impl NodeManager {
     async fn switch_to_local_after_remote(
         &self,
         mut shutdown_signal: ShutdownSignal,
+        app_handle: AppHandle,
     ) -> Result<(), anyhow::Error> {
         let node_type = self.node_type.clone();
         let node_manager = self.clone();
+        let app_handle = app_handle.clone();
         TasksTrackers::current().node_phase.get_task_tracker().await.spawn(async move {
+            let (progress_params_tx, mut progress_params_rx) =
+                watch::channel(HashMap::<String, String>::new());
+            let (progress_percentage_tx, progress_percentage_rx) = watch::channel(0f64);
+            let mut shutdown_signal_clone = shutdown_signal.clone();
+
+            TasksTrackers::current()
+                .node_phase
+                .get_task_tracker()
+                .await
+                .spawn(async move {
+                    loop {
+                        tokio::select! {
+                            _ = progress_params_rx.changed() => {
+                                let progress_params = progress_params_rx.borrow().clone();
+                                let percentage = *progress_percentage_rx.borrow();
+                                if let Some(step) = progress_params.get("step").cloned() {
+                                    let app_state = app_handle.state::<UniverseAppState>();
+                                    app_state.events_manager.handle_background_node_sync_update(&app_handle, progress_params.clone()).await;
+                                    if step == "Block" && percentage == 1.0 {
+                                        break;
+                                    }
+                                }
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                            },
+                            _ = shutdown_signal_clone.wait() => {
+                                break;
+                            }
+                        }
+                    }
+                });
+
             select! {
                 _ = shutdown_signal.wait() => {
                     info!(target: LOG_TARGET, "Shutdown signal received, stopping local node watcher");
@@ -382,7 +421,7 @@ impl NodeManager {
 
                         if let Some(local_current_service) = local_current_service {
                             match local_current_service
-                                .wait_synced(vec![None, None, None], node_manager.shutdown.clone())
+                                .wait_synced(&progress_params_tx, &progress_percentage_tx, node_manager.shutdown.clone())
                                 .await
                             {
                                 Ok(_) => {
@@ -429,13 +468,18 @@ impl NodeManager {
 
     pub async fn wait_synced(
         &self,
-        progress_trackers: Vec<Option<ChanneledStepUpdate>>,
+        progress_params_tx: &watch::Sender<HashMap<String, String>>,
+        progress_percentage_tx: &watch::Sender<f64>,
     ) -> Result<(), anyhow::Error> {
         self.wait_ready().await?;
         loop {
             let current_service = self.get_current_service().await?;
             match current_service
-                .wait_synced(progress_trackers.clone(), self.shutdown.clone())
+                .wait_synced(
+                    &progress_params_tx,
+                    &progress_percentage_tx,
+                    self.shutdown.clone(),
+                )
                 .await
             {
                 Ok(_) => {

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -219,7 +219,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
                 self.app_configuration.use_tor,
                 tor_control_port,
                 Some(self.app_configuration.base_node_grpc_address.clone()),
-                self.app_handle.clone()
+                self.app_handle.clone(),
             )
             .await
         {

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -162,6 +162,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
         });
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn setup_inner(&self) -> Result<Option<NodeSetupPhaseOutput>, Error> {
         let mut progress_stepper = self.progress_stepper.lock().await;
         let (data_dir, config_dir, log_dir) = self.get_app_dirs()?;

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -20,7 +20,7 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{
     binaries::{Binaries, BinaryResolver},
@@ -219,6 +219,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
                 self.app_configuration.use_tor,
                 tor_control_port,
                 Some(self.app_configuration.base_node_grpc_address.clone()),
+                self.app_handle.clone()
             )
             .await
         {
@@ -242,7 +243,11 @@ impl SetupPhaseImpl for NodeSetupPhase {
                 return Err(e.into());
             }
         }
-        // }
+
+        let (progress_params_tx, mut progress_params_rx) =
+            watch::channel(HashMap::<String, String>::new());
+        let (progress_percentage_tx, progress_percentage_rx) = watch::channel(0f64);
+        let mut shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
 
         let wait_for_initial_sync_tracker = progress_stepper.channel_step_range_updates(
             ProgressPlans::Node(ProgressSetupNodePlan::WaitingForInitialSync),
@@ -250,26 +255,59 @@ impl SetupPhaseImpl for NodeSetupPhase {
                 ProgressSetupNodePlan::WaitingForHeaderSync,
             )),
         );
-
         let wait_for_header_sync_tracker = progress_stepper.channel_step_range_updates(
             ProgressPlans::Node(ProgressSetupNodePlan::WaitingForHeaderSync),
             Some(ProgressPlans::Node(
                 ProgressSetupNodePlan::WaitingForBlockSync,
             )),
         );
-
         let wait_for_block_sync_tracker = progress_stepper.channel_step_range_updates(
             ProgressPlans::Node(ProgressSetupNodePlan::WaitingForBlockSync),
             None,
         );
 
+        TasksTrackers::current()
+            .node_phase
+            .get_task_tracker()
+            .await
+            .spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = progress_params_rx.changed() => {
+                            let progress_params = progress_params_rx.borrow().clone();
+                            let percentage = *progress_percentage_rx.borrow();
+                            if let Some(step) = progress_params.get("step").cloned() {
+                                let tracker = match step.as_str() {
+                                    "Startup" => &wait_for_initial_sync_tracker,
+                                    "Header" => &wait_for_header_sync_tracker,
+                                    "Block" => &wait_for_block_sync_tracker,
+                                    _ => {
+                                        warn!("Unknown step: {}", step);
+                                        continue;
+                                    }
+                                };
+
+                                if let Some(tracker) = tracker {
+                                    tracker.send_update(progress_params.clone(), percentage).await;
+                                    if step == "Block" && percentage == 1.0 {
+                                        break;
+                                    }
+                                } else {
+                                    warn!("Progress tracker not found for step: {}", step);
+                                }
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                            }
+                        },
+                        _ = shutdown_signal.wait() => {
+                            break;
+                        }
+                    }
+                }
+            });
+
         state
             .node_manager
-            .wait_synced(vec![
-                wait_for_initial_sync_tracker,
-                wait_for_header_sync_tracker,
-                wait_for_block_sync_tracker,
-            ])
+            .wait_synced(&progress_params_tx, &progress_percentage_tx)
             .await?;
 
         Ok(None)

--- a/src/containers/floating/Settings/sections/connections/Node.tsx
+++ b/src/containers/floating/Settings/sections/connections/Node.tsx
@@ -13,7 +13,7 @@ import { NodeType, useNodeStore } from '@app/store/useNodeStore.ts';
 import { BackgroundNodeSyncUpdatePayload } from '@app/types/events-payloads.ts';
 
 export function BackgroundNodeSyncProgress({ lastUpdate }: { lastUpdate: BackgroundNodeSyncUpdatePayload }) {
-    const { t } = useTranslation('setup-progresses', { useSuspense: false });
+    const { t } = useTranslation(['setup-progresses', 'setup-view'], { useSuspense: false });
     if (!lastUpdate) return null;
 
     switch (lastUpdate.step) {
@@ -101,14 +101,16 @@ export default function Node() {
                     </SettingsGroupContent>
                     {backgroundNodeSyncLastUpdate?.step && node_type == 'RemoteUntilLocal' && (
                         <SettingsGroupContent>
-                            <Stack direction="column" alignItems="flex-start">
-                                <Stack direction="row">
-                                    <Typography>{t('local-node-sync-progress')}: </Typography>
-                                    <b>
+                            <SettingsGroupTitle>
+                                <Typography variant="h6">{t('local-node-sync-progress')}</Typography>
+                            </SettingsGroupTitle>
+                            <SettingsGroupContent>
+                                <Stack direction="column" alignItems="flex-start">
+                                    <Stack direction="row">
                                         <BackgroundNodeSyncProgress lastUpdate={backgroundNodeSyncLastUpdate} />
-                                    </b>
+                                    </Stack>
                                 </Stack>
-                            </Stack>
+                            </SettingsGroupContent>
                         </SettingsGroupContent>
                     )}
                 </SettingsGroupContent>

--- a/src/containers/floating/Settings/sections/connections/Node.tsx
+++ b/src/containers/floating/Settings/sections/connections/Node.tsx
@@ -9,11 +9,60 @@ import {
     SettingsGroupTitle,
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
-import { useNodeStore } from '@app/store/useNodeStore.ts';
+import { NodeType, useNodeStore } from '@app/store/useNodeStore.ts';
+import { BackgroundNodeSyncUpdatePayload } from '@app/types/events-payloads.ts';
+
+export function BackgroundNodeSyncProgress({ lastUpdate }: { lastUpdate: BackgroundNodeSyncUpdatePayload }) {
+    const { t } = useTranslation('setup-progresses', { useSuspense: false });
+    if (!lastUpdate) return null;
+
+    switch (lastUpdate.step) {
+        case 'Startup':
+            return (
+                <Typography>
+                    {t('title.waiting-for-initial-sync', {
+                        initial_connected_peers: lastUpdate.initial_connected_peers,
+                        required_peers: lastUpdate.required_peers,
+                    })}
+                </Typography>
+            );
+        case 'Header':
+            return (
+                <Typography>
+                    {t('title.waiting-for-header-sync', {
+                        local_header_height: lastUpdate.local_header_height,
+                        tip_header_height: lastUpdate.tip_header_height,
+                        local_block_height: lastUpdate.local_block_height,
+                        tip_block_height: lastUpdate.tip_block_height,
+                    })}
+                </Typography>
+            );
+        case 'Block':
+            return (
+                <Typography>
+                    {t('title.waiting-for-block-sync', {
+                        local_header_height: lastUpdate.local_header_height,
+                        tip_header_height: lastUpdate.tip_header_height,
+                        local_block_height: lastUpdate.local_block_height,
+                        tip_block_height: lastUpdate.tip_block_height,
+                    })}
+                </Typography>
+            );
+        default:
+            return null;
+    }
+}
+
+const getNodeType = (nodeType?: NodeType) => {
+    if (!nodeType) return 'N/A';
+    if (nodeType == 'LocalAfterRemote') return 'Local';
+    if (nodeType == 'RemoteUntilLocal') return 'Remote';
+    return nodeType;
+};
 
 export default function Node() {
-    const { t } = useTranslation('settings');
-    const { node_type, node_identity, node_connection_address } = useNodeStore();
+    const { t } = useTranslation('settings', { useSuspense: false });
+    const { node_type, node_identity, node_connection_address, backgroundNodeSyncLastUpdate } = useNodeStore();
 
     return (
         <SettingsGroupWrapper>
@@ -27,7 +76,7 @@ export default function Node() {
                             <Stack direction="row">
                                 <Typography>{t('node-type')}</Typography>
                                 <Typography>
-                                    <b>{node_type || 'N/A'}</b>
+                                    <b>{getNodeType(node_type)}</b>
                                 </Typography>
                             </Stack>
                             <Stack direction="row">
@@ -50,6 +99,18 @@ export default function Node() {
                             </Stack>
                         </Stack>
                     </SettingsGroupContent>
+                    {backgroundNodeSyncLastUpdate?.step && node_type == 'RemoteUntilLocal' && (
+                        <SettingsGroupContent>
+                            <Stack direction="column" alignItems="flex-start">
+                                <Stack direction="row">
+                                    <Typography>{t('local-node-sync-progress')}: </Typography>
+                                    <b>
+                                        <BackgroundNodeSyncProgress lastUpdate={backgroundNodeSyncLastUpdate} />
+                                    </b>
+                                </Stack>
+                            </Stack>
+                        </SettingsGroupContent>
+                    )}
                 </SettingsGroupContent>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/hooks/app/useTauriEventsListener.ts
+++ b/src/hooks/app/useTauriEventsListener.ts
@@ -159,6 +159,11 @@ const useTauriEventsListener = () => {
                     case 'RestartingPhases':
                         handleRestartingPhases(event.payload);
                         break;
+                    case 'BackgroundNodeSyncUpdate':
+                        setNodeStoreState({
+                            backgroundNodeSyncLastUpdate: event.payload,
+                        });
+                        break;
                     default:
                         console.warn('Unknown event', JSON.stringify(event));
                         break;

--- a/src/store/useNodeStore.ts
+++ b/src/store/useNodeStore.ts
@@ -1,3 +1,4 @@
+import { BackgroundNodeSyncUpdatePayload } from '@app/types/events-payloads';
 import { create } from './create';
 
 export type NodeType = 'Local' | 'Remote' | 'RemoteUntilLocal' | 'LocalAfterRemote';
@@ -10,6 +11,7 @@ interface NodeStoreState {
     node_type?: NodeType;
     node_identity?: NodeIdentity;
     node_connection_address?: string;
+    backgroundNodeSyncLastUpdate?: BackgroundNodeSyncUpdatePayload;
 }
 
 const initialState: NodeStoreState = {

--- a/src/types/backend-state.ts
+++ b/src/types/backend-state.ts
@@ -1,4 +1,5 @@
 import {
+    BackgroundNodeSyncUpdatePayload,
     ConnectedPeersUpdatePayload,
     CriticalProblemPayload,
     DetectedAvailableGpuEngines,
@@ -151,4 +152,8 @@ export type BackendStateUpdateEvent =
     | {
           event_type: 'RestartingPhases';
           payload: SetupPhase[];
+      }
+    | {
+          event_type: 'BackgroundNodeSyncUpdate';
+          payload: BackgroundNodeSyncUpdatePayload;
       };

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -41,3 +41,24 @@ export interface NodeTypeUpdatePayload {
     };
     node_connection_address?: string;
 }
+
+export type BackgroundNodeSyncUpdatePayload =
+    | {
+          step: 'Startup';
+          initial_connected_peers: number;
+          required_peers: number;
+      }
+    | {
+          step: 'Header';
+          local_header_height: number;
+          tip_header_height: number;
+          local_block_height: number;
+          tip_block_height: number;
+      }
+    | {
+          step: 'Block';
+          local_header_height: number;
+          tip_header_height: number;
+          local_block_height: number;
+          tip_block_height: number;
+      };


### PR DESCRIPTION
* Add local node syncing status in settings when synced in the background
![Screenshot from 2025-04-09 09-15-56](https://github.com/user-attachments/assets/7c661da6-7c4a-4367-ab5b-81b2e8d03f80)

* use note types as Remote and Local only

* fix displaying Block sync progress(local header was incorrect)