### PR TITLE
chore(quick load): revert proxy_bypass_for_outbound_tcp change

### DIFF
--- a/src-tauri/src/node/local_node_adapter.rs
+++ b/src-tauri/src/node/local_node_adapter.rs
@@ -274,7 +274,7 @@ impl ProcessAdapter for LocalNodeAdapter {
             ));
             args.push("-p".to_string());
             args.push(
-                "base_node.p2p.transport.tor.proxy_bypass_for_outbound_tcp=false".to_string(),
+                "base_node.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true".to_string(),
             );
             if let Some(mut tor_control_port) = self.tor_control_port {
                 // macos uses libtor, so will be 9051


### PR DESCRIPTION
Description
---
Before the quick load, it was set to true. We probably shouldn't change this.
![image](https://github.com/user-attachments/assets/3693252d-99e6-4c0a-8e8f-d643bb7d0a11)
