### PR TITLE
chore: feature flag for ui-send-recv

### DIFF
--- a/src/components/transactions/wallet/Wallet.tsx
+++ b/src/components/transactions/wallet/Wallet.tsx
@@ -16,7 +16,7 @@ import { useCopyToClipboard } from '@app/hooks/index.ts';
 import { useWalletStore } from '@app/store/useWalletStore.ts';
 import { SendSVG } from '@app/assets/icons/send.tsx';
 import { ReceiveSVG } from '@app/assets/icons/receive.tsx';
-import { usePaperWalletStore } from '@app/store';
+import { useAirdropStore, usePaperWalletStore } from '@app/store';
 import { Button } from '@app/components/elements/buttons/Button';
 import SyncTooltip from '@app/containers/navigation/components/Wallet/SyncTooltip/SyncTooltip.tsx';
 import { Wrapper } from './wallet.styles.ts';
@@ -28,11 +28,10 @@ interface Props {
     setSection: (section: string) => void;
 }
 
-const environment = import.meta.env.MODE;
-
 const Wallet = memo(function Wallet({ section, setSection }: Props) {
     const { t } = useTranslation(['wallet', 'common', 'sidebar']);
     const { copyToClipboard, isCopied } = useCopyToClipboard();
+    const uiSendRecvEnabled = useAirdropStore((s) => s.uiSendRecvEnabled);
     const setShowPaperWalletModal = usePaperWalletStore((s) => s.setShowModal);
     const walletAddress = useWalletStore((state) => state.tari_address_base58);
     const displayAddress = truncateMiddle(walletAddress, 4);
@@ -56,7 +55,7 @@ const Wallet = memo(function Wallet({ section, setSection }: Props) {
             <HistoryList />
 
             <BottomNavWrapper>
-                {environment === 'development' ? (
+                {uiSendRecvEnabled ? (
                     <>
                         <NavButton
                             onClick={() => setSection('send')}

--- a/src/hooks/airdrop/stateHelpers/useAirdropPolling.ts
+++ b/src/hooks/airdrop/stateHelpers/useAirdropPolling.ts
@@ -5,6 +5,7 @@ import {
     fetchLatestXSpaceEvent,
     fetchOrphanChainUiFeatureFlag,
     fetchPollingFeatureFlag,
+    fetchUiSendRecvFeatureFlag,
 } from '@app/store/actions/airdropStoreActions';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useRef } from 'react';
@@ -30,6 +31,7 @@ export const useAirdropPolling = () => {
     const fetchFeatureFlags = useCallback(() => {
         fetchOrphanChainUiFeatureFlag();
         fetchPollingFeatureFlag();
+        fetchUiSendRecvFeatureFlag();
     }, []);
 
     const fetchFeatureFlagDebounced = useCallback(() => {

--- a/src/store/actions/airdropStoreActions.ts
+++ b/src/store/actions/airdropStoreActions.ts
@@ -7,7 +7,6 @@ import {
     BackendInMemoryConfig,
     BonusTier,
     CommunityMessage,
-    initialAirdropStoreState,
     setAirdropTokensInConfig,
     useAirdropStore,
     useConfigCoreStore,

--- a/src/store/actions/airdropStoreActions.ts
+++ b/src/store/actions/airdropStoreActions.ts
@@ -7,6 +7,7 @@ import {
     BackendInMemoryConfig,
     BonusTier,
     CommunityMessage,
+    initialAirdropStoreState,
     setAirdropTokensInConfig,
     useAirdropStore,
     useConfigCoreStore,
@@ -51,6 +52,7 @@ const clearState: AirdropStoreState = {
     userPoints: undefined,
     bonusTiers: undefined,
     flareAnimationType: undefined,
+    uiSendRecvEnabled: false,
 };
 
 const fetchBackendInMemoryConfig = async () => {
@@ -60,7 +62,7 @@ const fetchBackendInMemoryConfig = async () => {
         backendInMemoryConfig = await invoke('get_app_in_memory_config', {});
 
         const airdropTokens = (await invoke('get_airdrop_tokens')) || {};
-        const newState: AirdropStoreState = {
+        const newState: Partial<AirdropStoreState> = {
             backendInMemoryConfig,
         };
 

--- a/src/store/actions/airdropStoreActions.ts
+++ b/src/store/actions/airdropStoreActions.ts
@@ -238,6 +238,19 @@ export async function fetchOrphanChainUiFeatureFlag() {
     return response;
 }
 
+export async function fetchUiSendRecvFeatureFlag() {
+    const response = await handleAirdropRequest<{ access: boolean } | null>({
+        publicRequest: true,
+        path: '/features/ui-send-recv',
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+    useAirdropStore.setState({ uiSendRecvEnabled: response?.access || false });
+    return response;
+}
+
 export async function fetchCommunityMessages() {
     const response = await handleAirdropRequest<CommunityMessage[] | null>({
         publicRequest: true,

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -108,6 +108,7 @@ export interface AirdropStoreState {
     latestXSpaceEvent?: XSpaceEvent | null;
     pollingEnabled?: boolean;
     orphanChainUiDisabled?: boolean;
+    uiSendRecvEnabled: boolean;
     communityMessages?: CommunityMessage[];
 }
 
@@ -121,6 +122,7 @@ const initialState: AirdropStoreState = {
     flareAnimationType: undefined,
     latestXSpaceEvent: null,
     pollingEnabled: undefined,
+    uiSendRecvEnabled: false,
 };
 
 export const useAirdropStore = create<AirdropStoreState>()(() => ({ ...initialState }));


### PR DESCRIPTION
Issue: #1955 

Description
---
Add `ui-send-recv` feature flag that shows/hide send/recv feature

Currently I'm getting:
```
fetchUiSendRecvFeatureFlag – {response: {access: false, message: "inactive feature"}} (airdropStoreActions.ts, line 206)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature flag to control the visibility of "Send" and "Receive" options in the wallet interface.
  - The app now fetches and applies this feature flag dynamically, allowing for more flexible UI updates.

- **Bug Fixes**
  - Improved conditional rendering logic for wallet navigation buttons, ensuring correct display based on feature flag status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->