### PR TITLE
fix: [ quick load ] hide old app_config.json

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -982,6 +982,7 @@ fn default_gpu_engine() -> String {
     EngineType::OpenCL.to_string()
 }
 
+#[allow(dead_code)]
 async fn create_monereo_address(path: PathBuf) -> Result<String, anyhow::Error> {
     let cm = CredentialManager::default_with_dir(path);
 

--- a/src-tauri/src/configs/config_core.rs
+++ b/src-tauri/src/configs/config_core.rs
@@ -127,29 +127,34 @@ impl ConfigImpl for ConfigCore {
         &mut self.content
     }
 
-    fn migrate_old_config(&mut self, old_config: Self::OldConfig) {
+    fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>) {
         if self.content.was_config_migrated {
             return;
         }
 
-        self.content = ConfigCoreContent {
-            was_config_migrated: true,
-            created_at: SystemTime::now(),
-            is_p2pool_enabled: old_config.p2pool_enabled(),
-            use_tor: old_config.use_tor(),
-            allow_telemetry: old_config.allow_telemetry(),
-            last_binaries_update_timestamp: old_config.last_binaries_update_timestamp(),
-            anon_id: old_config.anon_id().to_string(),
-            should_auto_launch: old_config.should_auto_launch(),
-            mmproxy_use_monero_failover: old_config.mmproxy_use_monero_fail(),
-            mmproxy_monero_nodes: old_config.mmproxy_monero_nodes().to_vec(),
-            auto_update: old_config.auto_update(),
-            p2pool_stats_server_port: old_config.p2pool_stats_server_port(),
-            pre_release: old_config.pre_release(),
-            last_changelog_version: Version::from_str(old_config.last_changelog_version())
-                .unwrap_or_else(|_| Version::new(0, 0, 0)),
-            airdrop_tokens: old_config.airdrop_tokens(),
-            ..Default::default()
-        };
+        if old_config.is_some() {
+            let old_config = old_config.expect("Old config should be present");
+            self.content = ConfigCoreContent {
+                was_config_migrated: true,
+                created_at: SystemTime::now(),
+                is_p2pool_enabled: old_config.p2pool_enabled(),
+                use_tor: old_config.use_tor(),
+                allow_telemetry: old_config.allow_telemetry(),
+                last_binaries_update_timestamp: old_config.last_binaries_update_timestamp(),
+                anon_id: old_config.anon_id().to_string(),
+                should_auto_launch: old_config.should_auto_launch(),
+                mmproxy_use_monero_failover: old_config.mmproxy_use_monero_fail(),
+                mmproxy_monero_nodes: old_config.mmproxy_monero_nodes().to_vec(),
+                auto_update: old_config.auto_update(),
+                p2pool_stats_server_port: old_config.p2pool_stats_server_port(),
+                pre_release: old_config.pre_release(),
+                last_changelog_version: Version::from_str(old_config.last_changelog_version())
+                    .unwrap_or_else(|_| Version::new(0, 0, 0)),
+                airdrop_tokens: old_config.airdrop_tokens(),
+                ..Default::default()
+            };
+        } else {
+            self.content.set_was_config_migrated(true);
+        }
     }
 }

--- a/src-tauri/src/configs/config_mining.rs
+++ b/src-tauri/src/configs/config_mining.rs
@@ -123,26 +123,31 @@ impl ConfigImpl for ConfigMining {
         &mut self.content
     }
 
-    fn migrate_old_config(&mut self, old_config: Self::OldConfig) {
+    fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>) {
         if self.content.was_config_migrated {
             return;
         }
 
-        self.content = ConfigMiningContent {
-            was_config_migrated: true,
-            created_at: SystemTime::now(),
-            mode: old_config.mode(),
-            custom_max_cpu_usage: old_config.custom_cpu_usage(),
-            custom_max_gpu_usage: old_config.custom_gpu_usage(),
-            mine_on_app_start: old_config.mine_on_app_start(),
-            custom_mode_cpu_options: old_config.custom_mode_cpu_options().clone(),
-            eco_mode_cpu_options: old_config.eco_mode_cpu_options().clone(),
-            eco_mode_cpu_threads: old_config.eco_mode_cpu_threads(),
-            gpu_engine: old_config.gpu_engine(),
-            ludicrous_mode_cpu_options: old_config.ludicrous_mode_cpu_options().clone(),
-            gpu_mining_enabled: old_config.gpu_mining_enabled(),
-            cpu_mining_enabled: old_config.cpu_mining_enabled(),
-            ludicrous_mode_cpu_threads: old_config.ludicrous_mode_cpu_threads(),
-        };
+        if old_config.is_some() {
+            let old_config = old_config.expect("Old config should be present");
+            self.content = ConfigMiningContent {
+                was_config_migrated: true,
+                created_at: SystemTime::now(),
+                mode: old_config.mode(),
+                custom_max_cpu_usage: old_config.custom_cpu_usage(),
+                custom_max_gpu_usage: old_config.custom_gpu_usage(),
+                mine_on_app_start: old_config.mine_on_app_start(),
+                custom_mode_cpu_options: old_config.custom_mode_cpu_options().clone(),
+                eco_mode_cpu_options: old_config.eco_mode_cpu_options().clone(),
+                eco_mode_cpu_threads: old_config.eco_mode_cpu_threads(),
+                gpu_engine: old_config.gpu_engine(),
+                ludicrous_mode_cpu_options: old_config.ludicrous_mode_cpu_options().clone(),
+                gpu_mining_enabled: old_config.gpu_mining_enabled(),
+                cpu_mining_enabled: old_config.cpu_mining_enabled(),
+                ludicrous_mode_cpu_threads: old_config.ludicrous_mode_cpu_threads(),
+            };
+        } else {
+            self.content.set_was_config_migrated(true);
+        }
     }
 }

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -125,23 +125,28 @@ impl ConfigImpl for ConfigUI {
         &mut self.content
     }
 
-    fn migrate_old_config(&mut self, old_config: Self::OldConfig) {
+    fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>) {
         if self.content.was_config_migrated {
             return;
         }
 
-        self.content = ConfigUIContent {
-            was_config_migrated: true,
-            created_at: SystemTime::now(),
-            display_mode: old_config.display_mode(),
-            has_system_language_been_proposed: old_config.has_system_language_been_proposed(),
-            should_always_use_system_language: old_config.should_always_use_system_language(),
-            application_language: old_config.application_language().to_string(),
-            paper_wallet_enabled: old_config.paper_wallet_enabled(),
-            custom_power_levels_enabled: old_config.custom_power_levels_enabled(),
-            sharing_enabled: old_config.sharing_enabled(),
-            visual_mode: old_config.visual_mode(),
-            show_experimental_settings: old_config.show_experimental_settings(),
-        };
+        if old_config.is_some() {
+            let old_config = old_config.expect("Old config should be present");
+            self.content = ConfigUIContent {
+                was_config_migrated: true,
+                created_at: SystemTime::now(),
+                display_mode: old_config.display_mode(),
+                has_system_language_been_proposed: old_config.has_system_language_been_proposed(),
+                should_always_use_system_language: old_config.should_always_use_system_language(),
+                application_language: old_config.application_language().to_string(),
+                paper_wallet_enabled: old_config.paper_wallet_enabled(),
+                custom_power_levels_enabled: old_config.custom_power_levels_enabled(),
+                sharing_enabled: old_config.sharing_enabled(),
+                visual_mode: old_config.visual_mode(),
+                show_experimental_settings: old_config.show_experimental_settings(),
+            };
+        } else {
+            self.content.set_was_config_migrated(true);
+        }
     }
 }

--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -101,17 +101,22 @@ impl ConfigImpl for ConfigWallet {
         &mut self.content
     }
 
-    fn migrate_old_config(&mut self, old_config: Self::OldConfig) {
+    fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>) {
         if self.content.was_config_migrated {
             return;
         }
 
-        self.content = ConfigWalletContent {
-            was_config_migrated: true,
-            created_at: SystemTime::now(),
-            keyring_accessed: old_config.keyring_accessed(),
-            monero_address: old_config.monero_address().to_string(),
-            monero_address_is_generated: old_config.monero_address_is_generated(),
-        };
+        if old_config.is_some() {
+            let old_config = old_config.expect("Old config should be present");
+            self.content = ConfigWalletContent {
+                was_config_migrated: true,
+                created_at: SystemTime::now(),
+                keyring_accessed: old_config.keyring_accessed(),
+                monero_address: old_config.monero_address().to_string(),
+                monero_address_is_generated: old_config.monero_address_is_generated(),
+            };
+        } else {
+            self.content.set_was_config_migrated(true);
+        }
     }
 }

--- a/src-tauri/src/configs/trait_config.rs
+++ b/src-tauri/src/configs/trait_config.rs
@@ -155,7 +155,7 @@ pub trait ConfigImpl {
             .await;
         Ok(())
     }
-    async fn update_field_with_restart<F, I>(
+    async fn update_field_requires_restart<F, I>(
         setter_callback: F,
         value: I,
         phases_to_restart: Vec<SetupPhase>,

--- a/src-tauri/src/configs/trait_config.rs
+++ b/src-tauri/src/configs/trait_config.rs
@@ -109,7 +109,7 @@ pub trait ConfigImpl {
         Self::current().read().await._get_content().clone()
     }
     async fn load_app_handle(&mut self, app_handle: AppHandle);
-    fn migrate_old_config(&mut self, old_config: Self::OldConfig);
+    fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>);
     async fn update_field<F, I: Debug>(setter_callback: F, value: I) -> Result<(), Error>
     where
         I: Serialize + Clone,

--- a/src-tauri/src/configs/trait_config.rs
+++ b/src-tauri/src/configs/trait_config.rs
@@ -110,9 +110,9 @@ pub trait ConfigImpl {
     }
     async fn load_app_handle(&mut self, app_handle: AppHandle);
     fn handle_old_config_migration(&mut self, old_config: Option<Self::OldConfig>);
-    async fn update_field<F, I: Debug>(setter_callback: F, value: I) -> Result<(), Error>
+    async fn update_field<F, I>(setter_callback: F, value: I) -> Result<(), Error>
     where
-        I: Serialize + Clone,
+        I: Serialize + Clone + Debug,
         F: FnOnce(&mut Self::Config, I) -> &mut Self::Config,
         Self: 'static,
     {
@@ -139,13 +139,13 @@ pub trait ConfigImpl {
         Ok(())
     }
 
-    async fn update_field_with_restart<F, I: Debug>(
+    async fn update_field_with_restart<F, I>(
         setter_callback: F,
         value: I,
         phases_to_restart: Vec<SetupPhase>,
     ) -> Result<(), Error>
     where
-        I: Serialize + Clone,
+        I: Serialize + Clone + Debug,
         F: FnOnce(&mut Self::Config, I) -> &mut Self::Config,
         Self: 'static,
     {

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -185,10 +185,10 @@ impl SetupManager {
             .app_config_dir()
             .expect("Could not get config dir");
 
-        let is_old_config_file_exists = old_config.is_file_exists(old_config_path.clone());
-        let old_config_content = match is_old_config_file_exists {
-            true => Some(old_config.clone()),
-            false => None,
+        let old_config_content = if old_config.is_file_exists(old_config_path.clone()) {
+            Some(old_config.clone())
+        } else {
+            None
         };
 
         let mut config_core = ConfigCore::current().write().await;


### PR DESCRIPTION
### [ Summary ]
- Changed `load_or_create` method in `app_config` to prevent creating new default config file with each start
- When `app_config` is present it will be loaded and then migrated to new configs
- When `app_config` is not present migrations will be skiped and `is_migrated` flag will be set to `true`
- If `app_config` is present it will be moved to `{configs_location}/old/app_config.json` after migrations