### PR TITLE
fix: phase-timeout-counted-too-soon

### DIFF
--- a/src-tauri/src/setup/phase_core.rs
+++ b/src-tauri/src/setup/phase_core.rs
@@ -112,7 +112,6 @@ impl SetupPhaseImpl for CoreSetupPhase {
     ) {
         info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Core);
         TasksTrackers::current().core_phase.get_task_tracker().await.spawn(async move {
-            let setup_timeout = tokio::time::sleep(SETUP_TIMEOUT_DURATION);
             let mut shutdown_signal = TasksTrackers::current().core_phase.get_signal().await;
             for subscriber in &mut flow_subscribers.iter_mut() {
                 select! {
@@ -124,7 +123,7 @@ impl SetupPhaseImpl for CoreSetupPhase {
                 }
             };
             tokio::select! {
-                _ = setup_timeout => {
+                _ = tokio::time::sleep(SETUP_TIMEOUT_DURATION) => {
                     error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Core);
                     let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Core);
                     sentry::capture_message(&error_message, sentry::Level::Error);

--- a/src-tauri/src/setup/phase_hardware.rs
+++ b/src-tauri/src/setup/phase_hardware.rs
@@ -117,7 +117,6 @@ impl SetupPhaseImpl for HardwareSetupPhase {
         info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Hardware);
 
         TasksTrackers::current().hardware_phase.get_task_tracker().await.spawn(async move {
-            let setup_timeout = tokio::time::sleep(SETUP_TIMEOUT_DURATION);
             let mut shutdown_signal = TasksTrackers::current().hardware_phase.get_signal().await;
             for subscriber in &mut flow_subscribers.iter_mut() {
                 select! {
@@ -129,7 +128,7 @@ impl SetupPhaseImpl for HardwareSetupPhase {
                 }
             };
             tokio::select! {
-                _ = setup_timeout => {
+                _ = tokio::time::sleep(SETUP_TIMEOUT_DURATION) => {
                     error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Hardware);
                     let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Hardware);
                     sentry::capture_message(&error_message, sentry::Level::Error);

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -134,7 +134,6 @@ impl SetupPhaseImpl for NodeSetupPhase {
             } else {
                 SETUP_TIMEOUT_DURATION
             };
-            let setup_timeout = tokio::time::sleep(timeout_duration);
             let mut shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
             for subscriber in &mut flow_subscribers.iter_mut() {
                 select! {
@@ -146,7 +145,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
                 }
             };
             tokio::select! {
-                _ = setup_timeout => {
+                _ = tokio::time::sleep(timeout_duration) => {
                     error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Node);
                     let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Node);
                     sentry::capture_message(&error_message, sentry::Level::Error);

--- a/src-tauri/src/setup/phase_unknown.rs
+++ b/src-tauri/src/setup/phase_unknown.rs
@@ -125,7 +125,6 @@ impl SetupPhaseImpl for UnknownSetupPhase {
         info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Unknown);
 
         TasksTrackers::current().unknown_phase.get_task_tracker().await.spawn(async move {
-            let setup_timeout = tokio::time::sleep(SETUP_TIMEOUT_DURATION);
             let mut shutdown_signal = TasksTrackers::current().unknown_phase.get_signal().await;
             for subscriber in &mut flow_subscribers.iter_mut() {
                 select! {
@@ -137,7 +136,7 @@ impl SetupPhaseImpl for UnknownSetupPhase {
                 }
             };
             tokio::select! {
-                _ = setup_timeout => {
+                _ = tokio::time::sleep(SETUP_TIMEOUT_DURATION) => {
                     error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Unknown);
                     let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Unknown);
                     sentry::capture_message(&error_message, sentry::Level::Error);

--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -110,7 +110,6 @@ impl SetupPhaseImpl for WalletSetupPhase {
         info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Wallet);
 
         TasksTrackers::current().wallet_phase.get_task_tracker().await.spawn(async move {
-            let setup_timeout = tokio::time::sleep(SETUP_TIMEOUT_DURATION);
             let mut shutdown_signal = TasksTrackers::current().wallet_phase.get_signal().await;
             for subscriber in &mut flow_subscribers.iter_mut() {
                 select! {
@@ -123,7 +122,7 @@ impl SetupPhaseImpl for WalletSetupPhase {
             };
 
             tokio::select! {
-                _ = setup_timeout => {
+                _ = tokio::time::sleep(SETUP_TIMEOUT_DURATION) => {
                     error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Wallet);
                     let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Wallet);
                     sentry::capture_message(&error_message, sentry::Level::Error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified timeout handling during setup phases, resulting in cleaner and more maintainable code. There is no change to user-facing behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->