### PR TITLE
fix: retry sync if local node is still 50 blocks behind remote node

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -178,38 +178,12 @@ impl NodeAdapterService {
             let tip_res = tip.into_inner();
             let sync_progress = sync_progress.into_inner();
             if tip_res.initial_sync_achieved {
-                if sync_progress.local_height >= sync_progress.tip_height {
-                    info!(target: LOG_TARGET, "Initial sync achieved and local height is equal or greater than tip height");
-                    let tip_height = match tip_res.metadata {
-                        Some(metadata) => metadata.best_block_height,
-                        None => 0,
-                    };
-                    return Ok(tip_height);
-                } else {
-                    info!(target: LOG_TARGET, "Initial sync achieved but local height is lower than tip height");
-                    // Report to sentry that we have initial sync achieved but local height is lower than tip height
-                    let error_msg =
-                        "Initial sync achieved but local height is lower than tip height"
-                            .to_string();
-                    error!(target: LOG_TARGET, "{}", error_msg);
-                    let extra = vec![
-                        (
-                            "local_height".to_string(),
-                            json!(sync_progress.local_height.to_string()),
-                        ),
-                        (
-                            "tip_height".to_string(),
-                            json!(sync_progress.tip_height.to_string()),
-                        ),
-                    ];
-                    sentry::capture_event(Event {
-                        message: Some(error_msg),
-                        level: sentry::Level::Error,
-                        culprit: Some("node-sync-inconsistency".to_string()),
-                        extra: extra.into_iter().collect(),
-                        ..Default::default()
-                    });
-                }
+                info!(target: LOG_TARGET, "Initial sync achieved");
+                let tip_height = match tip_res.metadata {
+                    Some(metadata) => metadata.best_block_height,
+                    None => 0,
+                };
+                return Ok(tip_height);
             }
 
             let mut progress_params: HashMap<String, String> = HashMap::new();

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -34,7 +34,7 @@ use tari_shutdown::ShutdownSignal;
 use tauri::AppHandle;
 use tokio::sync::watch::{self, Sender};
 use tokio::sync::RwLock;
-use tokio::time::{sleep, timeout};
+use tokio::time::sleep;
 use tokio::{fs, select};
 use tokio_util::task::TaskTracker;
 
@@ -159,7 +159,6 @@ impl NodeManager {
         let task_tracker = TasksTrackers::current().node_phase.get_task_tracker().await;
 
         if self.is_local().await? {
-            info!("Starting local node");
             self.configure_adapter(
                 self.local_node_watcher.clone(),
                 self.is_local_current().await?,
@@ -179,7 +178,6 @@ impl NodeManager {
             .await?;
         }
         if self.is_remote().await? {
-            info!("Starting remote node");
             self.configure_adapter(
                 self.remote_node_watcher.clone(),
                 self.is_remote_current().await?,
@@ -304,9 +302,7 @@ impl NodeManager {
                 )
                 .await
             {
-                Ok(synced_height) => {
-                    // let remote_height = self.
-                    info!("synced height: {}", synced_height);
+                Ok(_) => {
                     return Ok(());
                 }
                 Err(e) => match e {
@@ -545,7 +541,6 @@ pub async fn start_status_forwarding_thread(
                             None => true,
                         };
 
-                        info!(target: LOG_TARGET, "Forwarded Local BaseNodeStatus: {:?}", status);
                         if base_node_watch_tx.send(status).is_err() {
                             error!(target: LOG_TARGET, "Failed to forward local BaseNodeStatus via base_node_watch_tx");
                         }

--- a/src-tauri/src/telemetry_service.rs
+++ b/src-tauri/src/telemetry_service.rs
@@ -95,7 +95,7 @@ impl TelemetryService {
         let mut shutdown_signal = TasksTrackers::current().common.get_signal().await;
 
         self.version = app_version;
-        let mut cancellation_token = self.cancellation_token.clone();
+        let cancellation_token = self.cancellation_token.clone();
         let in_memory_config_cloned = self.in_memory_config.clone();
         let telemetry_api_url = in_memory_config_cloned
             .read()


### PR DESCRIPTION
Description
---
Fixes: #1895 

Retries local node sync if it's at least 50 blocks behind remote node.

Motivation and Context
---
Syncing process doesn't updates tip height while syncing so if it takes a long time then right after syncing it could sync again.

How Has This Been Tested?
---
The best way is to have local node (preferably on nextnet) that is few hundred blocks behind the [textexplorer](https://textexplore-nextnet.tari.com/).
Run TU and check logs for sync progress and potential retries and fork chain warnings.

What process can a PR reviewer use to test or verify this change?
---
Same as above


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced node sync logic to more accurately track and report the local node's block height after syncing.
  - Improved reliability when switching node types by ensuring the local node is sufficiently up-to-date before switching.
  - Added clearer informational and warning messages during the sync and switching process.

- **Style**
  - Minor code cleanup for improved maintainability (no impact on user-facing features).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->