### PR TITLE
feat(quick load): use dynamic p2pool node grpc address for mmproxy

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -52,7 +52,6 @@ use crate::wallet_manager::WalletManagerError;
 use crate::{airdrop, UniverseAppState, APPLICATION_FOLDER_ID};
 
 use base64::prelude::*;
-use futures_util::TryFutureExt;
 use keyring::Entry;
 use log::{debug, error, info, warn};
 use monero_address_creator::Seed as MoneroSeed;
@@ -1456,18 +1455,14 @@ pub async fn start_mining<'r>(
         let source = if p2pool_enabled {
             let use_local = state.node_manager.is_local_current().await.unwrap_or(false);
             let grpc_address = state.p2pool_manager.get_grpc_address(use_local).await;
-            GpuNodeSource::P2Pool {
-                grpc_address: grpc_address.to_string(),
-            }
+            GpuNodeSource::P2Pool { grpc_address }
         } else {
             let grpc_address = state
                 .node_manager
                 .get_grpc_address()
                 .await
                 .map_err(|e| e.to_string())?;
-            GpuNodeSource::BaseNode {
-                grpc_address: grpc_address.to_string(),
-            }
+            GpuNodeSource::BaseNode { grpc_address }
         };
 
         info!(target: LOG_TARGET, "2 Starting gpu miner");

--- a/src-tauri/src/gpu_miner_adapter.rs
+++ b/src-tauri/src/gpu_miner_adapter.rs
@@ -51,7 +51,7 @@ const LOG_TARGET: &str = "tari::universe::gpu_miner_adapter";
 
 pub enum GpuNodeSource {
     BaseNode { grpc_address: String },
-    P2Pool { port: u16 },
+    P2Pool { grpc_address: String },
 }
 
 pub(crate) struct GpuMinerAdapter {
@@ -141,7 +141,7 @@ impl ProcessAdapter for GpuMinerAdapter {
 
         let tari_node_address = match self.node_source.as_ref() {
             Some(GpuNodeSource::BaseNode { grpc_address }) => grpc_address.clone(),
-            Some(GpuNodeSource::P2Pool { port }) => format!("http://127.0.0.1:{}", port),
+            Some(GpuNodeSource::P2Pool { grpc_address }) => grpc_address.clone(),
             None => {
                 return Err(anyhow!("GpuMinerAdapter node_source is not set"));
             }

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -44,7 +44,7 @@ pub(crate) struct MergeMiningProxyConfig {
     pub port: u16,
     pub p2pool_enabled: bool,
     pub base_node_grpc_address: String,
-    pub p2pool_grpc_port: u16,
+    pub p2pool_node_grpc_address: String,
     pub coinbase_extra: String,
     pub tari_address: TariAddress,
     pub use_monero_fail: bool,
@@ -57,9 +57,9 @@ impl MergeMiningProxyConfig {
         self.base_node_grpc_address = grpc_address;
     }
 
-    pub fn set_to_use_p2pool(&mut self, port: u16) {
+    pub fn set_to_use_p2pool(&mut self, grpc_address: String) {
         self.p2pool_enabled = true;
-        self.p2pool_grpc_port = port;
+        self.p2pool_node_grpc_address = grpc_address;
     }
 }
 
@@ -161,7 +161,7 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
             args.push("-p".to_string());
             args.push(format!(
                 "merge_mining_proxy.p2pool_node_grpc_address={}",
-                format!("http://127.0.0.1:{}", config.p2pool_grpc_port)
+                config.p2pool_node_grpc_address
             ));
         }
 

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -161,7 +161,7 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
             args.push("-p".to_string());
             args.push(format!(
                 "merge_mining_proxy.p2pool_node_grpc_address={}",
-                config.base_node_grpc_address
+                format!("http://127.0.0.1:{}", config.p2pool_grpc_port)
             ));
         }
 

--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -118,7 +118,6 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
             "--non-interactive-mode".to_string(),
             format!("--log-config={}", config_dir_string),
             "-p".to_string(),
-            // TODO: Test that this fails with an invalid value.Currently the process continues
             format!(
                 "merge_mining_proxy.base_node_grpc_address={}",
                 config.base_node_grpc_address
@@ -156,14 +155,13 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
             args.push(format!("merge_mining_proxy.monerod_url={}", node));
         }
 
-        // TODO: uncomment if p2pool is needed in CPU mining
         if config.p2pool_enabled {
             args.push("-p".to_string());
             args.push("merge_mining_proxy.p2pool_enabled=true".to_string());
             args.push("-p".to_string());
             args.push(format!(
                 "merge_mining_proxy.p2pool_node_grpc_address={}",
-                "https://grpc-p2pool.nextnet.tari.com:443"
+                config.base_node_grpc_address
             ));
         }
 

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -48,7 +48,7 @@ pub(crate) struct StartConfig {
     pub base_node_grpc_address: String,
     pub coinbase_extra: String,
     pub p2pool_enabled: bool,
-    pub p2pool_port: u16,
+    pub p2pool_node_grpc_address: String,
     pub monero_nodes: Vec<String>,
     pub use_monero_fail: bool,
 }
@@ -59,7 +59,7 @@ impl StartConfig {
         Self {
             p2pool_enabled: override_by.p2pool_enabled,
             base_node_grpc_address: override_by.base_node_grpc_address,
-            p2pool_port: override_by.p2pool_grpc_port,
+            p2pool_node_grpc_address: override_by.p2pool_node_grpc_address,
             coinbase_extra: override_by.coinbase_extra,
             tari_address: override_by.tari_address,
             use_monero_fail: override_by.use_monero_fail,
@@ -144,7 +144,7 @@ impl MmProxyManager {
             coinbase_extra: config.coinbase_extra.clone(),
             p2pool_enabled: config.p2pool_enabled,
             port: PortAllocator::new().assign_port_with_fallback(),
-            p2pool_grpc_port: config.p2pool_port,
+            p2pool_node_grpc_address: config.p2pool_node_grpc_address,
             monero_nodes: config.monero_nodes.clone(),
             use_monero_fail: config.use_monero_fail,
         };

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -221,10 +221,10 @@ impl P2poolManager {
                 .as_ref()
                 .map(|c| c.grpc_port)
                 .unwrap_or_default();
-            return format!("http://127.0.0.1:{}", grpc_port);
+            format!("http://127.0.0.1:{}", grpc_port)
         } else {
             let network = Network::get_current_or_user_setting_or_default();
-            return format!("https://grpc-p2pool.{}.tari.com:443", network);
+            format!("https://grpc-p2pool.{}.tari.com:443", network)
         }
     }
 

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use futures_util::future::FusedFuture;
 use log::{info, warn};
+use tari_common::configuration::Network;
 use tokio::sync::{watch, RwLock};
 use tokio::time::sleep;
 
@@ -41,7 +42,7 @@ const LOG_TARGET: &str = "tari::universe::p2pool_manager";
 
 #[derive(Clone)]
 pub struct P2poolConfig {
-    pub grpc_port: u16,
+    pub grpc_port: u16, // Local
     pub stats_server_port: u16,
     pub base_node_address: String,
     pub cpu_benchmark_hashrate: Option<u64>,
@@ -211,14 +212,20 @@ impl P2poolManager {
         Ok(exit_code)
     }
 
-    pub async fn grpc_port(&self) -> u16 {
-        let process_watcher = self.watcher.read().await;
-        process_watcher
-            .adapter
-            .config
-            .as_ref()
-            .map(|c| c.grpc_port)
-            .unwrap_or_default()
+    pub async fn get_grpc_address(&self, use_local: bool) -> String {
+        if use_local {
+            let process_watcher = self.watcher.read().await;
+            let grpc_port = process_watcher
+                .adapter
+                .config
+                .as_ref()
+                .map(|c| c.grpc_port)
+                .unwrap_or_default();
+            return format!("http://127.0.0.1:{}", grpc_port);
+        } else {
+            let network = Network::get_current_or_user_setting_or_default();
+            return format!("https://grpc-p2pool.{}.tari.com:443", network);
+        }
     }
 
     pub async fn stats_server_port(&self) -> u16 {

--- a/src-tauri/src/setup/phase_unknown.rs
+++ b/src-tauri/src/setup/phase_unknown.rs
@@ -237,7 +237,6 @@ impl SetupPhaseImpl for UnknownSetupPhase {
             .await;
 
         let base_node_grpc_address = state.node_manager.get_grpc_address().await?;
-
         let p2pool_port = state.p2pool_manager.grpc_port().await;
         state
             .mm_proxy_manager


### PR DESCRIPTION
Use p2pool node dynamically:
* use local p2pool node when local node is synced
* when remote node is used, use remote p2pool node

Remote
--
p2pool node grpc address: **https://grpc-p2pool.nextnet.tari.com:443**

```
Starting minotari_merge_mining_proxy process with args: -b /home/fish/.local/share/com.tari.universe.alpha/mmproxy --non-interactive-mode --log-config=/home/fish/.local/share/com.tari.universe.alpha/logs/proxy/configs/log4rs_config_proxy.yml -p merge_mining_proxy.base_node_grpc_address=https://grpc.nextnet.tari.com:443 -p merge_mining_proxy.listener_address=/ip4/127.0.0.1/tcp/43641 -p merge_mining_proxy.coinbase_extra=v3,8YRvFhyHFS6KEDtuiy3MJD3MBKft,0.9.847,47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU -p merge_mining_proxy.wallet_payment_address=32FZ9MmtkbcxNwF1Qia1RykS2i3ycaJC5er32xaFi1fpkNKjKvVo6VFPKjoigSME76EmsaDPZLXu2e3ivp5MWSU54j1 -p merge_mining_proxy.wait_for_initial_sync_at_startup=false -p merge_mining_proxy.check_tari_difficulty_before_submit=false -p merge_mining_proxy.use_dynamic_fail_data=false -p merge_mining_proxy.p2pool_enabled=true -p merge_mining_proxy.p2pool_node_grpc_address=https://grpc-p2pool.nextnet.tari.com:443
```

Local
--
p2pool node grpc address(port may vary): **http://127.0.0.1:46797**

```
Starting minotari_merge_mining_proxy process with args: -b /home/fish/.local/share/com.tari.universe.alpha/mmproxy --non-interactive-mode --log-config=/home/fish/.local/share/com.tari.universe.alpha/logs/proxy/configs/log4rs_config_proxy.yml -p merge_mining_proxy.base_node_grpc_address=http://127.0.0.1:36725 -p merge_mining_proxy.listener_address=/ip4/127.0.0.1/tcp/45101 -p merge_mining_proxy.coinbase_extra=v3,bbEz4xRadJShATJBC5tPaH1gA86Y,0.9.847,47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU -p merge_mining_proxy.wallet_payment_address=f284hoWP8yfcxsEDghPU5D4bpiLVPhrfKemGdLjXqJvfyAytf6gwo5jus34EfUooE4RZUUk7PQqk5xDWy76aSsDGS9j -p merge_mining_proxy.wait_for_initial_sync_at_startup=false -p merge_mining_proxy.check_tari_difficulty_before_submit=false -p merge_mining_proxy.use_dynamic_fail_data=false -p merge_mining_proxy.p2pool_enabled=true -p merge_mining_proxy.p2pool_node_grpc_address=http://127.0.0.1:46797
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved flexibility by allowing configuration of full gRPC addresses for P2Pool and base node connections, rather than relying solely on port numbers.

- **Refactor**
	- Updated various settings and configuration fields to use gRPC address strings instead of port numbers for P2Pool and related components.
	- Streamlined retrieval and usage of gRPC addresses, reducing redundancy and enhancing clarity in setup processes.

- **Documentation**
	- Added clarifying comments regarding local port usage in configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->