### PR TITLE
fix: add additional config saves

### DIFF
--- a/src-tauri/src/configs/config_core.rs
+++ b/src-tauri/src/configs/config_core.rs
@@ -131,6 +131,7 @@ impl ConfigCore {
         if config.content.mmproxy_monero_nodes.is_empty() {
             warn!("Empty list of monero nodes for mmproxy found. Using default list");
             config.content.mmproxy_monero_nodes = default_monero_nodes();
+            let _unused = Self::_save_config(config.content.clone());
         }
 
         EventsManager::handle_config_core_loaded(&app_handle, config.content.clone()).await;
@@ -198,6 +199,7 @@ impl ConfigImpl for ConfigCore {
                 airdrop_tokens: old_config.airdrop_tokens(),
                 ..Default::default()
             };
+            let _unused = Self::_save_config(self.content.clone());
         } else {
             self.content.set_was_config_migrated(true);
         }

--- a/src-tauri/src/configs/config_mining.rs
+++ b/src-tauri/src/configs/config_mining.rs
@@ -164,6 +164,7 @@ impl ConfigImpl for ConfigMining {
                 cpu_mining_enabled: old_config.cpu_mining_enabled(),
                 ludicrous_mode_cpu_threads: old_config.ludicrous_mode_cpu_threads(),
             };
+            let _unused = Self::_save_config(self.content.clone());
         } else {
             self.content.set_was_config_migrated(true);
         }

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -98,6 +98,8 @@ impl ConfigUI {
         config.handle_old_config_migration(old_config);
 
         EventsManager::handle_config_ui_loaded(&app_handle, config.content.clone()).await;
+        drop(config);
+
         let _unused = Self::update_field(
             ConfigUIContent::propose_system_language,
             "en-US".to_string(),

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -98,8 +98,6 @@ impl ConfigUI {
         config.handle_old_config_migration(old_config);
 
         EventsManager::handle_config_ui_loaded(&app_handle, config.content.clone()).await;
-        drop(config);
-
         let _unused = Self::update_field(
             ConfigUIContent::propose_system_language,
             "en-US".to_string(),
@@ -162,6 +160,7 @@ impl ConfigImpl for ConfigUI {
                 visual_mode: old_config.visual_mode(),
                 show_experimental_settings: old_config.show_experimental_settings(),
             };
+            let _unused = Self::_save_config(self.content.clone());
         } else {
             self.content.set_was_config_migrated(true);
         }

--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -192,6 +192,7 @@ impl ConfigImpl for ConfigWallet {
                 monero_address: old_config.monero_address().to_string(),
                 monero_address_is_generated: old_config.monero_address_is_generated(),
             };
+            let _unused = Self::_save_config(self.content.clone());
         } else {
             self.content.set_was_config_migrated(true);
         }


### PR DESCRIPTION
### [ Summary ]
- After setting monero nodes update config file to match current struct data
- Add save after migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured configuration changes are saved immediately after updates or migrations, improving reliability and persistence of settings across app configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->