### PR TITLE
chore(node start): move wait_ready_for_node_process to the retries loop

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -318,11 +318,9 @@ impl NodeManager {
 
     pub async fn wait_ready(&self) -> Result<(), NodeManagerError> {
         if self.is_remote().await? {
-            wait_ready_for_node_process(&self.remote_node_watcher).await?;
             ensure_node_identity_reachable(&self.remote_node_watcher, "Remote").await?;
         }
         if self.is_local().await? {
-            wait_ready_for_node_process(&self.local_node_watcher).await?;
             ensure_node_identity_reachable(&self.local_node_watcher, "Local").await?;
         }
 
@@ -595,6 +593,7 @@ where
                 .as_ref()
                 .and_then(|watcher| watcher.adapter.get_service())
         } {
+            wait_ready_for_node_process(node_watcher).await?;
             match service.get_identity().await {
                 Ok(_) => {
                     return Ok(());


### PR DESCRIPTION
Description
---
Move `wait_ready_for_node_process` to the `ensure_node_identity_reachable` loop so it be called before each `get_identity` try.

**It detects corrupted db in several tries(2/3) instead of max retries(20)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for checking node readiness by updating the sequence of readiness and identity reachability checks. This change streamlines internal readiness checks but does not affect user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->