### PR TITLE
fix: await send-one-sided tx when processing

### DIFF
--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -69,8 +69,8 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                     paymentId: data.message,
                 };
                 await invoke('send_one_sided_to_stealth_address', payload);
-
                 addPendingTransaction(payload);
+                setStatus('completed');
                 setSection('history');
             } catch (error) {
                 setStoreError(`Error sending transaction: ${error}`);

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -71,7 +71,6 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                 await invoke('send_one_sided_to_stealth_address', payload);
                 addPendingTransaction(payload);
                 setStatus('completed');
-                setSection('history');
             } catch (error) {
                 setStoreError(`Error sending transaction: ${error}`);
                 setError(`root.invoke_error`, {
@@ -79,7 +78,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                 });
             }
         },
-        [status, setStatus, setSection, setError, t]
+        [status, setStatus, setError, t]
     );
 
     const getModalTitle = () => {

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -68,7 +68,10 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                     destination: data.address,
                     paymentId: data.message,
                 };
-                await invoke('send_one_sided_to_stealth_address', payload);
+                await invoke('send_one_sided_to_stealth_address', {
+                    ...payload,
+                    amount: payload.amount.toString(),
+                });
                 addPendingTransaction(payload);
                 setStatus('completed');
             } catch (error) {
@@ -76,6 +79,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                 setError(`root.invoke_error`, {
                     message: `${t('send.error-message')} ${error}`,
                 });
+                setStatus('fields');
             }
         },
         [status, setStatus, setError, t]

--- a/src/components/transactions/send/SendReview/SendReview.tsx
+++ b/src/components/transactions/send/SendReview/SendReview.tsx
@@ -45,23 +45,6 @@ export function SendReview({
         }
     }, [status, setStatus, latestTx, latestPendingTx]);
 
-    // This is temporary, delete when we have a real processing state
-    useEffect(() => {
-        let timer: NodeJS.Timeout;
-
-        if (status === 'processing') {
-            timer = setTimeout(() => {
-                setStatus('completed');
-            }, 5000);
-        }
-
-        return () => {
-            if (timer) {
-                clearTimeout(timer);
-            }
-        };
-    }, [status, setStatus]);
-
     const formattedAmount = formatNumber((amount || 0) * 1_000_000, FormatPreset.TXTM_LONG);
     const formattedAddress = truncateMiddle(address, 5);
 


### PR DESCRIPTION
* Await until tx is broadcasted and then display confirmation dialog. Remove timeout for this step
* Redirect to the *fields* step, when error occured while sending tx
* Fix Max button throwing an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the transaction send flow by updating status handling after a successful send.
  - Removed the automatic 5-second timer that transitioned the transaction status to completed, resulting in more accurate status updates based on actual transaction data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->