### PR TITLE
feat(quick load): fix node connection issues and corrupted db

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -382,20 +382,21 @@ impl NodeStatusMonitor {
 
 #[async_trait]
 impl StatusMonitor for NodeStatusMonitor {
-    async fn check_health(&self, _uptime: Duration) -> HealthStatus {
+    async fn check_health(&self, uptime: Duration) -> HealthStatus {
         let duration = std::time::Duration::from_secs(5);
         match timeout(duration, self.node_client.get_network_state()).await {
             Ok(res) => match res {
                 Ok(status) => {
                     let _res = self.status_broadcast.send(status.clone());
-                    if status.num_connections == 0
+                    if status.num_connections == 0 && uptime > Duration::from_secs(60)
                         // Remote Node always returns 0 connections
                         && self.node_type != NodeType::Remote
                         && self.node_type != NodeType::RemoteUntilLocal
                     {
                         warn!(
-                            "{:?} Node Health Check Warning: No connections",
-                            self.node_type
+                            "{:?} Node Health Check Warning: No connections | status: {:?}",
+                            self.node_type,
+                            status.clone()
                         );
                         return HealthStatus::Warning;
                     }
@@ -429,21 +430,15 @@ impl StatusMonitor for NodeStatusMonitor {
                 }
             },
             Err(e) => {
-                warn!("{:?} Node Health Check Error. {:?}", self.node_type, e);
+                warn!(
+                    "{:?} Node Health Check (get_network_state) error: {:?}",
+                    self.node_type, e
+                );
                 match self.node_client.get_identity().await {
-                    Ok(_) => match self.node_client.get_identity().await {
-                        Ok(identity) => {
-                            info!(target: LOG_TARGET, "{:?} Node identity: {:?}", self.node_type, identity);
-                            return HealthStatus::Healthy;
-                        }
-                        Err(e) => {
-                            warn!(
-                                "{:?} Node Health Check Error: checking base node identity: {:?}",
-                                self.node_type, e
-                            );
-                            return HealthStatus::Unhealthy;
-                        }
-                    },
+                    Ok(identity) => {
+                        info!(target: LOG_TARGET, "{:?} Node hecking base node identity success: {:?}", self.node_type, identity);
+                        return HealthStatus::Healthy;
+                    }
                     Err(e) => {
                         warn!(
                             "{:?} Node Health Check Error: checking base node identity: {:?}",


### PR DESCRIPTION
* Handle corrupted state
* Solve problems when node hasn't started yet and we treat it as unhealthy
* wait 60sec before propagating warnings for node healthcheck
* `wait_ready` waits for both local and remote node for RemoteUntilLocal
* wait ready stops on shutdown signal