### PR TITLE
fix: allow miner settings change during setup

### DIFF
--- a/src/containers/floating/Settings/sections/mining/CpuMiningMarkup.tsx
+++ b/src/containers/floating/Settings/sections/mining/CpuMiningMarkup.tsx
@@ -12,13 +12,11 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 import { setCpuMiningEnabled } from '@app/store/actions/appConfigStoreActions.ts';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { useConfigMiningStore } from '@app/store/useAppConfigStore.ts';
 
 export default function CpuMiningSettings() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const isCpuMiningEnabled = useConfigMiningStore((s) => s.cpu_mining_enabled);
-    const isSettingUp = useSetupStore((s) => !s.miningUnlocked);
 
     const handleCpuMiningEnabled = useCallback(async () => {
         await setCpuMiningEnabled(!isCpuMiningEnabled);
@@ -34,11 +32,7 @@ export default function CpuMiningSettings() {
                     <Typography>{t('mining-toggle-warning')}</Typography>
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <ToggleSwitch
-                        checked={isCpuMiningEnabled}
-                        disabled={isSettingUp}
-                        onChange={handleCpuMiningEnabled}
-                    />
+                    <ToggleSwitch checked={isCpuMiningEnabled} onChange={handleCpuMiningEnabled} />
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/containers/floating/Settings/sections/mining/CpuMiningMarkup.tsx
+++ b/src/containers/floating/Settings/sections/mining/CpuMiningMarkup.tsx
@@ -13,10 +13,12 @@ import {
 } from '../../components/SettingsGroup.styles.ts';
 import { setCpuMiningEnabled } from '@app/store/actions/appConfigStoreActions.ts';
 import { useConfigMiningStore } from '@app/store/useAppConfigStore.ts';
+import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 export default function CpuMiningSettings() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const isCpuMiningEnabled = useConfigMiningStore((s) => s.cpu_mining_enabled);
+    const isHardwarePhaseFinished = useSetupStore((s) => s.hardwarePhaseFinished);
 
     const handleCpuMiningEnabled = useCallback(async () => {
         await setCpuMiningEnabled(!isCpuMiningEnabled);
@@ -32,7 +34,11 @@ export default function CpuMiningSettings() {
                     <Typography>{t('mining-toggle-warning')}</Typography>
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <ToggleSwitch checked={isCpuMiningEnabled} onChange={handleCpuMiningEnabled} />
+                    <ToggleSwitch
+                        checked={isCpuMiningEnabled}
+                        disabled={!isHardwarePhaseFinished}
+                        onChange={handleCpuMiningEnabled}
+                    />
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -16,16 +16,19 @@ import { GpuDevice } from '@app/types/app-status.ts';
 import { toggleDeviceExclusion } from '@app/store/actions/miningStoreActions.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import { useConfigMiningStore } from '@app/store/useAppConfigStore.ts';
+import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 const GpuDevices = memo(function GpuDevices() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const gpuDevices = useMiningMetricsStore((s) => s.gpu_devices);
     const isGPUMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
+    const isHardwarePhaseFinished = useSetupStore((s) => s.hardwarePhaseFinished);
 
     const miningInitiated = useMiningStore((s) => s.miningInitiated);
     const isGpuMiningEnabled = useConfigMiningStore((s) => s.gpu_mining_enabled);
     const isExcludingGpuDevices = useMiningStore((s) => s.isExcludingGpuDevices);
-    const isDisabled = isExcludingGpuDevices || isGPUMining || miningInitiated || !isGpuMiningEnabled;
+    const isDisabled =
+        !isHardwarePhaseFinished || isExcludingGpuDevices || isGPUMining || miningInitiated || !isGpuMiningEnabled;
 
     const handleSetExcludedDevice = useCallback(async (device: GpuDevice) => {
         await toggleDeviceExclusion(device.device_index, !device.settings.is_excluded);

--- a/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuDevices.tsx
@@ -15,19 +15,17 @@ import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 import { GpuDevice } from '@app/types/app-status.ts';
 import { toggleDeviceExclusion } from '@app/store/actions/miningStoreActions.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { useConfigMiningStore } from '@app/store/useAppConfigStore.ts';
 
 const GpuDevices = memo(function GpuDevices() {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
-    const miningAllowed = useSetupStore((s) => s.miningUnlocked);
     const gpuDevices = useMiningMetricsStore((s) => s.gpu_devices);
     const isGPUMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
 
     const miningInitiated = useMiningStore((s) => s.miningInitiated);
     const isGpuMiningEnabled = useConfigMiningStore((s) => s.gpu_mining_enabled);
     const isExcludingGpuDevices = useMiningStore((s) => s.isExcludingGpuDevices);
-    const isDisabled = isExcludingGpuDevices || isGPUMining || miningInitiated || !miningAllowed || !isGpuMiningEnabled;
+    const isDisabled = isExcludingGpuDevices || isGPUMining || miningInitiated || !isGpuMiningEnabled;
 
     const handleSetExcludedDevice = useCallback(async (device: GpuDevice) => {
         await toggleDeviceExclusion(device.device_index, !device.settings.is_excluded);

--- a/src/containers/floating/Settings/sections/mining/GpuMiningMarkup.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuMiningMarkup.tsx
@@ -12,11 +12,9 @@ import {
 } from '../../components/SettingsGroup.styles.ts';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 import { setGpuMiningEnabled, useConfigMiningStore } from '@app/store';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 const GpuMiningMarkup = () => {
     const { t } = useTranslation(['settings'], { useSuspense: false });
-    const isSettingUp = useSetupStore((s) => !s.miningUnlocked);
     const isGpuMiningEnabled = useConfigMiningStore((s) => s.gpu_mining_enabled);
     const gpuDevicesHardware = useMiningMetricsStore((s) => s.gpu_devices);
 
@@ -44,11 +42,7 @@ const GpuMiningMarkup = () => {
                     )}
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <ToggleSwitch
-                        checked={isGpuMiningEnabled}
-                        disabled={isSettingUp}
-                        onChange={handleGpuMiningEnabled}
-                    />
+                    <ToggleSwitch checked={isGpuMiningEnabled} onChange={handleGpuMiningEnabled} />
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/containers/floating/Settings/sections/mining/GpuMiningMarkup.tsx
+++ b/src/containers/floating/Settings/sections/mining/GpuMiningMarkup.tsx
@@ -12,11 +12,13 @@ import {
 } from '../../components/SettingsGroup.styles.ts';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
 import { setGpuMiningEnabled, useConfigMiningStore } from '@app/store';
+import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 const GpuMiningMarkup = () => {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const isGpuMiningEnabled = useConfigMiningStore((s) => s.gpu_mining_enabled);
     const gpuDevicesHardware = useMiningMetricsStore((s) => s.gpu_devices);
+    const isHardwarePhaseFinished = useSetupStore((s) => s.hardwarePhaseFinished);
 
     const isGPUMiningAvailable = useMemo(() => {
         if (!gpuDevicesHardware) return false;
@@ -42,7 +44,11 @@ const GpuMiningMarkup = () => {
                     )}
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <ToggleSwitch checked={isGpuMiningEnabled} onChange={handleGpuMiningEnabled} />
+                    <ToggleSwitch
+                        checked={isGpuMiningEnabled}
+                        disabled={!isHardwarePhaseFinished}
+                        onChange={handleGpuMiningEnabled}
+                    />
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/containers/floating/Settings/sections/p2p/P2pMarkup.tsx
+++ b/src/containers/floating/Settings/sections/p2p/P2pMarkup.tsx
@@ -12,7 +12,6 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 import { setP2poolEnabled, useConfigCoreStore } from '@app/store';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 interface P2pMarkupProps {
     setDisabledStats: (value: boolean) => void;
@@ -21,9 +20,6 @@ interface P2pMarkupProps {
 const P2pMarkup = ({ setDisabledStats }: P2pMarkupProps) => {
     const { t } = useTranslation(['common', 'settings'], { useSuspense: false });
     const isP2poolEnabled = useConfigCoreStore((state) => state.is_p2pool_enabled);
-    const miningAllowed = useSetupStore((s) => s.miningUnlocked);
-
-    const isDisabled = !miningAllowed;
 
     const handleP2poolEnabled = useCallback(
         async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -43,7 +39,7 @@ const P2pMarkup = ({ setDisabledStats }: P2pMarkupProps) => {
                     <Typography>{t('pool-mining-description', { ns: 'settings' })}</Typography>
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <ToggleSwitch checked={isP2poolEnabled} disabled={isDisabled} onChange={handleP2poolEnabled} />
+                    <ToggleSwitch checked={isP2poolEnabled} onChange={handleP2poolEnabled} />
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>

--- a/src/containers/navigation/components/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
+++ b/src/containers/navigation/components/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
@@ -3,23 +3,21 @@ import { CustomPowerLevelsDialog } from './CustomPowerLevelsDialog';
 import { useMiningStore } from '@app/store/useMiningStore';
 import { useEffect } from 'react';
 import { getMaxAvailableThreads, setCustomLevelsDialogOpen } from '@app/store';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
 
 export const CustomPowerLevelsDialogContainer = () => {
     const customLevelsDialogOpen = useMiningStore((s) => s.customLevelsDialogOpen);
     const isChangingMode = useMiningStore((s) => s.isChangingMode);
     const maxThreads = useMiningStore((s) => s.maxAvailableThreads);
-    const isMiningnlocked = useSetupStore((s) => s.miningUnlocked);
 
     const handleClose = () => {
         setCustomLevelsDialogOpen(false);
     };
     useEffect(() => {
-        if (!maxThreads && isMiningnlocked) {
+        if (!maxThreads) {
             getMaxAvailableThreads();
         }
-    }, [maxThreads, isMiningnlocked]);
+    }, [maxThreads]);
 
     return (
         <Dialog

--- a/src/containers/navigation/components/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
+++ b/src/containers/navigation/components/Miner/components/CustomPowerLevels/CustomPowerLevelsDialogContainer.tsx
@@ -4,20 +4,22 @@ import { useMiningStore } from '@app/store/useMiningStore';
 import { useEffect } from 'react';
 import { getMaxAvailableThreads, setCustomLevelsDialogOpen } from '@app/store';
 import { CircularProgress } from '@app/components/elements/CircularProgress.tsx';
+import { useSetupStore } from '@app/store/useSetupStore';
 
 export const CustomPowerLevelsDialogContainer = () => {
     const customLevelsDialogOpen = useMiningStore((s) => s.customLevelsDialogOpen);
     const isChangingMode = useMiningStore((s) => s.isChangingMode);
     const maxThreads = useMiningStore((s) => s.maxAvailableThreads);
+    const isHardwarePhaseFinished = useSetupStore((s) => s.hardwarePhaseFinished);
 
     const handleClose = () => {
         setCustomLevelsDialogOpen(false);
     };
     useEffect(() => {
-        if (!maxThreads) {
+        if (!maxThreads && isHardwarePhaseFinished) {
             getMaxAvailableThreads();
         }
-    }, [maxThreads]);
+    }, [isHardwarePhaseFinished, maxThreads]);
 
     return (
         <Dialog

--- a/src/containers/navigation/components/Miner/components/ModeSelect.tsx
+++ b/src/containers/navigation/components/Miner/components/ModeSelect.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 import { modeType } from '@app/store/types';
 import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
-import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { useMiningStore } from '@app/store/useMiningStore.ts';
 import { setDialogToShow } from '@app/store/actions/uiStoreActions.ts';
 import { changeMiningMode, setCustomLevelsDialogOpen } from '@app/store/actions/miningStoreActions.ts';
@@ -22,8 +21,6 @@ interface ModeSelectProps {
 }
 const ModeSelect = memo(function ModeSelect({ variant = 'primary' }: ModeSelectProps) {
     const { t } = useTranslation('common', { useSuspense: false });
-    const isSettingUp = useSetupStore((s) => !s.appUnlocked);
-    const isMiningUnlocked = useSetupStore((s) => s.miningUnlocked);
     const mode = useConfigMiningStore((s) => s.mode);
     const isCPUMining = useMiningMetricsStore((s) => s.cpu_mining_status.is_mining);
     const isGPUMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
@@ -69,8 +66,7 @@ const ModeSelect = memo(function ModeSelect({ variant = 'primary' }: ModeSelectP
 
     const selectMarkup = (
         <Select
-            disabled={!isMiningUnlocked || (isSettingUp && !isMininimal)}
-            loading={!isMiningUnlocked || isChangingMode || (isMining && (isMiningLoading || !isMiningControlsEnabled))}
+            loading={isChangingMode || (isMining && (isMiningLoading || !isMiningControlsEnabled))}
             onChange={handleChange}
             selectedValue={mode}
             options={tabOptions}

--- a/src/containers/navigation/components/Miner/components/ModeSelect.tsx
+++ b/src/containers/navigation/components/Miner/components/ModeSelect.tsx
@@ -15,6 +15,7 @@ import custom from '@app/assets/icons/emoji/custom.png';
 
 import { TileItem } from '../styles';
 import { useConfigMiningStore, useConfigUIStore } from '@app/store';
+import { useSetupStore } from '@app/store/useSetupStore';
 
 interface ModeSelectProps {
     variant?: 'primary' | 'minimal';
@@ -24,6 +25,7 @@ const ModeSelect = memo(function ModeSelect({ variant = 'primary' }: ModeSelectP
     const mode = useConfigMiningStore((s) => s.mode);
     const isCPUMining = useMiningMetricsStore((s) => s.cpu_mining_status.is_mining);
     const isGPUMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
+    const isHardwarePhaseFinished = useSetupStore((s) => s.hardwarePhaseFinished);
 
     const isMiningControlsEnabled = useMiningStore((s) => s.miningControlsEnabled);
     const isChangingMode = useMiningStore((s) => s.isChangingMode);
@@ -66,7 +68,12 @@ const ModeSelect = memo(function ModeSelect({ variant = 'primary' }: ModeSelectP
 
     const selectMarkup = (
         <Select
-            loading={isChangingMode || (isMining && (isMiningLoading || !isMiningControlsEnabled))}
+            disabled={!isHardwarePhaseFinished}
+            loading={
+                !isHardwarePhaseFinished ||
+                isChangingMode ||
+                (isMining && (isMiningLoading || !isMiningControlsEnabled))
+            }
             onChange={handleChange}
             selectedValue={mode}
             options={tabOptions}

--- a/src/hooks/app/useTauriEventsListener.ts
+++ b/src/hooks/app/useTauriEventsListener.ts
@@ -29,6 +29,7 @@ import { refreshTransactions, setWalletAddress, setWalletBalance, updateWalletSc
 import { deepEqual } from '@app/utils/objectDeepEqual.ts';
 import {
     handleAppUnlocked,
+    handleHardwarePhaseFinished,
     handleMiningLocked,
     handleMiningUnlocked,
     handleWalletLocked,
@@ -79,6 +80,7 @@ const useTauriEventsListener = () => {
                         case 'CorePhaseFinished':
                             break;
                         case 'HardwarePhaseFinished':
+                            await handleHardwarePhaseFinished();
                             break;
                         case 'NodePhaseFinished':
                             break;

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -61,6 +61,9 @@ export const handleMiningLocked = async () => {
         await stopMining();
     }
 };
+export const handleHardwarePhaseFinished = async () => {
+    useSetupStore.setState({ hardwarePhaseFinished: true });
+};
 
 export const updateCoreSetupPhaseInfo = (payload: ProgressTrackerUpdatePayload | undefined) => {
     useSetupStore.setState({ core_phase_setup_payload: payload });

--- a/src/store/types/setup.ts
+++ b/src/store/types/setup.ts
@@ -3,6 +3,7 @@ import { ProgressTrackerUpdatePayload } from '@app/hooks/app/useProgressEventsLi
 export interface SetupState {
     miningUnlocked: boolean;
     walletUnlocked: boolean;
+    hardwarePhaseFinished: boolean;
     appUnlocked: boolean;
     core_phase_setup_payload?: ProgressTrackerUpdatePayload;
     hardware_phase_setup_payload?: ProgressTrackerUpdatePayload;

--- a/src/store/useSetupStore.ts
+++ b/src/store/useSetupStore.ts
@@ -6,6 +6,7 @@ export type PhaseTitle = 'setup-core' | 'setup-local-node' | 'setup-hardware' | 
 const initialState: SetupState = {
     miningUnlocked: false,
     walletUnlocked: false,
+    hardwarePhaseFinished: false,
     appUnlocked: false,
     core_phase_setup_payload: undefined,
     hardware_phase_setup_payload: undefined,


### PR DESCRIPTION
Solves: https://github.com/tari-project/universe/issues/1947

Description
---
Allow when **Hardware phase finished**:
* change mining mode(eco/ludi/custom)
* enable/disable cpu mining
* enable/disable gpu mining
* enable/disable gpu devices

Allow everytime:
* toggle p2pool mining

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new status to track when the hardware phase of setup is complete, enabling improved control over mining and related settings.

- **Bug Fixes**
  - Updated toggle switches and controls in mining and P2P settings to more accurately reflect hardware setup status, ensuring they are enabled or disabled at the correct times.

- **Refactor**
  - Simplified and unified the logic for enabling, disabling, and loading states across mining-related controls based on hardware phase completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->