### PR TITLE
fix: setup listener race condition after shutting down phases

### DIFF
--- a/src-tauri/src/setup/phase_hardware.rs
+++ b/src-tauri/src/setup/phase_hardware.rs
@@ -50,10 +50,7 @@ use tokio::{
     },
 };
 
-use super::{
-    setup_manager::{PhaseStatus, SetupManager},
-    trait_setup_phase::SetupPhaseImpl,
-};
+use super::{setup_manager::PhaseStatus, trait_setup_phase::SetupPhaseImpl};
 
 static LOG_TARGET: &str = "tari::universe::phase_hardware";
 const SETUP_TIMEOUT_DURATION: Duration = Duration::from_secs(60 * 10); // 10 Minutes
@@ -236,7 +233,7 @@ impl SetupPhaseImpl for HardwareSetupPhase {
     async fn finalize_setup(
         &self,
         sender: Sender<PhaseStatus>,
-        payload: Option<HardwareSetupPhaseOutput>,
+        _payload: Option<HardwareSetupPhaseOutput>,
     ) -> Result<(), Error> {
         sender.send(PhaseStatus::Success).ok();
         self.progress_stepper
@@ -246,12 +243,6 @@ impl SetupPhaseImpl for HardwareSetupPhase {
             .await;
 
         EventsManager::handle_hardware_phase_finished(&self.app_handle, true).await;
-
-        if let Some(payload) = payload {
-            let _unused = SetupManager::get_instance()
-                .hardware_phase_output
-                .send(payload);
-        }
         Ok(())
     }
 }

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -21,11 +21,8 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::{
-    phase_core::CoreSetupPhase,
-    phase_hardware::{HardwareSetupPhase, HardwareSetupPhaseOutput},
-    phase_node::NodeSetupPhase,
-    phase_unknown::UnknownSetupPhase,
-    phase_wallet::WalletSetupPhase,
+    phase_core::CoreSetupPhase, phase_hardware::HardwareSetupPhase, phase_node::NodeSetupPhase,
+    phase_unknown::UnknownSetupPhase, phase_wallet::WalletSetupPhase,
     trait_setup_phase::SetupPhaseImpl,
 };
 use crate::{


### PR DESCRIPTION
### [ Summary ]
- Fixed case when we instantly unlocked mining after locking it which cause xmrig to point to the old mmproxy address
- Shutdown wait_for_unlock_conditions for the time of shutting down phases to avoid race conditions
- Removed unused hardware phase payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved reliability of the setup process by introducing explicit cancellation control, allowing certain setup operations to be cleanly stopped and restarted.

- **Refactor**
  - Streamlined internal handling of unused parameters and removed obsolete fields to enhance maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->