### PR TITLE
fix: clean wallet data when node db corrupted

### DIFF
--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -244,6 +244,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
                         if STOP_ON_ERROR_CODES.contains(&code) {
                             warn!(target: LOG_TARGET, "Database for node is corrupt or needs a restart, deleting and trying again.");
                             state.node_manager.clean_data_folder(&data_dir).await?;
+                            state.wallet_manager.clean_data_folder(&data_dir).await?;
                         }
                         continue;
                     }


### PR DESCRIPTION
Description
---
* When node db is corrupted(network restarted etc), clean also wallet folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability by ensuring both node and wallet data folders are cleaned when node startup fails due to specific errors, reducing issues with corrupted or stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->