### PR TITLE
fix(node switch): prevent from redundant use of switch_to_local_when_…

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -198,19 +198,19 @@ impl NodeManager {
         }
 
         let node_type = self.get_node_type().await?;
-        if matches!(node_type, NodeType::RemoteUntilLocal) {
-            self.switch_to_local_when_synced(shutdown_signal.clone(), app_handle)
-                .await?;
-        }
         start_status_forwarding_thread(
             self.clone(),
             self.base_node_watch_tx.clone(),
             self.local_node_watch_rx.clone(),
             self.remote_node_watch_rx.clone(),
-            shutdown_signal,
+            shutdown_signal.clone(),
         )
         .await?;
         self.wait_ready().await?;
+        if matches!(node_type, NodeType::RemoteUntilLocal) {
+            self.switch_to_local_when_synced(shutdown_signal, app_handle)
+                .await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
When db is corrupted/chain reset we were calling `switch_to_local_when_synced` twice. First wait_ready for node, then call switch_to_local_when_synced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the order of internal processes to ensure local switch monitoring starts after node readiness and status forwarding are established. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->