### PR TITLE
feat: adds orphan flag to telemetry

### DIFF
--- a/src-tauri/src/app_in_memory_config.rs
+++ b/src-tauri/src/app_in_memory_config.rs
@@ -64,8 +64,8 @@ impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
 impl Default for AppInMemoryConfig {
     fn default() -> Self {
         AppInMemoryConfig {
-            airdrop_url: "http://localhost:4000".into(),
-            airdrop_api_url: "http://localhost:3004".into(),
+            airdrop_url: "https://airdrop.tari.com".into(),
+            airdrop_api_url: "https://ut.tari.com".into(),
             telemetry_api_url: "https://ut.tari.com/push".into(),
         }
     }

--- a/src-tauri/src/app_in_memory_config.rs
+++ b/src-tauri/src/app_in_memory_config.rs
@@ -64,8 +64,8 @@ impl From<AppInMemoryConfig> for AirdropInMemoryConfig {
 impl Default for AppInMemoryConfig {
     fn default() -> Self {
         AppInMemoryConfig {
-            airdrop_url: "https://airdrop.tari.com".into(),
-            airdrop_api_url: "https://ut.tari.com".into(),
+            airdrop_url: "http://localhost:4000".into(),
+            airdrop_api_url: "http://localhost:3004".into(),
             telemetry_api_url: "https://ut.tari.com/push".into(),
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1049,6 +1049,7 @@ fn main() {
         p2pool_stats_rx.clone(),
         tor_watch_rx.clone(),
         stats_collector.build(),
+        node_manager.clone(),
     );
     let telemetry_service = TelemetryService::new(app_config.clone(), app_in_memory_config.clone());
     let updates_manager = UpdatesManager::new(app_config.clone(), shutdown.to_signal());


### PR DESCRIPTION
This commit integrates the `NodeManager` into the telemetry data collection process. This allows us to gather information about the node's status, specifically whether it is on an orphan chain, and include this data in the telemetry reports. The `is_orphan` status is added to the telemetry data payload. Also local host urls for airdrop endpoints added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced telemetry reporting now provides more comprehensive status insights for improved system monitoring. This update gathers additional performance data to deliver greater operational transparency, helping users access deeper insights into system behavior and trends for a more robust monitoring experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->