### PR TITLE
fix: xtm conversion `MicroMinotari` -> `Minotari`

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -66,7 +66,7 @@ use std::thread::{available_parallelism, sleep};
 use std::time::{Duration, Instant, SystemTime};
 use tari_common::configuration::Network;
 use tari_common_types::tari_address::TariAddressFeatures;
-use tari_core::transactions::tari_amount::MicroMinotari;
+use tari_core::transactions::tari_amount::{MicroMinotari, Minotari};
 use tauri::ipc::InvokeError;
 use tauri::{Manager, PhysicalPosition, PhysicalSize};
 use tauri_plugin_sentry::sentry;
@@ -1736,9 +1736,24 @@ pub fn verify_address_for_send(
 }
 
 #[tauri::command]
-pub fn format_micro_minotari(amount: String) -> Result<String, String> {
-    let mm_amount = MicroMinotari::from_str(&amount).map_err(|e| e.to_string())?;
-    Ok(format!("{}", mm_amount))
+pub fn validate_minotari_amount(
+    amount: String,
+    state: tauri::State<'_, UniverseAppState>,
+) -> Result<(), InvokeError> {
+    let t_amount = Minotari::from_str(&amount).map_err(|e| e.to_string())?;
+    let m_amount = MicroMinotari::from(t_amount);
+
+    let balance = state
+        .wallet_state_watch_rx
+        .borrow()
+        .clone()
+        .and_then(|state| state.balance);
+
+    let available_balance = balance.expect("Could not get balance").available_balance;
+    match m_amount.cmp(&available_balance) {
+        std::cmp::Ordering::Less => Ok(()),
+        _ => Err(InvokeError::from("Insufficient balance".to_string())),
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1282,7 +1282,7 @@ fn main() {
             commands::frontend_ready,
             commands::send_one_sided_to_stealth_address,
             commands::verify_address_for_send,
-            commands::format_micro_minotari,
+            commands::validate_minotari_amount,
             commands::trigger_phases_restart,
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/spend_wallet_adapter.rs
+++ b/src-tauri/src/spend_wallet_adapter.rs
@@ -32,8 +32,10 @@ use anyhow::Error;
 use log::info;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 use tari_common::configuration::Network;
+use tari_core::transactions::tari_amount::{MicroMinotari, Minotari};
 use tari_crypto::ristretto::RistrettoPublicKey;
 use tari_shutdown::{Shutdown, ShutdownSignal};
 use tari_utilities::hex::Hex;
@@ -101,11 +103,14 @@ impl SpendWalletAdapter {
 
     pub async fn send_one_sided_to_stealth_address(
         &mut self,
-        amount: String,
+        _amount: String,
         destination: String,
         payment_id: Option<String>,
     ) -> Result<(), Error> {
         let seed_words = self.get_seed_words(self.get_config_dir()).await?;
+        let t_amount = Minotari::from_str(_amount.as_str())?;
+        let converted_amount = MicroMinotari::from(t_amount);
+        let amount = converted_amount.to_string();
         let commands = vec![
             ExecutionCommand::new("recovery")
                 .with_extra_args(vec!["--recovery".to_string()])

--- a/src/components/transactions/components/TxInput.tsx
+++ b/src/components/transactions/components/TxInput.tsx
@@ -15,7 +15,7 @@ import { AnimatePresence } from 'motion/react';
 
 type TxInputBase = Omit<InputHTMLAttributes<HTMLInputElement>, 'name'>;
 export interface TxInputProps extends TxInputBase {
-    value: string;
+    value?: string | number;
     onChange: (e: ChangeEvent<HTMLInputElement>) => void;
     onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
     name: string;
@@ -77,7 +77,6 @@ export function TxInput({
                     ref={ref}
                     id={name}
                     name={name}
-                    type="text"
                     value={displayValue}
                     onChange={onChange}
                     onBlur={handleBlur}

--- a/src/components/transactions/history/ListItem.styles.ts
+++ b/src/components/transactions/history/ListItem.styles.ts
@@ -93,6 +93,7 @@ export const Chip = styled.div`
     text-transform: uppercase;
     border-radius: 50px;
     background-color: ${({ theme }) => theme.colors.green[700]};
+    color: #fff; // no theming needed,should always be white
     height: 14px;
     padding: 0 7px;
 `;

--- a/src/components/transactions/send/FormField.tsx
+++ b/src/components/transactions/send/FormField.tsx
@@ -34,22 +34,36 @@ export function FormField({
     const labelT = t(`send.label`, { context: name });
     const placeholderT = t(`send.placeholder`, { context: name });
 
+    const amountRules =
+        name === 'amount'
+            ? {
+                  pattern: /^[0-9]+$/,
+              }
+            : undefined;
+    const rules = {
+        required: {
+            value: required,
+            message: t('send.required', { fieldName: name }),
+        },
+        amountRules,
+    };
+
     return (
         <Controller
             control={control}
             name={name as InputName}
-            rules={{
-                required: {
-                    value: required,
-                    message: t('send.required', { fieldName: name }),
-                },
-            }}
-            render={({ field: { ref: _ref, name, ...rest }, fieldState }) => {
+            rules={rules}
+            render={({ field: { ref: _ref, name, value, ...rest }, fieldState }) => {
                 return (
                     <TxInput
                         {...rest}
                         name={name}
                         onChange={(e) => {
+                            const value = e.target.value;
+                            const valueIsNaN = isNaN(Number(value));
+                            if (name === 'amount' && valueIsNaN) {
+                                return;
+                            }
                             rest.onChange(e);
                             if (handleChange) {
                                 handleChange(e, name as InputName);
@@ -63,7 +77,8 @@ export function FormField({
                         errorMessage={errorText || fieldState.error?.message}
                         autoFocus={autoFocus}
                         truncateOnBlur={truncateOnBlur}
-                        truncateText={truncateOnBlur && rest.value ? String(rest.value) : undefined}
+                        value={value}
+                        truncateText={truncateOnBlur && value ? String(value) : undefined}
                         isValid={isValid}
                     />
                 );

--- a/src/components/transactions/send/types.ts
+++ b/src/components/transactions/send/types.ts
@@ -1,6 +1,6 @@
 export interface SendInputs {
     message: string;
     address: string;
-    amount: string;
+    amount?: number;
 }
 export type InputName = keyof SendInputs;

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -59,10 +59,10 @@ export const useWalletStore = create<WalletStoreState>()(() => ({
 }));
 
 // Temporary solution until we use excess_sig to track pending transactions
-export const addPendingTransaction = (payload: { amount: string; destination: string; paymentId: string }) => {
+export const addPendingTransaction = (payload: { amount: number; destination: string; paymentId: string }) => {
     const transaction: PendingTransaction = {
         tx_id: Date.now(),
-        amount: Number(payload.amount.replace(/[Tt]$/, '000000')),
+        amount: Number(payload.amount) * 1_000_000,
         dest_address: payload.destination,
         payment_id: payload.paymentId,
         direction: 2,

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -108,6 +108,6 @@ declare module '@tauri-apps/api/core' {
         param: 'verify_address_for_send',
         payload: { address: string; sendingMethod?: number }
     ): Promise<void>;
-    function invoke(param: 'format_micro_minotari', payload: { amount: string }): Promise<string>;
+    function invoke(param: 'validate_minotari_amount', payload: { amount: string }): Promise<string>;
     function invoke(param: 'trigger_phases_restart'): Promise<void>;
 }


### PR DESCRIPTION
Description
---
- updated `format_micro_minotari` to include a check against `available_balance` & renamed 
- convert transaction amounts from strings to `Minotari`, and then to `MicroMinotari` before sending/validating
- update tx form amount inputs to only cater for numbers
- update `NEW` chip text colour
- update formatting on pending txs

Motivation and Context
---
- [comment on this issue](https://github.com/tari-project/universe/issues/1577#issuecomment-2812293470)


How Has This Been Tested?
---
locally: 

https://github.com/user-attachments/assets/45867593-a4b5-401d-8d5d-19e2c27b484d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved validation for transaction amounts to ensure they do not exceed the available wallet balance.

- **Bug Fixes**
  - Enhanced input validation to only allow numeric values for transaction amounts.

- **Style**
  - Updated transaction history styling to ensure chip text is always displayed in white.

- **Refactor**
  - Streamlined the handling and type consistency of transaction amounts across the application, transitioning from string to number where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->