### PR TITLE
fix: text overflow fade effect

### DIFF
--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,5 +1,5 @@
 import * as m from 'motion/react-m';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 // don't need theming for this file as the colours are the same in dark/light mode (black and white)
 
@@ -36,7 +36,7 @@ export const IconContainer = styled(m.div)`
     justify-content: center;
     background-color: white;
     border-radius: 8px;
-    width: 38px;
+    min-width: 38px;
     height: 38px;
 `;
 
@@ -59,7 +59,7 @@ export const ContentContainer = styled(m.div)`
     overflow: hidden;
 `;
 
-export const TitleContainer = styled(m.div)`
+export const TitleContainer = styled(m.div)<{ $hasTextOverflow: boolean }>`
     display: flex;
     align-items: center;
     justify-content: space-evenly;
@@ -67,24 +67,28 @@ export const TitleContainer = styled(m.div)`
     overflow: hidden;
     text-overflow: ellipsis;
     position: relative;
-    &::before,
-    &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        width: 20px;
-        z-index: 2;
-        pointer-events: none;
-    }
-    &::before {
-        left: 0;
-        background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);
-    }
-    &::after {
-        right: 0;
-        background: linear-gradient(to left, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);
-    }
+    ${({ $hasTextOverflow }) =>
+        $hasTextOverflow &&
+        css`
+            &::before,
+            &::after {
+                content: '';
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                width: 20px;
+                z-index: 2;
+                pointer-events: none;
+            }
+            &::before {
+                left: 0;
+                background: linear-gradient(to right, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);
+            }
+            &::after {
+                right: 0;
+                background: linear-gradient(to left, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);
+            }
+        `}
 `;
 
 export const Title = styled(m.span)`

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -51,10 +51,10 @@ const XSpaceEventBanner = () => {
     }, [latestXSpaceEvent]);
 
     useEffect(() => {
-        if (titleRef.current && containerRef.current) {
-            const titleWidth = titleRef.current.scrollWidth;
-            const containerWidth = containerRef.current.clientWidth;
-            setIsTextTooLong(titleWidth > containerWidth);
+        const isTextTooLong = (latestXSpaceEvent?.text.length || 0) > 25;
+        setIsTextTooLong(isTextTooLong);
+        if (isTextTooLong && titleRef.current && containerRef.current) {
+            const titleWidth = titleRef.current.scrollWidth || 0;
             setTransitionPixelWidth(titleWidth / 2);
         }
     }, [latestXSpaceEvent]); // Re-run the effect when the event changes
@@ -114,7 +114,7 @@ const XSpaceEventBanner = () => {
                                 </DateLabel>
                             )}
 
-                            <TitleContainer ref={containerRef}>
+                            <TitleContainer ref={containerRef} $hasTextOverflow={isTextTooLong}>
                                 <Title
                                     ref={titleRef}
                                     animate={


### PR DESCRIPTION
Implemented a fade effect on the XSpaceBanner title when the text overflows its container. This improves readability by visually indicating that there's more text than is currently visible.  The logic to determine text overflow has been simplified to use text length. The fade effect is conditionally applied based on whether the text overflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for detecting text overflow in banners, making it more efficient and consistent.
  - Gradient overlays on banner titles now only appear when text actually overflows, enhancing visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->