### PR TITLE
chore: bump tower and deps not on wanted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
             "name": "tari-universe",
             "version": "0.9.840",
             "dependencies": {
-                "@floating-ui/react": "^0.27.5",
+                "@floating-ui/react": "^0.27.7",
                 "@lottiefiles/dotlottie-react": "^0.13.2",
-                "@tari-project/tari-tower": "^0.0.30",
+                "@tari-project/tari-tower": "^0.0.31",
                 "@tauri-apps/api": "^2.4.0",
                 "@tauri-apps/plugin-clipboard-manager": "^2.2.2",
                 "@tauri-apps/plugin-os": "^2.2.1",
@@ -21,7 +21,7 @@
                 "i18next-browser-languagedetector": "^8.0.4",
                 "i18next-http-backend": "^3.0.2",
                 "linkify-react": "^4.2.0",
-                "motion": "^12.5.0",
+                "motion": "^12.7.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.2.0",
                 "react-hook-form": "^7.54.2",
@@ -41,7 +41,7 @@
                 "@nabla/vite-plugin-eslint": "^2.0.5",
                 "@taplo/cli": "^0.7.0",
                 "@tauri-apps/cli": "^2.4.0",
-                "@types/node": "^22.13.13",
+                "@types/node": "^22.14.1",
                 "@types/react": "^18.3.20",
                 "@types/react-dom": "^18.3.5",
                 "@types/uuid": "^10.0.0",
@@ -49,18 +49,18 @@
                 "@vitejs/plugin-react": "^4.3.4",
                 "babel-plugin-styled-components": "^2.1.4",
                 "eslint": "^9.23.0",
-                "eslint-config-prettier": "^10.1.1",
+                "eslint-config-prettier": "^10.1.2",
                 "eslint-plugin-i18next": "^6.1.1",
                 "eslint-plugin-prettier": "^5.2.5",
                 "eslint-plugin-react": "^7.37.3",
                 "eslint-plugin-react-compiler": "^19.0.0-beta-30d8a17-20250209",
                 "eslint-plugin-react-hooks": "^5.2.0",
-                "knip": "^5.46.0",
+                "knip": "^5.50.3",
                 "prettier": "^3.5.3",
                 "react-qr-code": "^2.0.15",
                 "typescript": "^5.8.2",
-                "typescript-eslint": "^8.28.0",
-                "vite": "^6.2.3"
+                "typescript-eslint": "^8.29.1",
+                "vite": "^6.2.6"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1207,9 +1207,9 @@
             }
         },
         "node_modules/@floating-ui/react": {
-            "version": "0.27.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.6.tgz",
-            "integrity": "sha512-9GLOPbW8jTeboR2ar9uMMUDUZjpTLscUvOjNvRw2EgppgoLHLUh/P/OW9evULosnvDjhYf2Gwk/gMOP9KvXD2A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.7.tgz",
+            "integrity": "sha512-5V9pwFeiv+95Jlowq/7oiGISSrdXMTs2jfoSy8k+WM6oI/Skm1WWjPdJWeporN2O4UGcsaCJdirKffKayMoPgw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react-dom": "^2.1.2",
@@ -1724,24 +1724,6 @@
                 "win32"
             ]
         },
-        "node_modules/@snyk/github-codeowners": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@snyk/github-codeowners/-/github-codeowners-1.1.0.tgz",
-            "integrity": "sha512-lGFf08pbkEac0NYgVf4hdANpAgApRjNByLXB+WBip3qj1iendOIyAwP2GKkKbQMNVy2r1xxDf0ssfWscoiC+Vw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^4.1.1",
-                "ignore": "^5.1.8",
-                "p-map": "^4.0.0"
-            },
-            "bin": {
-                "github-codeowners": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=8.10"
-            }
-        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -1759,9 +1741,9 @@
             }
         },
         "node_modules/@tari-project/tari-tower": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@tari-project/tari-tower/-/tari-tower-0.0.30.tgz",
-            "integrity": "sha512-pGkxvJDC3EX6MrUUjmu3zdTBrdOd8oL7LYUdQPjQgiYPxfIeSYLAEAa5qHTKg3bdidkvAT5Hzi1YOKbFEoNd0g==",
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/@tari-project/tari-tower/-/tari-tower-0.0.31.tgz",
+            "integrity": "sha512-3rkZHWIYdN8nHIUndwTqv0fFwSnJCtZ1lhhO5fIiew5y9AeKLaAcQQvQUGLY0oEVAM5v432SZz19WJaQqimpOA==",
             "license": "ISC",
             "peerDependencies": {
                 "min-signal": "^1.0.2",
@@ -2134,9 +2116,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.14.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-            "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+            "version": "22.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+            "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2189,17 +2171,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
-            "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.1.tgz",
+            "integrity": "sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.29.0",
-                "@typescript-eslint/type-utils": "8.29.0",
-                "@typescript-eslint/utils": "8.29.0",
-                "@typescript-eslint/visitor-keys": "8.29.0",
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/type-utils": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -2219,16 +2201,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
-            "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.1.tgz",
+            "integrity": "sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.29.0",
-                "@typescript-eslint/types": "8.29.0",
-                "@typescript-eslint/typescript-estree": "8.29.0",
-                "@typescript-eslint/visitor-keys": "8.29.0",
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/typescript-estree": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2244,14 +2226,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
-            "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.1.tgz",
+            "integrity": "sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.0",
-                "@typescript-eslint/visitor-keys": "8.29.0"
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2262,14 +2244,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
-            "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.1.tgz",
+            "integrity": "sha512-DkDUSDwZVCYN71xA4wzySqqcZsHKic53A4BLqmrWFFpOpNSoxX233lwGu/2135ymTCR04PoKiEEEvN1gFYg4Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.29.0",
-                "@typescript-eslint/utils": "8.29.0",
+                "@typescript-eslint/typescript-estree": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -2286,9 +2268,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
-            "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.1.tgz",
+            "integrity": "sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2300,14 +2282,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
-            "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.1.tgz",
+            "integrity": "sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.0",
-                "@typescript-eslint/visitor-keys": "8.29.0",
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/visitor-keys": "8.29.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -2327,16 +2309,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
-            "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.1.tgz",
+            "integrity": "sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.29.0",
-                "@typescript-eslint/types": "8.29.0",
-                "@typescript-eslint/typescript-estree": "8.29.0"
+                "@typescript-eslint/scope-manager": "8.29.1",
+                "@typescript-eslint/types": "8.29.1",
+                "@typescript-eslint/typescript-estree": "8.29.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2351,13 +2333,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
-            "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.1.tgz",
+            "integrity": "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.29.0",
+                "@typescript-eslint/types": "8.29.1",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -2415,20 +2397,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ajv": {
@@ -2890,16 +2858,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/clone": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -2939,16 +2897,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/commander": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/concat-map": {
@@ -3585,9 +3533,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
-            "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+            "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3676,9 +3624,9 @@
             }
         },
         "node_modules/eslint-plugin-react-compiler": {
-            "version": "19.0.0-beta-e993439-20250405",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-e993439-20250405.tgz",
-            "integrity": "sha512-8ZQU4qGc8NOfsM7u7tf7gXmZ+d4tSK+7BFb+Fvs4s9ItQ12m/G6ttSGxompH/Jq7nXgnJ20EqQRshwVG6GwUdA==",
+            "version": "19.0.0-beta-ebf51a3-20250411",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-ebf51a3-20250411.tgz",
+            "integrity": "sha512-R7ncuwbCPFAoeMlS56DGGSJFxmRtlWafYH/iWyep5Ks0RaPqTCL4k5gA87axUBBcITsaIgUGkbqAxDxl8Xfm5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4026,13 +3974,13 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.6.3",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.6.3.tgz",
-            "integrity": "sha512-2hsqknz23aloK85bzMc9nSR2/JP+fValQ459ZTVElFQ0xgwR2YqNjYSuDZdFBPOwVCt4Q9jgyTt6hg6sVOALzw==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.7.0.tgz",
+            "integrity": "sha512-BBRndpEpu61SpJj+VSuLTTglikhZRL/kdVqivqNIXF0szIJQrnGM6cASApK8eKYNVMCj1Jgh9ek6QtJroZFTRQ==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.6.3",
-                "motion-utils": "^12.6.3",
+                "motion-dom": "^12.6.5",
+                "motion-utils": "^12.6.5",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -4504,16 +4452,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
-            }
-        },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/inline-style-parser": {
@@ -5106,9 +5044,9 @@
             }
         },
         "node_modules/knip": {
-            "version": "5.47.0",
-            "resolved": "https://registry.npmjs.org/knip/-/knip-5.47.0.tgz",
-            "integrity": "sha512-ikjijudvI81Iv49YJqgujJlGSXnCTFBTU9/NwHqW9wLA31IslEs+6npRL1TAdvT7Q+5mOOh6c8xrIwGd9sV+IQ==",
+            "version": "5.50.3",
+            "resolved": "https://registry.npmjs.org/knip/-/knip-5.50.3.tgz",
+            "integrity": "sha512-0A4G7UPucGTCpNh5vHSfL0+tVQIuKfJKdg8sAq6EC3COKbAchEbM+TeN4w32OrnJW9CesHs71lqftlggMVfW2A==",
             "dev": true,
             "funding": [
                 {
@@ -5126,8 +5064,7 @@
             ],
             "license": "ISC",
             "dependencies": {
-                "@nodelib/fs.walk": "3.0.1",
-                "@snyk/github-codeowners": "1.1.0",
+                "@nodelib/fs.walk": "^1.2.3",
                 "easy-table": "1.2.0",
                 "enhanced-resolve": "^5.18.1",
                 "fast-glob": "^3.3.3",
@@ -5139,7 +5076,6 @@
                 "pretty-ms": "^9.0.0",
                 "smol-toml": "^1.3.1",
                 "strip-json-comments": "5.0.1",
-                "summary": "2.1.0",
                 "zod": "^3.22.4",
                 "zod-validation-error": "^3.0.3"
             },
@@ -5153,44 +5089,6 @@
             "peerDependencies": {
                 "@types/node": ">=18",
                 "typescript": ">=5.0.4"
-            }
-        },
-        "node_modules/knip/node_modules/@nodelib/fs.scandir": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-4.0.1.tgz",
-            "integrity": "sha512-vAkI715yhnmiPupY+dq+xenu5Tdf2TBQ66jLvBIcCddtz+5Q8LbMKaf9CIJJreez8fQ8fgaY+RaywQx8RJIWpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "4.0.0",
-                "run-parallel": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/knip/node_modules/@nodelib/fs.stat": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-4.0.0.tgz",
-            "integrity": "sha512-ctr6bByzksKRCV0bavi8WoQevU6plSp2IkllIsEqaiKe2mwNNnaluhnRhcsgGZHrrHk57B3lf95MkLMO3STYcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
-        "node_modules/knip/node_modules/@nodelib/fs.walk": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-3.0.1.tgz",
-            "integrity": "sha512-nIh/M6Kh3ZtOmlY00DaUYB4xeeV6F3/ts1l29iwl3/cfyY/OuCfUx+v08zgx8TKPTifXRcjjqVQ4KB2zOYSbyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "4.0.1",
-                "fastq": "^1.15.0"
-            },
-            "engines": {
-                "node": ">=18.18.0"
             }
         },
         "node_modules/knip/node_modules/picomatch": {
@@ -5975,12 +5873,12 @@
             }
         },
         "node_modules/motion": {
-            "version": "12.6.3",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-12.6.3.tgz",
-            "integrity": "sha512-zw/vqUgv5F5m9fkvOl/eCv2AF1+tkeZl3fu2uIlisIaip8sm5e0CouAl6GkdiRoF+G7s29CjqMdIyPMirwUGHA==",
+            "version": "12.7.0",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-12.7.0.tgz",
+            "integrity": "sha512-0LEZLdZgLWtL25W67wJKpV7ooT1w22Zf1Fy6A3TnzrwPIteEPFOknW1q5Ksj0DLiGgn5MroWbSSbhPOX7OhPeQ==",
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^12.6.3",
+                "framer-motion": "^12.7.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -6001,18 +5899,18 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.6.3",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.6.3.tgz",
-            "integrity": "sha512-gRY08RjcnzgFYLemUZ1lo/e9RkBxR+6d4BRvoeZDSeArG4XQXERSPapKl3LNQRu22Sndjf1h+iavgY0O4NrYqA==",
+            "version": "12.6.5",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.6.5.tgz",
+            "integrity": "sha512-jpM9TQLXzYMWMJ7Ec7sAj0iis8oIuu6WvjI3yNKJLdrZyrsI/b2cRInDVL8dCl683zQQq19DpL9cSMP+k8T1NA==",
             "license": "MIT",
             "dependencies": {
-                "motion-utils": "^12.6.3"
+                "motion-utils": "^12.6.5"
             }
         },
         "node_modules/motion-utils": {
-            "version": "12.6.3",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.6.3.tgz",
-            "integrity": "sha512-R/b3Ia2VxtTNZ4LTEO5pKYau1OUNHOuUfxuP0WFCTDYdHkeTBR9UtxR1cc8mDmKr8PEhmmfnTKGz3rSMjNRoRg==",
+            "version": "12.6.5",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.6.5.tgz",
+            "integrity": "sha512-IsOeKsOF+FWBhxQEDFBO6ZYC8/jlidmVbbLpe9/lXSA9j9kzGIMUuIBx2SZY+0reAS0DjZZ1i7dJp4NHrjocPw==",
             "license": "MIT"
         },
         "node_modules/ms": {
@@ -6241,22 +6139,6 @@
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -7367,13 +7249,6 @@
             "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
             "license": "MIT"
         },
-        "node_modules/summary": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/summary/-/summary-2.1.0.tgz",
-            "integrity": "sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7633,15 +7508,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.0.tgz",
-            "integrity": "sha512-ep9rVd9B4kQsZ7ZnWCVxUE/xDLUUUsRzE0poAeNu+4CkFErLfuvPt/qtm2EpnSyfvsR0S6QzDFSrPCFBwf64fg==",
+            "version": "8.29.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.1.tgz",
+            "integrity": "sha512-f8cDkvndhbQMPcysk6CUSGBWV+g1utqdn71P5YKwMumVMOG/5k7cHq0KyG4O52nB0oKS4aN2Tp5+wB4APJGC+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.29.0",
-                "@typescript-eslint/parser": "8.29.0",
-                "@typescript-eslint/utils": "8.29.0"
+                "@typescript-eslint/eslint-plugin": "8.29.1",
+                "@typescript-eslint/parser": "8.29.1",
+                "@typescript-eslint/utils": "8.29.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7860,9 +7735,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-            "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+            "version": "6.2.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+            "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
         "knip": "knip"
     },
     "dependencies": {
-        "@floating-ui/react": "^0.27.5",
+        "@floating-ui/react": "^0.27.7",
         "@lottiefiles/dotlottie-react": "^0.13.2",
-        "@tari-project/tari-tower": "^0.0.30",
+        "@tari-project/tari-tower": "^0.0.31",
         "@tauri-apps/api": "^2.4.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.2.2",
         "@tauri-apps/plugin-os": "^2.2.1",
@@ -28,7 +28,7 @@
         "i18next-browser-languagedetector": "^8.0.4",
         "i18next-http-backend": "^3.0.2",
         "linkify-react": "^4.2.0",
-        "motion": "^12.5.0",
+        "motion": "^12.7.0",
         "react": "^18.3.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.54.2",
@@ -48,7 +48,7 @@
         "@nabla/vite-plugin-eslint": "^2.0.5",
         "@taplo/cli": "^0.7.0",
         "@tauri-apps/cli": "^2.4.0",
-        "@types/node": "^22.13.13",
+        "@types/node": "^22.14.1",
         "@types/react": "^18.3.20",
         "@types/react-dom": "^18.3.5",
         "@types/uuid": "^10.0.0",
@@ -56,17 +56,17 @@
         "@vitejs/plugin-react": "^4.3.4",
         "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^9.23.0",
-        "eslint-config-prettier": "^10.1.1",
+        "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-i18next": "^6.1.1",
         "eslint-plugin-prettier": "^5.2.5",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-compiler": "^19.0.0-beta-30d8a17-20250209",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "knip": "^5.46.0",
+        "knip": "^5.50.3",
         "prettier": "^3.5.3",
         "react-qr-code": "^2.0.15",
         "typescript": "^5.8.2",
-        "typescript-eslint": "^8.28.0",
-        "vite": "^6.2.3"
+        "typescript-eslint": "^8.29.1",
+        "vite": "^6.2.6"
     }
 }


### PR DESCRIPTION
Description
---

- bumped tower version and dependencies not on `wanted` version


Motivation and Context
---

- tower update to bring down the noise in logs:
  - removed the logs styling (didn't work in universe after being parsed through these loggers)
  - updated the long block log message 
- vite had a good update which fixed a security vulnerability

How has this been tested?
---

- ran locally
- checked each changelog (no breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated core dependencies to enhance stability, performance, and compatibility throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->