### PR TITLE
chore: enhance orphan chain warning message and refactor

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -350,7 +350,7 @@ impl NodeAdapterService {
                 .iter()
                 .any(|local_block| block_scan_block.1 == local_block.1)
             {
-                let local_block = block_scan_blocks.iter().find(|b| b.0 == block_scan_block.0);
+                let local_block = local_blocks.iter().find(|b| b.0 == block_scan_block.0);
                 error!(target: LOG_TARGET, "Miner is stuck on orphan chain. Block at height: {} and hash: {} does not exist locally", block_scan_block.0, block_scan_block.1);
                 if let Some(local_block) = local_block {
                     error!(target: LOG_TARGET, "Local block at height: {} and hash: {}", local_block.0, local_block.1);

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -381,14 +381,9 @@ impl NodeManager {
         Err(anyhow::anyhow!("grpc_address not set"))
     }
 
-    pub async fn check_if_is_orphan_chain(
-        &self,
-        report_to_sentry: bool,
-    ) -> Result<bool, anyhow::Error> {
+    pub async fn check_if_is_orphan_chain(&self) -> Result<bool, anyhow::Error> {
         let current_service = self.get_current_service().await?;
-        current_service
-            .check_if_is_orphan_chain(report_to_sentry)
-            .await
+        current_service.check_if_is_orphan_chain().await
     }
 
     pub async fn list_connected_peers(&self) -> Result<Vec<String>, anyhow::Error> {

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -454,7 +454,7 @@ async fn get_telemetry_data(
     let p2pool_enabled = *config.is_p2pool_enabled() && p2pool_stats.is_some();
     let mut extra_data = HashMap::new();
     let is_orphan = node_manager
-        .check_if_is_orphan_chain(false)
+        .check_if_is_orphan_chain()
         .await
         .unwrap_or(false);
     extra_data.insert("is_orphan".to_string(), is_orphan.to_string());


### PR DESCRIPTION
Description
---
Add more info to orphan chain errors messages to make visible which blocks had mismatched hashes.

Motivation and Context
---
Lately we see more orphan chain warning but with it was difficult to verify without additional information which blocks were invalid.

How Has This Been Tested?
---
Making real orphan chain is tedious as it requires to ban all peers and start mining (preferably on esme), but after reset my initial setup has already reported orphan chain with these logs:
```
15:43:29 ERROR Miner is stuck on orphan chain. Block at height: 0 and hash: f517a8821efa01fda8553e6ca9586c0a4d1fb64228a5433c5d4e60638ee12460 does not exist locally
15:43:29 ERROR Local block at height: 0 and hash: 9c673c00b27d721b1ad79fbf48e8fd6037259f112c1c1084c91a5e30bc12efca
```
This at least proves partially that's it works

What process can a PR reviewer use to test or verify this change?
---
Same as above

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for orphan chain detection to ensure errors are only reported once per runtime and include more detailed information.
- **Refactor**
  - Simplified the orphan chain check process by removing unnecessary parameters and streamlining error handling and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->