### PR TITLE
fix: prevent from overriding node phase status when completed

### DIFF
--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -324,7 +324,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
             .wait_synced(&progress_params_tx, &progress_percentage_tx)
             .await?;
         progress_handle.abort();
-        let _ = progress_handle.await;
+        let _unused = progress_handle.await;
 
         Ok(())
     }

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -280,7 +280,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
             Some(ProgressPlans::Node(ProgressSetupNodePlan::Done)),
         );
 
-        TasksTrackers::current()
+        let progress_handle = TasksTrackers::current()
             .node_phase
             .get_task_tracker()
             .await
@@ -323,6 +323,8 @@ impl SetupPhaseImpl for NodeSetupPhase {
             .node_manager
             .wait_synced(&progress_params_tx, &progress_percentage_tx)
             .await?;
+        progress_handle.abort();
+        let _ = progress_handle.await;
 
         Ok(())
     }

--- a/src/store/types/setup.ts
+++ b/src/store/types/setup.ts
@@ -7,7 +7,6 @@ export interface SetupState {
     appUnlocked: boolean;
     core_phase_setup_payload?: ProgressTrackerUpdatePayload;
     hardware_phase_setup_payload?: ProgressTrackerUpdatePayload;
-    remote_node_phase_setup_payload?: ProgressTrackerUpdatePayload;
     node_phase_setup_payload?: ProgressTrackerUpdatePayload;
     wallet_phase_setup_payload?: ProgressTrackerUpdatePayload;
     unknown_phase_setup_payload?: ProgressTrackerUpdatePayload;

--- a/src/store/useSetupStore.ts
+++ b/src/store/useSetupStore.ts
@@ -10,7 +10,6 @@ const initialState: SetupState = {
     appUnlocked: false,
     core_phase_setup_payload: undefined,
     hardware_phase_setup_payload: undefined,
-    remote_node_phase_setup_payload: undefined,
     node_phase_setup_payload: undefined,
     wallet_phase_setup_payload: undefined,
     unknown_phase_setup_payload: undefined,


### PR DESCRIPTION
Description
---
* last syncing update might overwrite the "is_completed" flag for node phase due to race condition:
```rust
        EventsManager::handle_progress_tracker_update(
            ...
            false, // is completed
        )
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the property related to remote node phase setup progress tracking from the application state.  
- **Chores**
  - Improved internal handling of progress tracking tasks for node synchronization to ensure clean termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->