### PR TITLE
fix(ui): better send form field error message ui

### DIFF
--- a/src/components/transactions/components/TxInput.style.ts
+++ b/src/components/transactions/components/TxInput.style.ts
@@ -36,10 +36,12 @@ export const StyledInput = styled.input<{ $hasIcon?: boolean }>`
     letter-spacing: -1px;
     font-weight: 500;
     opacity: 0.9;
+
     &:focus {
         outline: none;
         opacity: 1;
     }
+
     &::placeholder {
         color: ${({ theme }) => theme.palette.text.shadow};
         font-size: 1.4rem;
@@ -73,4 +75,13 @@ export const CheckIconWrapper = styled(m.div)`
     pointer-events: none;
     width: 25px;
     height: 25px;
+`;
+
+export const ErrorText = styled(m.div)`
+    color: ${({ theme }) => theme.palette.error.main};
+
+    font-size: 12px;
+    font-weight: 500;
+    width: max-content;
+    overflow: hidden;
 `;

--- a/src/components/transactions/components/TxInput.tsx
+++ b/src/components/transactions/components/TxInput.tsx
@@ -8,8 +8,10 @@ import {
     Label,
     AccentWrapper,
     CheckIconWrapper,
+    ErrorText,
 } from './TxInput.style.ts';
 import CheckIcon from './CheckIcon.tsx';
+import { AnimatePresence } from 'motion/react';
 
 type TxInputBase = Omit<InputHTMLAttributes<HTMLInputElement>, 'name'>;
 export interface TxInputProps extends TxInputBase {
@@ -93,6 +95,17 @@ export function TxInput({
                     </CheckIconWrapper>
                 )}
             </ContentWrapper>
+            <AnimatePresence>
+                {errorMessage && (
+                    <ErrorText
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                    >
+                        {errorMessage}
+                    </ErrorText>
+                )}
+            </AnimatePresence>
         </Wrapper>
     );
 }

--- a/src/components/transactions/send/FormField.tsx
+++ b/src/components/transactions/send/FormField.tsx
@@ -15,6 +15,7 @@ interface FormFieldProps {
     autoFocus?: boolean;
     truncateOnBlur?: boolean;
     isValid?: boolean;
+    errorText?: string;
 }
 export function FormField({
     control,
@@ -27,6 +28,7 @@ export function FormField({
     truncateOnBlur,
     onBlur,
     isValid,
+    errorText,
 }: FormFieldProps) {
     const { t } = useTranslation('wallet');
     const labelT = t(`send.label`, { context: name });
@@ -58,7 +60,7 @@ export function FormField({
                         label={labelT}
                         icon={icon}
                         accent={accent}
-                        errorMessage={fieldState.error?.message}
+                        errorMessage={errorText || fieldState.error?.message}
                         autoFocus={autoFocus}
                         truncateOnBlur={truncateOnBlur}
                         truncateText={truncateOnBlur && rest.value ? String(rest.value) : undefined}

--- a/src/components/transactions/send/Send.tsx
+++ b/src/components/transactions/send/Send.tsx
@@ -150,6 +150,7 @@ export function Send({ setSection }: Props) {
                             autoFocus
                             truncateOnBlur
                             isValid={isAddressValid}
+                            errorText={errors.address?.message}
                         />
 
                         <FormField control={control} name="message" handleChange={handleChange} />
@@ -177,10 +178,6 @@ export function Send({ setSection }: Props) {
                         >
                             {t('send.cta-send')}
                         </Button>
-                        <ErrorMessageWrapper>
-                            <Typography variant="p">{errors.address?.message}</Typography>
-                            <Typography variant="p">{errors.amount?.message}</Typography>
-                        </ErrorMessageWrapper>
                     </BottomWrapper>
                 </StyledForm>
                 <AnimatePresence>{showConfirmation && <Confirmation />}</AnimatePresence>

--- a/src/components/transactions/send/Send.tsx
+++ b/src/components/transactions/send/Send.tsx
@@ -10,13 +10,12 @@ import { addPendingTransaction, setError as setStoreError } from '@app/store';
 import { Button } from '@app/components/elements/buttons/Button.tsx';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
 import { TariOutlineSVG } from '@app/assets/icons/tari-outline.tsx';
-import { Typography } from '@app/components/elements/Typography.tsx';
 
 import type { InputName, SendInputs } from './types.ts';
 import { Confirmation } from './Confirmation.tsx';
 import { FormField } from './FormField.tsx';
 
-import { BottomWrapper, DividerIcon, ErrorMessageWrapper, FormFieldsWrapper, StyledForm, Wrapper } from './Send.styles';
+import { BottomWrapper, DividerIcon, FormFieldsWrapper, StyledForm, Wrapper } from './Send.styles';
 import { HeaderLabel, TabHeader } from '../components/Tabs/tab.styles.ts';
 
 const defaultValues = { message: '', address: '', amount: '' };


### PR DESCRIPTION
I've improved the error message UI for the Send form fields. The errors now animate and are part of the Input components. This provides more context to the user and looks much better visually. 

![CleanShot 2025-04-14 at 18 09 43@2x](https://github.com/user-attachments/assets/aaeccc94-011c-48e0-9ecc-486252f3515d)

![CleanShot 2025-04-14 at 18 15 06@2x](https://github.com/user-attachments/assets/20dcc49c-19c7-41ba-b943-395446112d74)
