### PR TITLE
fix: estimating remaining time when headers step

### DIFF
--- a/src/containers/main/Sync/components/useProgressCountdown.ts
+++ b/src/containers/main/Sync/components/useProgressCountdown.ts
@@ -19,8 +19,8 @@ export const useProgressCountdown = () => {
                 // Calculate for header sync
                 if (step === 'Header' && local_header_height != null && tip_header_height != null) {
                     const remainingHeaders = Number(tip_header_height) - Number(local_header_height);
-                    const estimatedMinutes = remainingHeaders * 0.002866666667;
-                    setCountdown(Math.ceil(estimatedMinutes * 60 * 2 + 60)); // Convert to seconds(double for blocks sync after)
+                    const estimatedMinutes = (remainingHeaders + Number(tip_block_height)) * 0.002866666667 + 1;
+                    setCountdown(Math.ceil(estimatedMinutes * 60)); // Convert to seconds
                     return;
                 }
                 // Calculate for block sync


### PR DESCRIPTION
Description
---
Consider tip_block_height instead of doubling remainingHeaders


https://github.com/user-attachments/assets/385f7014-639d-47d8-89ef-44bd5ac43534



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and updated the countdown timer calculation for the header sync step, resulting in a revised estimated time display during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->