### PR TITLE
fix(quick-load): ui issues - smaller screens and missing hashrates

### DIFF
--- a/src/containers/main/Sync/components/Progress.tsx
+++ b/src/containers/main/Sync/components/Progress.tsx
@@ -47,16 +47,6 @@ export default function Progress() {
     }, [corePhaseInfoPayload, hardwarePhaseInfoPayload, nodePhaseInfoPayload, unknownPhaseInfoPayload]);
 
     const setupProgress = currentPhaseToShow?.progress;
-    // const setupPhaseTitle = currentPhaseToShow?.phase_title;
-    // const setupTitle = currentPhaseToShow?.title;
-    // const setupParams = currentPhaseToShow?.title_params ? { ...currentPhaseToShow.title_params } : {};
-
-    // const setUpText = setupTitle ? t(`setup-view:title.${setupTitle}`, setupTitleParams) : '';
-
-    // const setUpText =
-    //     setupTitle && setupPhaseTitle
-    //         ? `${t(`phase-title.${setupPhaseTitle}`)} | ${t(`title.${setupTitle}`, { ...setupParams })}`
-    //         : '';
 
     const setUpText =
         countdown === 1

--- a/src/containers/main/Sync/sync.styles.ts
+++ b/src/containers/main/Sync/sync.styles.ts
@@ -25,6 +25,9 @@ export const Content = styled(m.div)`
     overflow: hidden;
     gap: 40px;
     padding: calc(0.3rem + 1vmin);
+    @media (max-height: 955px) {
+        gap: 30px;
+    }
 `;
 
 export const HeaderContent = styled(m.div)`
@@ -44,7 +47,7 @@ export const SubHeading = styled(Typography).attrs({ variant: 'p' })`
 `;
 
 export const HeaderImg = styled.img`
-    width: min(360px, 34vh);
+    width: min(360px, 32vh);
     max-width: 100%;
 `;
 

--- a/src/store/actions/miningMetricsStoreActions.ts
+++ b/src/store/actions/miningMetricsStoreActions.ts
@@ -45,6 +45,7 @@ export const handleBaseNodeStatusUpdate = (base_node_status: BaseNodeStatus) => 
         // initial set, later updates via new block height handlers only
         setDisplayBlockHeight(base_node_status.block_height);
     }
+    useMiningMetricsStore.setState({ base_node_status });
 };
 export const handleMiningModeChange = () => {
     useMiningMetricsStore.setState((currentState) => ({


### PR DESCRIPTION
Description
---
- adjust `gap` and header image sizing on the syncing screen
- set the whole base node status in `handleBaseNodeStatusUpdate`

Motivation and Context
---

https://github.com/tari-project/universe/issues/1831

How Has This Been Tested?
---

https://github.com/user-attachments/assets/9079a731-d05d-4771-a8f3-82235022ef56

