### PR TITLE
fix: health check timeouts register as warnings not restarts

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -413,7 +413,7 @@ impl NodeStatusMonitor {
 #[async_trait]
 impl StatusMonitor for NodeStatusMonitor {
     async fn check_health(&self, _uptime: Duration) -> HealthStatus {
-        let duration = std::time::Duration::from_secs(5);
+        let duration = std::time::Duration::from_secs(3);
         match timeout(duration, self.node_service.get_network_state()).await {
             Ok(res) => match res {
                 Ok(status) => {


### PR DESCRIPTION
If a health check times out, don't restart it, rather set a warning. 10 warnings = restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved health check timeout handling by explicitly tracking and logging repeated timeouts, ensuring better monitoring and feedback for process health.
- **Refactor**
	- Adjusted timeout duration for node health checks, reducing the maximum wait time for network state responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->