### PR TITLE
fix: network credential manager migration

### DIFF
--- a/src-tauri/src/credential_manager.rs
+++ b/src-tauri/src/credential_manager.rs
@@ -59,7 +59,6 @@ pub enum CredentialError {
 
 const FALLBACK_FILE_PATH: &str = "credentials_backup.bin";
 
-const KEYCHAIN_USERNAME_LEGACY: &str = "internal_wallet";
 const KEYCHAIN_USERNAME: &str = "inner_wallet_credentials";
 
 pub struct CredentialManager {
@@ -71,18 +70,10 @@ pub struct CredentialManager {
 
 impl CredentialManager {
     fn new(service_name: String, username: String, fallback_dir: PathBuf) -> Self {
-        let fallback_file_exists = fallback_dir.join(FALLBACK_FILE_PATH).exists();
-        let fallback_mode = AtomicBool::new(fallback_file_exists);
+        let file_path = fallback_dir
+            .join(FALLBACK_FILE_PATH);
 
-        if fallback_file_exists {
-            let new_path = fallback_dir
-                .join(Network::get_current().as_key_str())
-                .join(FALLBACK_FILE_PATH);
-            if !new_path.exists() {
-                std::fs::rename(fallback_dir.join(FALLBACK_FILE_PATH), new_path.clone())
-                    .expect("Failed to rename fallback file");
-            }
-        }
+        let fallback_mode = AtomicBool::new(file_path.exists());
 
         CredentialManager {
             service_name,
@@ -99,65 +90,37 @@ impl CredentialManager {
             Network::get_current().as_key_str()
         );
 
-        let new_credential_manager = CredentialManager::new(
+        CredentialManager::new(
             APPLICATION_FOLDER_ID.into(),
             network_specific_name.clone(),
-            fallback_dir.clone(),
-        );
-
-        let old_credential_manager = CredentialManager::new(
-            APPLICATION_FOLDER_ID.into(),
-            KEYCHAIN_USERNAME.into(),
-            fallback_dir.clone(),
-        );
-
-        if new_credential_manager.load_from_keyring().is_err() {
-            if let Ok(credential) = old_credential_manager.load_from_keyring() {
-                new_credential_manager
-                    .save_to_keyring(&credential)
-                    .expect("Failed to migrate credentials");
-            }
-        }
-
-        new_credential_manager
+            fallback_dir.join(Network::get_current().as_key_str())
+        )
     }
 
-    pub async fn migrate(&self, wallet_config: &WalletConfig) -> Result<(), CredentialError> {
+    pub async fn migrate(&self) -> Result<(), CredentialError> {
         // Shortcut and do nothing if we already have new credential format
         let creds = self.get_credentials().await;
-        if let Ok(creds) = &creds {
-            info!(target: LOG_TARGET, "Found credentials");
-            if creds.tari_seed_passphrase.is_some() {
-                info!(target: LOG_TARGET, "Credentials already migrated. Skipping.");
-                return Ok(());
-            }
-        }
-
-        let passphrase = if wallet_config.passphrase.is_some() {
-            info!(target: LOG_TARGET, "Found wallet passphrase");
-            wallet_config.passphrase.clone()
-        } else if let Ok(legacy) = self.load_from_legacy() {
-            info!(target: LOG_TARGET, "Found legacy keyring passphrase");
-            Some(legacy)
-        } else {
-            info!(target: LOG_TARGET, "No credentials in a new format, and no legacy passphrase found, skipping migration");
-            None
-        };
-
-        if let Some(safe_password) = passphrase {
-            info!(target: LOG_TARGET, "Migrating passphrase to new credential format");
-            let credential = match creds {
-                Ok(mut cred) => {
-                    cred.tari_seed_passphrase = Some(safe_password);
-                    cred
+        match creds {
+            Ok(creds) => {
+                info!(target: LOG_TARGET, "Found credentials");
+                if creds.tari_seed_passphrase.is_some() {
+                    info!(target: LOG_TARGET, "Credentials already migrated. Skipping.");
+                    return Ok(());
                 }
-                Err(_) => Credential {
-                    tari_seed_passphrase: Some(safe_password),
-                    monero_seed: None,
-                },
-            };
+            },
+            Err(_e) => {
+                info!(target: LOG_TARGET, "No credentials found, migrating credentials");
+                let parent_dir = self.fallback_dir.parent().expect("Failed to get parent directory");
+                let old_credential_manager = CredentialManager::new(
+                    APPLICATION_FOLDER_ID.into(),
+                    KEYCHAIN_USERNAME.into(),
+                    parent_dir.to_path_buf(),
+                );
 
-            self.set_credentials(&credential).await?;
+                if let Ok(credential) = old_credential_manager.get_credentials().await {
+                   self.set_credentials(&credential).await?
+                }
+            }
         }
 
         Ok(())
@@ -273,15 +236,8 @@ impl CredentialManager {
         Ok(credential)
     }
 
-    fn load_from_legacy(&self) -> Result<SafePassword, CredentialError> {
-        let entry = Entry::new(&self.service_name, KEYCHAIN_USERNAME_LEGACY)?;
-        let pw = SafePassword::from(entry.get_password()?);
-        Ok(pw)
-    }
-
     fn fallback_file(&self) -> PathBuf {
         self.fallback_dir
-            .join(Network::get_current().as_key_str())
             .join(FALLBACK_FILE_PATH)
     }
 }

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -82,7 +82,7 @@ impl InternalWallet {
                     config.config_path = Some(file_parent.to_path_buf());
 
                     let cm = CredentialManager::default_with_dir(config_path.clone());
-                    if let Err(e) = cm.migrate(&config).await {
+                    if let Err(e) = cm.migrate().await {
                         warn!(target: LOG_TARGET, "Failed to migrate wallet credentials: {}", e.to_string());
                     }
 


### PR DESCRIPTION
Description
---
The network prefix for the credential manager suffered a migratory issue in both keychain, and backup file form. Opt to remove the old migration for the ceredential manager and introduce another.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified credential migration and fallback file handling by removing legacy migration logic and support for old credential formats.
  - Streamlined the credential manager's initialization process for improved clarity and maintainability.

- **Bug Fixes**
  - Reduced potential confusion by ensuring only the current credential format and fallback location are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->