### PR TITLE
fix: node updates when setting up

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1784,12 +1784,13 @@ pub async fn set_node_type(
     ConfigCore::update_field_requires_restart(
         ConfigCoreContent::set_node_type,
         node_type.clone(),
-        vec![SetupPhase::Wallet, SetupPhase::Node, SetupPhase::Unknown],
+        vec![SetupPhase::Node, SetupPhase::Wallet, SetupPhase::Unknown],
     )
     .await
     .map_err(InvokeError::from_anyhow)?;
 
     state.node_manager.set_node_type(node_type.clone()).await;
+    EventsManager::handle_node_type_update(&app_handle).await;
 
     SetupManager::get_instance()
         .restart_phases_from_queue(app_handle)

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -289,7 +289,6 @@ impl NodeManager {
         progress_params_tx: &watch::Sender<HashMap<String, String>>,
         progress_percentage_tx: &watch::Sender<f64>,
     ) -> Result<(), anyhow::Error> {
-        self.wait_ready().await?;
         let shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
         loop {
             let current_service = self.get_current_service().await?;
@@ -591,6 +590,7 @@ where
             wait_ready_for_node_process(node_watcher).await?;
             match service.get_identity().await {
                 Ok(_) => {
+                    wait_ready_for_node_process(node_watcher).await?;
                     return Ok(());
                 }
                 Err(err) => {

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -222,7 +222,6 @@ impl SetupPhaseImpl for NodeSetupPhase {
 
         info!(target: LOG_TARGET, "Starting node manager, grpc address: {}", self.app_configuration.base_node_grpc_address);
 
-        // Note: it starts 2 processes of node
         for _i in 0..2 {
             match state
                 .node_manager

--- a/src/containers/floating/Settings/sections/connections/ConnectionsSettings.tsx
+++ b/src/containers/floating/Settings/sections/connections/ConnectionsSettings.tsx
@@ -2,14 +2,20 @@ import Node from './Node.tsx';
 import Network from './Network.tsx';
 import Peers from './Peers.tsx';
 import NodeTypeConfiguration from './NodeTypeConfiguration.tsx';
+import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 export const ConnectionsSettings = () => {
+    const isAppSettingUp = useSetupStore((s) => !s.appUnlocked);
     return (
         <>
             {import.meta.env.MODE == 'development' && <NodeTypeConfiguration />}
             <Node />
-            <Network />
-            <Peers />
+            {!isAppSettingUp && (
+                <>
+                    <Network />
+                    <Peers />
+                </>
+            )}
         </>
     );
 };

--- a/src/containers/main/Sync/components/useProgressCountdown.ts
+++ b/src/containers/main/Sync/components/useProgressCountdown.ts
@@ -3,53 +3,81 @@ import { useNodeStore } from '@app/store/useNodeStore';
 import { useTranslation } from 'react-i18next';
 import { useSetupStore } from '@app/store/useSetupStore';
 
+const MIN_PER_BLOCK_SYNC = 0.002866666667;
+const REMOTE_DEFAULT_ESTIMATE = 120;
+
+const getLocalNodeEstimate = (nodeSetupParams: Record<string, string> | undefined): number => {
+    if (nodeSetupParams) {
+        const { step, local_header_height, tip_header_height, local_block_height, tip_block_height } = nodeSetupParams;
+        if (step === 'Header' && local_header_height != null && tip_header_height != null) {
+            const remainingHeaders = Number(tip_header_height) - Number(local_header_height);
+            const estimatedMinutes = (remainingHeaders + Number(tip_block_height)) * MIN_PER_BLOCK_SYNC + 1;
+            return Math.ceil(estimatedMinutes * 60); // Convert to seconds
+        }
+        if (step === 'Block' && local_block_height != null && tip_block_height != null) {
+            const remainingBlocks = Number(tip_block_height) - Number(local_block_height);
+            const estimatedMinutes = remainingBlocks * MIN_PER_BLOCK_SYNC + 1;
+            return Math.ceil(estimatedMinutes * 60); // Convert to seconds
+        }
+    }
+    return 60;
+};
+
+function hasValidEstimate(nodeSetupParams: Record<string, string> | undefined) {
+    if (!nodeSetupParams) return false;
+    if (nodeSetupParams.step === 'Header') {
+        return +nodeSetupParams.tip_header_height > 0;
+    }
+    if (nodeSetupParams.step === 'Block') {
+        return +nodeSetupParams.tip_block_height > 0;
+    }
+
+    return false;
+}
+
 export const useProgressCountdown = () => {
     const { t } = useTranslation('setup-progresses');
     const isNodePhaseCompleted = useSetupStore((state) => Boolean(state.node_phase_setup_payload?.is_complete));
     const nodeSetupParams = useSetupStore((state) => state.node_phase_setup_payload?.title_params);
     const nodeType = useNodeStore((s) => s.node_type);
-
-    const [countdown, setCountdown] = useState(nodeType !== 'Local' ? 120 : 60);
+    const [countdown, setCountdown] = useState(nodeType !== 'Local' ? REMOTE_DEFAULT_ESTIMATE : -1);
 
     useEffect(() => {
+        if (countdown < 0 && hasValidEstimate(nodeSetupParams)) {
+            // Update Local Node estimate when sync params retrieved
+            const estimate = getLocalNodeEstimate(nodeSetupParams);
+            setCountdown(estimate);
+        }
+    }, [countdown, nodeSetupParams]);
+
+    useEffect(() => {
+        // Handle node type changes during setup
+        if (!nodeType) return;
         if (nodeType === 'Local') {
-            if (nodeSetupParams) {
-                const { step, local_header_height, tip_header_height, local_block_height, tip_block_height } =
-                    nodeSetupParams;
-                // Calculate for header sync
-                if (step === 'Header' && local_header_height != null && tip_header_height != null) {
-                    const remainingHeaders = Number(tip_header_height) - Number(local_header_height);
-                    const estimatedMinutes = remainingHeaders * 0.002866666667;
-                    setCountdown(Math.ceil(estimatedMinutes * 60 * 2 + 60)); // Convert to seconds(double for blocks sync after)
-                    return;
-                }
-                // Calculate for block sync
-                if (step === 'Block' && local_block_height != null && tip_block_height != null) {
-                    const remainingBlocks = Number(tip_block_height) - Number(local_block_height);
-                    const estimatedMinutes = remainingBlocks * 0.002866666667 + 1;
-                    setCountdown(Math.ceil(estimatedMinutes * 60)); // Convert to seconds
-                    return;
-                }
+            if (!hasValidEstimate(nodeSetupParams)) {
+                setCountdown(-1);
             }
+        } else {
+            setCountdown(REMOTE_DEFAULT_ESTIMATE);
         }
-    }, [nodeType, nodeSetupParams, isNodePhaseCompleted]);
+        // eslint-disable-next-line react-compiler/react-compiler
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nodeType]);
 
     useEffect(() => {
-        // Only count down for remote node or local node with completed phase
-        if (nodeType !== 'Local' || isNodePhaseCompleted) {
-            const interval = setInterval(() => {
-                setCountdown((prevCountdown) => {
-                    if (prevCountdown > 0) {
-                        return prevCountdown - 1;
-                    } else {
-                        clearInterval(interval);
-                        return 0;
-                    }
-                });
-            }, 1000);
+        const interval = setInterval(() => {
+            setCountdown((prevCountdown) => {
+                if (prevCountdown > 0) {
+                    return prevCountdown - 1;
+                }
+                if (prevCountdown === 0) {
+                    clearInterval(interval);
+                }
+                return prevCountdown;
+            });
+        }, 1000);
 
-            return () => clearInterval(interval);
-        }
+        return () => clearInterval(interval);
     }, [nodeType, isNodePhaseCompleted]);
 
     const formatTime = (seconds: number) => {

--- a/src/hooks/app/useTauriEventsListener.ts
+++ b/src/hooks/app/useTauriEventsListener.ts
@@ -34,7 +34,7 @@ import {
     handleWalletLocked,
     handleWalletUnlocked,
 } from '@app/store/actions/setupStoreActions';
-import { setBackgroundNodeState, setNodeTypeState } from '@app/store/useNodeStore';
+import { setBackgroundNodeState, setNodeStoreState } from '@app/store/useNodeStore';
 import {
     handleConfigCoreLoaded,
     handleConfigMiningLoaded,
@@ -161,7 +161,7 @@ const useTauriEventsListener = () => {
                             setNetworkStatus(event.payload);
                             break;
                         case `NodeTypeUpdate`:
-                            setNodeTypeState(event.payload);
+                            setNodeStoreState(event.payload);
                             break;
                         case 'RestartingPhases':
                             handleRestartingPhases(event.payload);

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -16,7 +16,7 @@ import { setUITheme } from './uiStoreActions';
 import { GpuThreads } from '@app/types/app-status.ts';
 import { displayMode, modeType } from '../types';
 import { ConfigCore, ConfigMining, ConfigUI, ConfigWallet } from '@app/types/configs.ts';
-import { NodeType } from '../useNodeStore.ts';
+import { NodeType, updateNodeType as updateNodeTypeForNodeStore } from '../useNodeStore.ts';
 
 interface SetModeProps {
     mode: modeType;
@@ -284,10 +284,12 @@ export const setVisualMode = (enabled: boolean) => {
 export const setNodeType = async (nodeType: NodeType) => {
     const previousNodeType = useConfigCoreStore.getState().node_type;
     useConfigCoreStore.setState({ node_type: nodeType });
+    updateNodeTypeForNodeStore(nodeType);
 
     invoke('set_node_type', { nodeType: nodeType }).catch((e) => {
         console.error('Could not set node type', e);
         setError('Could not change node type');
         useConfigCoreStore.setState({ node_type: previousNodeType });
+        updateNodeTypeForNodeStore(nodeType);
     });
 };

--- a/src/store/useNodeStore.ts
+++ b/src/store/useNodeStore.ts
@@ -28,8 +28,12 @@ export const useNodeStore = create<NodeStoreState>()(() => ({
     ...initialState,
 }));
 
-export const setNodeTypeState = (newState: Partial<NodeStoreState>) => {
+export const setNodeStoreState = (newState: Partial<NodeStoreState>) => {
     useNodeStore.setState((state) => ({ ...state, ...newState }));
+};
+
+export const updateNodeType = (node_type: NodeType) => {
+    setNodeStoreState({ ...initialState, node_type });
 };
 
 export const setBackgroundNodeState = (backgroundNodeSyncLastUpdate: BackgroundNodeSyncUpdatePayload) => {


### PR DESCRIPTION
Description
---
* Count down est. remaining startup time regardless of the speed of sync.
* Immediately apply node related values when node type changed(prevent from problematic nullable values)
* Fix changing node type during setup
* Prevent from some Setup failures
* Hide connected peers/miners connection to the network until setup is finished(it's not updated during the setup anyway)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Network and peers settings are now hidden while the app is still setting up, improving the setup experience.
  - Countdown timer for node synchronization now provides more accurate estimates and a clearer indication when estimates are unavailable.

- **Bug Fixes**
  - Node type updates are now consistently propagated across the app, ensuring UI and state remain in sync.

- **Improvements**
  - Synchronization progress countdown is more reliable and easier to understand.
  - Enhanced event handling for node type changes, leading to a more responsive UI during configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->