### PR TITLE
fix(ui): edit functionality on review transaction form

### DIFF
--- a/src/components/transactions/send/SendForm.tsx
+++ b/src/components/transactions/send/SendForm.tsx
@@ -13,7 +13,11 @@ import { BottomWrapper, FormFieldsWrapper } from './Send.styles';
 import { useTariBalance } from '@app/hooks/wallet/useTariBalance.ts';
 import useDebouncedValue from '@app/hooks/helpers/useDebounce.ts';
 
-export function SendForm() {
+interface Props {
+    isBack?: boolean;
+}
+
+export function SendForm({ isBack }: Props) {
     const { t } = useTranslation('wallet');
 
     const [address, setAddress] = useState('');
@@ -57,11 +61,18 @@ export function SendForm() {
         void validateAddress(debouncedAddress);
     }, [debouncedAddress, validateAddress]);
 
+    useEffect(() => {
+        const address = getValues().address;
+        setIsAddressEmpty(address.length === 0);
+        void validateAddress(address);
+    }, [getValues, validateAddress]);
+
     function handleChange(e: ChangeEvent<HTMLInputElement>, name: InputName) {
         const value = e.target.value;
         setValue(name, value, { shouldValidate: true });
         clearErrors(name);
     }
+
     function handleAddressChange(e: ChangeEvent<HTMLInputElement>, name: InputName) {
         const value = e.target.value.replace(/\s/g, '');
         setAddress(value);
@@ -90,7 +101,7 @@ export function SendForm() {
                     handleChange={handleAddressChange}
                     onBlur={handleAddressBlur}
                     required
-                    autoFocus
+                    autoFocus={!isBack}
                     truncateOnBlur
                     isValid={isAddressValid}
                     errorText={errors.address?.message}
@@ -103,6 +114,7 @@ export function SendForm() {
                     required
                     icon={<TariOutlineSVG />}
                     disabled={isAddressEmpty}
+                    autoFocus={isBack}
                     secondaryField={
                         <FormField
                             control={control}

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -19,6 +19,8 @@ const defaultValues = { message: '', address: '', amount: undefined };
 export default function SendModal({ section, setSection }: SendModalProps) {
     const { t } = useTranslation('wallet');
     const [status, setStatus] = useState<SendStatus>('fields');
+    const [isBack, setIsBack] = useState(false);
+
     const methods = useForm<SendInputs>({
         defaultValues,
         mode: 'all',
@@ -28,6 +30,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
 
     const resetForm = () => {
         setStatus('fields');
+        setIsBack(false);
         reset();
     };
 
@@ -38,6 +41,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
 
     function handleBack() {
         setStatus('fields');
+        setIsBack(true);
     }
 
     const handleFormSubmit = useCallback(
@@ -99,7 +103,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                 <Wrapper $isLoading={methods.formState.isSubmitting}>
                     <StyledForm onSubmit={methods.handleSubmit(handleFormSubmit)}>
                         {status === 'fields' ? (
-                            <SendForm />
+                            <SendForm isBack={isBack} />
                         ) : (
                             <SendReview
                                 status={status}


### PR DESCRIPTION
Issue: 

When reviewing a transaction and clicking the back button, the Amount and Message fields were disabled. 

Fix: 

Now when hitting the back button to edit and make changes, the Amount and Message fields are active. I also made it so the Amount field is auto-focused instead of the address field when going back to edit, since that's the most likely field for the user to update. 

![CleanShot 2025-04-25 at 16 53 28@2x](https://github.com/user-attachments/assets/5071ea10-2b5c-48ea-89a6-efb33541d41d)

![CleanShot 2025-04-25 at 16 53 39@2x](https://github.com/user-attachments/assets/7c27c644-7eb3-4abc-aa7f-ee7f5f5bd7e6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the send form experience by adjusting input field autofocus based on navigation, making it easier to resume editing after returning from the review step.

- **Bug Fixes**
  - Address field validation and empty state are now reliably synchronized when navigating back to the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->