### PR TITLE
chore(send): remove loading indicator for broadcasted transaction

### DIFF
--- a/src/components/transactions/history/ListItem.styles.ts
+++ b/src/components/transactions/history/ListItem.styles.ts
@@ -48,18 +48,6 @@ export const BlockInfoWrapper = styled.div`
     display: flex;
     flex-direction: column;
 `;
-export const StatusWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    margin-right: 8px;
-`;
-export const CircularProgressWrapper = styled.div`
-    height: 25px;
-    width: 25px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-`;
 export const TitleWrapper = styled(Typography)`
     display: flex;
     color: ${({ theme }) => theme.palette.text.primary};

--- a/src/components/transactions/history/ListItem.tsx
+++ b/src/components/transactions/history/ListItem.tsx
@@ -13,35 +13,23 @@ import {
     ValueChangeWrapper,
     ValueWrapper,
     CurrencyText,
-    StatusWrapper,
-    CircularProgressWrapper,
     Chip,
     BlockInfoWrapper,
     Content,
 } from './ListItem.styles.ts';
 import { useConfigUIStore, useUIStore } from '@app/store';
-import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
-import { TransactionStatus } from '@app/types/transactions.ts';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { useTranslation } from 'react-i18next';
 
-const BaseItem = memo(function BaseItem({ title, time, value, type, chip, status, onClick }: BaseItemProps) {
+const BaseItem = memo(function BaseItem({ title, time, value, type, chip, onClick }: BaseItemProps) {
     // note re. isPositiveValue:
     // amounts in the tx response are always positive numbers but
     // if the transaction type is 'sent' it must be displayed as a negative amount, with a leading `-`
     const isPositiveValue = type !== 'sent';
-    const isPending = status === TransactionStatus.Broadcast;
     const displayTitle = title.length > 30 ? truncateMiddle(title, 8) : title;
     return (
         <ContentWrapper onClick={onClick}>
             <Content>
-                {isPending && (
-                    <StatusWrapper>
-                        <CircularProgressWrapper>
-                            <CircularProgress />
-                        </CircularProgressWrapper>
-                    </StatusWrapper>
-                )}
                 <BlockInfoWrapper>
                     <TitleWrapper title={title}>{displayTitle}</TitleWrapper>
                     <TimeWrapper variant="p">{time}</TimeWrapper>

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -2,7 +2,7 @@
 
 export enum TransactionStatus {
     // This transaction has been broadcast to the base layer network and is currently in one or more base node mempools.
-    Broadcast = 1,
+    // Broadcast = 1,
     /// This transaction is mined and confirmed at the current base node's height
     MinedConfirmed = 6,
     /// This is faux transaction mainly for one-sided transaction outputs or wallet recovery outputs have been found


### PR DESCRIPTION
Description
---
* Since transaction is broadcasted, we can treat it as "completed", it's validated and certainly will be added to the next mined block
* Note: Transaction is still not persistent until it's mined!


https://github.com/user-attachments/assets/5b0379aa-93a9-4517-840f-1ec6b807630a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the pending transaction status indicator from transaction history items, simplifying their display. Pending transactions are no longer visually distinguished from completed ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->