### PR TITLE
fix(quick-load): lone tower

### DIFF
--- a/src/App/App.styles.ts
+++ b/src/App/App.styles.ts
@@ -43,7 +43,6 @@ export const AppContentContainer = styled(m.div).attrs({
     height: 100vh;
     z-index: 1;
     position: relative;
-
     pointer-events: none;
     * > {
         pointer-events: all;

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -16,13 +16,11 @@ import { AppContentContainer } from './App.styles.ts';
 import { useUIStore } from '@app/store/useUIStore.ts';
 import { TOWER_CANVAS_ID } from '@app/store';
 
-const CurrentAppSection = function CurrentAppSection({
-    showSplashscreen,
-    isShuttingDown,
-}: {
+interface CurrentAppSectionProps {
     showSplashscreen?: boolean;
     isShuttingDown?: boolean;
-}) {
+}
+function CurrentAppSection({ showSplashscreen, isShuttingDown }: CurrentAppSectionProps) {
     const currentSection = useMemo(() => {
         const showMainView = !isShuttingDown && !showSplashscreen;
 
@@ -53,7 +51,7 @@ const CurrentAppSection = function CurrentAppSection({
     }, [showSplashscreen, isShuttingDown]);
 
     return <AnimatePresence mode="wait">{currentSection}</AnimatePresence>;
-};
+}
 
 export default function App() {
     const isShuttingDown = useShuttingDown();

--- a/src/components/CharSpinner/CharSpinner.tsx
+++ b/src/components/CharSpinner/CharSpinner.tsx
@@ -1,4 +1,3 @@
-import { Trans } from 'react-i18next';
 import { Character, Characters, CharacterWrapper, SpinnerWrapper, Wrapper, XTMWrapper } from './CharSpinner.styles.ts';
 
 const transition = {
@@ -97,12 +96,7 @@ export default function CharSpinner({
                 <CharacterWrapper style={{ height: letterHeight * 10 }}>{charMarkup}</CharacterWrapper>
             </SpinnerWrapper>
 
-            {/* // eslint-disable-next-line i18next/no-literal-string */}
-            {value === '-' ? null : (
-                <XTMWrapper>
-                    <Trans>tXTM</Trans>
-                </XTMWrapper>
-            )}
+            {value === `-` ? null : <XTMWrapper>{`tXTM`}</XTMWrapper>}
         </Wrapper>
     );
 }

--- a/src/components/transactions/components/Tabs/tab.styles.ts
+++ b/src/components/transactions/components/Tabs/tab.styles.ts
@@ -1,40 +1,9 @@
 import styled, { css } from 'styled-components';
-import * as m from 'motion/react-m';
-import { SB_WIDTH } from '@app/theme/styles.ts';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { convertHexToRGBA } from '@app/utils';
 import { IconButton } from '@app/components/elements/buttons/IconButton.tsx';
 import { Button } from '@app/components/elements/buttons/Button.tsx';
 
-export const TabsWrapper = styled.div`
-    width: 100%;
-    display: flex;
-`;
-export const Wrapper = styled.div`
-    width: 100%;
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    position: relative;
-    overflow: hidden;
-    gap: 15px;
-`;
-
-export const GUTTER = 20;
-export const SB_CONTENT_WIDTH = SB_WIDTH - GUTTER * 2;
-export const Track = styled(m.div)`
-    display: flex;
-    flex-direction: row;
-    gap: 20px;
-    flex-shrink: 0;
-`;
-
-export const ItemWrapper = styled(m.div)`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    max-height: 100%;
-`;
 export const HeaderLabel = styled(Typography).attrs({
     variant: 'p',
 })`
@@ -49,7 +18,7 @@ export const TabHeader = styled.div<{ $noBorder?: boolean }>`
     text-transform: capitalize;
     justify-content: space-between;
     align-items: center;
-    padding: 0px 0 15px 0;
+    padding: 0 0 15px 0;
     border-bottom: ${({ theme }) => `1px solid ${theme.colorsAlpha.greyscaleAlpha[10]}`};
 
     ${({ $noBorder }) =>

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -12,7 +12,6 @@ import { Language } from '@app/i18initializer';
 import { PaperWalletDetails } from '@app/types/app-status.ts';
 import { displayMode, modeType } from '@app/store/types.ts';
 import { SignData } from '@app/types/ws.ts';
-import { SetupPhase } from './backend-state';
 
 declare module '@tauri-apps/api/core' {
     function invoke(


### PR DESCRIPTION
could not reproduce after the first time it happened, but this is the only thing i could think of MAYBE having an impact on which screens show up after the splash screen :/ 

just removed the `const CurrentAppSection = function CurrentAppSection({....` left over from when it was memoized. 

the rest of the changes are just lint fixes