### PR TITLE
fix(quick load): continue initial sync when tip increased

### DIFF
--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -214,10 +214,9 @@ impl SetupPhaseImpl for WalletSetupPhase {
         drop(spend_wallet_manager);
 
         let node_status_watch_rx = (*app_state.node_status_watch_rx).clone();
-        let node_status = *node_status_watch_rx.borrow();
         state
             .wallet_manager
-            .wait_for_initial_wallet_scan(self.get_app_handle(), node_status.block_height)
+            .wait_for_initial_wallet_scan(self.get_app_handle(), node_status_watch_rx)
             .await?;
 
         Ok(None)

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -217,6 +217,7 @@ impl WalletManager {
             })
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn wait_for_initial_wallet_scan(
         &self,
         app: &AppHandle,


### PR DESCRIPTION
Description
---
Wallet scanning with the remote node takes long time. In the meantime, block height can change.

* Ensure we sync up to the current highest tip
* Reflect this changes in the Wallet UI

I also added missing `break` inside initial sync progress updates task when we finished initial scanning process.

Logs:
```
17:24:52 INFO  Wallet scan completed up to block height 12984
17:24:52 INFO  Node height increased from 12984 to 12985 while initial scanning, continuing..
...
17:24:57 INFO  Wallet scan completed up to block height 12985
17:24:57 INFO  Initial wallet scan complete up to 12985 block height. Available balance: 163496.222751 T
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved wallet scan progress tracking, allowing real-time updates as the blockchain height increases.
- **Refactor**
  - Enhanced initial wallet scan to dynamically adapt to changes in block height for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->