### PR TITLE
fix(quick load): await for listener setup before emitting app ready

### DIFF
--- a/src/App/AppEffects.tsx
+++ b/src/App/AppEffects.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 
 import setupLogger from '../utils/shared-logger';
 
@@ -19,13 +18,6 @@ setupLogger();
 export default function AppEffects() {
     useEffect(() => {
         async function initialize() {
-            await invoke('frontend_ready')
-                .then(() => {
-                    console.info('Successfully called frontend_ready');
-                })
-                .catch((e) => {
-                    console.error('Failed to call frontend_ready: ', e);
-                });
             await setMiningNetwork();
             await airdropSetup();
         }


### PR DESCRIPTION
It was a race condition when we emitted "AppReady" event when setting up the listener.

* I awaited listener setup before emitting AppReady event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of backend event listeners for better reliability and maintainability.
  - Adjusted the timing and placement of backend readiness notifications to ensure smoother integration with the Tauri backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->