### PR TITLE
fix: await connected peers shutdown

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1233,6 +1233,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,7 +3021,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -4166,6 +4208,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matches"
@@ -6392,8 +6443,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -6404,8 +6464,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7199,6 +7265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7736,6 +7811,7 @@ dependencies = [
  "blake2",
  "cfspeedtest",
  "chrono",
+ "console-subscriber",
  "der",
  "device_query",
  "dirs 5.0.1",
@@ -8745,6 +8821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8835,6 +8921,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.8",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -9100,6 +9187,12 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
  "tracing-core",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -103,6 +103,7 @@ reqwest-middleware = "0.4.0"
 reqwest-retry = "0.7.0"
 cfspeedtest = "1.3.1"
 getset = "0.1.5"
+console-subscriber = "0.4.1"
 
 [target.'cfg(windows)'.dependencies]
 planif = "1.0.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -249,9 +249,9 @@ async fn initialize_frontend_updates(app: &tauri::AppHandle) -> Result<(), anyho
 
     let move_app = app.clone();
 
-    TasksTrackers::current().common.get_task_tracker().await.spawn(async move {
+    TasksTrackers::current().node_phase.get_task_tracker().await.spawn(async move {
         let app_state = move_app.state::<UniverseAppState>().clone();
-        let mut shutdown_signal = TasksTrackers::current().common.get_signal().await;
+        let mut shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
         let mut interval = time::interval(Duration::from_secs(10));
 
         loop {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -987,6 +987,16 @@ fn main() {
     let _unused = fix_path_env::fix();
     // TODO: Integrate sentry into logs. Because we are using Tari's logging infrastructure, log4rs
     // sets the logger and does not expose a way to add sentry into it.
+    #[cfg(debug_assertions)]
+    {
+        if cfg!(tokio_unstable) {
+            console_subscriber::init();
+        } else {
+            println!(
+                "Tokio console disabled. To enable, run with: RUSTFLAGS=\"--cfg tokio_unstable\""
+            );
+        }
+    }
 
     let client = sentry::init((
         "https://edd6b9c1494eb7fda6ee45590b80bcee@o4504839079002112.ingest.us.sentry.io/4507979991285760",


### PR DESCRIPTION
Description
---
Fix 10 minute shutdown after remote node become unhealthy.
```
15:31:18 INFO  Triggering shutdown for Common processes
15:31:18 INFO  Triggering task close for Common processes
15:31:18 INFO  TelemetryManager::start_telemetry_process has been cancelled by app shutdown
15:31:18 INFO  Shutdown signal received. Stopping periodic updates.
15:31:18 INFO  Waiting for Common processes to finish
15:31:21 ERROR remote_minotari_node is not healthy: health check timed out
... 10 minutes of same error message ...
15:41:36 ERROR remote_minotari_node is not healthy: health check timed out
15:41:39 ERROR Error getting connected peers
15:41:39 ERROR Unknown error: status: Unavailable, message: "grpc-status header missing, mapped from HTTP status code 502", details: [], metadata: MetadataMap { headers: {"alt-svc": "h3=\":443\"; ma=2592000", "server": "Caddy", "x-host": "tari-nextnet-grpc-bhs-01", "content-length": "0", "date": "Thu, 10 Apr 2025 13:41:39 GMT"} }
15:41:39 WARN  Remote Node Health Check Error: checking base node status: UnknownError(status: Unavailable, message: "grpc-status header missing, mapped from HTTP status code 502", details: [], metadata: MetadataMap { headers: {"alt-svc": "h3=\":443\"; ma=2592000", "server": "Caddy", "x-host": "tari-nextnet-grpc-bhs-01", "content-length": "0", "date": "Thu, 10 Apr 2025 13:41:39 GMT"} })
15:41:39 WARN  remote_minotari_node is not healthy. Health check returned false
15:41:40 ERROR Unknown error: status: Unavailable, message: "grpc-status header missing, mapped from HTTP status code 502", details: [], metadata: MetadataMap { headers: {"alt-svc": "h3=\":443\"; ma=2592000", "server": "Caddy", "x-host": "tari-nextnet-grpc-bhs-01", "content-length": "0", "date": "Thu, 10 Apr 2025 13:41:40 GMT"} }
15:41:43 INFO  Node is not synced, skipping orphan chain check
```

Motivation and Context
---
While remote node was unhealthy, call for listing connected peers was blocked and this task wouldn't receive shutdown signal.
Since node runs on `node` phase task tracker than we should we able to gracefully shutdown it if signal and runtime are from same task tracker.

How Has This Been Tested?
---
I have no 100% reproduction scenario. It happens after running TU for at least 10 minutes.

What process can a PR reviewer use to test or verify this change?
---
Same as above

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
