### PR TITLE
fix: missing monero seed words after settings reset

### DIFF
--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -102,9 +102,8 @@ impl ConfigWallet {
 
         config.handle_old_config_migration(old_config);
         config.load_app_handle(app_handle.clone()).await;
-
-        EventsManager::handle_config_wallet_loaded(&app_handle, config.content.clone()).await;
         drop(config);
+
         // Think about better place for this
         // This must happend before InternalWallet::load_or_create !!!
         if ConfigWallet::content().await.monero_address().is_empty() {
@@ -135,6 +134,12 @@ impl ConfigWallet {
                 error!(target: LOG_TARGET, "Error loading internal wallet: {:?}", e);
             }
         };
+
+        EventsManager::handle_config_wallet_loaded(
+            &app_handle,
+            Self::current().write().await.content.clone(),
+        )
+        .await;
     }
 }
 


### PR DESCRIPTION
## Should fix #1900 

### [ Summary ]
- Send wallet config via event after monero address is created 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed the timing of wallet configuration event notifications to occur after the wallet is fully loaded or created, ensuring app state is updated before the event is emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->