### PR TITLE
fix: filter only wanted transactions

### DIFF
--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -128,6 +128,10 @@ impl WalletAdapter {
             let tx = message.transaction.ok_or_else(|| {
                 WalletStatusMonitorError::UnknownError(anyhow::anyhow!("Transaction not found"))
             })?;
+            if tx.status == 14 || tx.status == 7 {
+                // Remove TRANSACTION_STATUS_COINBASE_NOT_IN_BLOCK_CHAIN and REJECTED
+                continue;
+            }
             transactions.push(TransactionInfo {
                 tx_id: tx.tx_id,
                 source_address: tx.source_address.to_hex(),


### PR DESCRIPTION
Remove `TRANSACTION_STATUS_COINBASE_NOT_IN_BLOCK_CHAIN` and `REJECTED` from the transaction history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction history by excluding transactions with certain status codes, ensuring only relevant transactions are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->