### PR TITLE
fix: phase node high cpu

### DIFF
--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -304,8 +304,8 @@ impl SetupPhaseImpl for NodeSetupPhase {
                                 } else {
                                     warn!("Progress tracker not found for step: {}", step);
                                 }
-                                tokio::time::sleep(Duration::from_secs(1)).await;
                             }
+                            tokio::time::sleep(Duration::from_secs(1)).await;
                         },
                         _ = shutdown_signal.wait() => {
                             break;


### PR DESCRIPTION
Description
---
Reduce high CPU usage, comparison is visible on these screenshots:

before:
![cpu_usage_before](https://github.com/user-attachments/assets/b0174b50-c680-472a-95b5-4411ba5530fe)

and after:
![cpu_usage_after](https://github.com/user-attachments/assets/0e2800fd-b077-4ba2-b152-55a68dffa72b)

Motivation and Context
---
Spawned loop in `phase_node` was being polled constantly without any delay, causing my app to use 15% of all CPU without any mining.

Here is comparison between polling same future before and after:

before:
![phase_node_over_polling](https://github.com/user-attachments/assets/9403dce2-08c0-48b9-84ed-e16942c5aa40)

after:
![phase_node_fixed](https://github.com/user-attachments/assets/23f04d5c-985d-4f50-9ba3-a838cd48e304)

How Has This Been Tested?
---
Run TU on feature branch and measure CPU usage while not mining and compare it with this branch.

What process can a PR reviewer use to test or verify this change?
---
Same as above.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

