### PR TITLE
feat(quick load): increase wallet scanning timeout

### DIFF
--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -85,7 +85,7 @@ impl EventsManager {
                 _ = shutdown_signal.wait() => {
                     info!(target: LOG_TARGET, "Shutdown signal received. Exiting wait for initial wallet scan");
                 }
-                result = events_service.wait_for_wallet_scan(block_height, Duration::from_secs(300)) => {
+                result = events_service.wait_for_wallet_scan(block_height, Duration::from_secs(3600)) => {
                     match result {
                         Ok(scanned_wallet_state) => match scanned_wallet_state.balance {
                             Some(balance) => EventsEmitter::emit_wallet_balance_update(&app, balance).await,


### PR DESCRIPTION
Wallet scanning takes long time when scanning with the remote node. It's safe to increase timeout, because bad state will immediately stop it.