### PR TITLE
feat(ui): added sync with phone button

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Jou transaksie is ingedien!\nDit sal in jou geskiedenis verskyn nadat \"n paar blokke gemyn is.",
   "empty-tx": "Geen transaksies gevind nie",
   "history": {
-    "label-rewards": "My belonings"
+    "available-balance": "Available Balance",
+    "label-rewards": "My belonings",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "My Tari",
   "new": "Nuut",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "您的交易已提交！\n在挖掘几个区块后，它将显示在您的历史记录中。",
   "empty-tx": "未找到交易",
   "history": {
-    "label-rewards": "我的奖励"
+    "available-balance": "Available Balance",
+    "label-rewards": "我的奖励",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "我的 Tari",
   "new": "新建",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Ihre Transaktion wurde übermittelt!\nSie wird in Ihrer Historie angezeigt, nachdem einige Blöcke gemined wurden.",
   "empty-tx": "Keine Transaktionen gefunden",
   "history": {
-    "label-rewards": "Meine Belohnungen"
+    "available-balance": "Available Balance",
+    "label-rewards": "Meine Belohnungen",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Mein Tari",
   "new": "Neu",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Your transaction has been submitted!\nIt will show up in your history after mining a few blocks.",
   "empty-tx": "No transactions found",
   "history": {
-    "label-rewards": "My rewards"
+    "available-balance": "Available Balance",
+    "label-rewards": "My rewards",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "My Tari",
   "new": "New",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Votre transaction a été soumise !\nElle apparaîtra dans votre historique après le minage de quelques blocs.",
   "empty-tx": "Aucune transaction trouvée",
   "history": {
-    "label-rewards": "Mes récompenses"
+    "available-balance": "Available Balance",
+    "label-rewards": "Mes récompenses",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Mon Tari",
   "new": "Nouveau",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "आपका लेन-देन सबमिट कर दिया गया है!\nकुछ ब्लॉकों के माइनिंग के बाद यह आपके इतिहास में दिखाई देगा।",
   "empty-tx": "कोई लेन-देन नहीं मिला",
   "history": {
-    "label-rewards": "मेरे पुरस्कार"
+    "available-balance": "Available Balance",
+    "label-rewards": "मेरे पुरस्कार",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "मेरा तारी",
   "new": "नया",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Transaksi Anda telah dikirim!\nIni akan muncul dalam riwayat Anda setelah menambang beberapa blok.",
   "empty-tx": "Tidak ada transaksi ditemukan",
   "history": {
-    "label-rewards": "Hadiah saya"
+    "available-balance": "Available Balance",
+    "label-rewards": "Hadiah saya",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Tari Saya",
   "new": "Baru",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "トランザクションが送信されました！\nいくつかのブロックをマイニングした後、履歴に表示されます。",
   "empty-tx": "トランザクションが見つかりません",
   "history": {
-    "label-rewards": "私の報酬"
+    "available-balance": "Available Balance",
+    "label-rewards": "私の報酬",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "私のTari",
   "new": "新規",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "거래가 제출되었습니다!\n몇 개의 블록을 채굴한 후 기록에 표시됩니다.",
   "empty-tx": "거래를 찾을 수 없음",
   "history": {
-    "label-rewards": "내 보상"
+    "available-balance": "Available Balance",
+    "label-rewards": "내 보상",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "내 Tari",
   "new": "새로운",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Twoja transakcja została przesłana!\nPojawi się w historii po wykopaniu kilku bloków.",
   "empty-tx": "Nie znaleziono transakcji",
   "history": {
-    "label-rewards": "Moje nagrody"
+    "available-balance": "Available Balance",
+    "label-rewards": "Moje nagrody",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Moje Tari",
   "new": "Nowy",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "Ваша транзакция отправлена!\nОна появится в Вашей истории после добычи нескольких блоков.",
   "empty-tx": "Транзакции не найдены",
   "history": {
-    "label-rewards": "Мои награды"
+    "available-balance": "Available Balance",
+    "label-rewards": "Мои награды",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Мой Tari",
   "new": "Новый",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -2,7 +2,9 @@
   "confirmation-message": "İşleminiz gönderildi!\nBirkaç blok madenciliğinden sonra geçmişinizde görünecektir.",
   "empty-tx": "İşlem bulunamadı",
   "history": {
-    "label-rewards": "Ödüllerim"
+    "available-balance": "Available Balance",
+    "label-rewards": "Ödüllerim",
+    "sync-with-phone": "Sync with Phone"
   },
   "my_tari": "Benim Tari",
   "new": "Yeni",

--- a/src/components/transactions/wallet/ArrowRight.tsx
+++ b/src/components/transactions/wallet/ArrowRight.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const ArrowRight: React.FC = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10" fill="none">
+        <path
+            d="M1 9L5 5L1 1"
+            stroke="currentColor"
+            strokeWidth="1.33333"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+);
+
+export default ArrowRight;

--- a/src/components/transactions/wallet/Wallet.tsx
+++ b/src/components/transactions/wallet/Wallet.tsx
@@ -19,9 +19,10 @@ import { ReceiveSVG } from '@app/assets/icons/receive.tsx';
 import { useAirdropStore, usePaperWalletStore } from '@app/store';
 import { Button } from '@app/components/elements/buttons/Button';
 import SyncTooltip from '@app/containers/navigation/components/Wallet/SyncTooltip/SyncTooltip.tsx';
-import { Wrapper } from './wallet.styles.ts';
+import { SyncButton, TabsTitle, TabsWarapper, Wrapper } from './wallet.styles.ts';
 import { memo } from 'react';
 import { useTariBalance } from '@app/hooks/wallet/useTariBalance.ts';
+import ArrowRight from './ArrowRight.tsx';
 
 interface Props {
     section: string;
@@ -51,6 +52,15 @@ const Wallet = memo(function Wallet({ section, setSection }: Props) {
             </TabHeader>
 
             <WalletBalanceMarkup />
+
+            {uiSendRecvEnabled && !isWalletScanning && (
+                <TabsWarapper>
+                    <TabsTitle>{`Available Balance`}</TabsTitle>
+                    <SyncButton onClick={() => setShowPaperWalletModal(true)}>
+                        {`Sync with Phone`} <ArrowRight />
+                    </SyncButton>
+                </TabsWarapper>
+            )}
 
             <HistoryList />
 

--- a/src/components/transactions/wallet/Wallet.tsx
+++ b/src/components/transactions/wallet/Wallet.tsx
@@ -55,9 +55,9 @@ const Wallet = memo(function Wallet({ section, setSection }: Props) {
 
             {uiSendRecvEnabled && !isWalletScanning && (
                 <TabsWarapper>
-                    <TabsTitle>{`Available Balance`}</TabsTitle>
+                    <TabsTitle>{t('history.available-balance')}</TabsTitle>
                     <SyncButton onClick={() => setShowPaperWalletModal(true)}>
-                        {`Sync with Phone`} <ArrowRight />
+                        {t('history.sync-with-phone')} <ArrowRight />
                     </SyncButton>
                 </TabsWarapper>
             )}

--- a/src/components/transactions/wallet/wallet.styles.ts
+++ b/src/components/transactions/wallet/wallet.styles.ts
@@ -1,3 +1,4 @@
+import { convertHexToRGBA } from '@app/utils';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
@@ -18,7 +19,7 @@ export const TabsWarapper = styled.div`
 `;
 
 export const TabsTitle = styled.div`
-    color: rgba(17, 17, 17, 0.5);
+    color: ${({ theme }) => convertHexToRGBA(theme.palette.contrast, 0.5)};
     font-family: Poppins, sans-serif;
     font-size: 11px;
     font-style: normal;
@@ -27,7 +28,7 @@ export const TabsTitle = styled.div`
 `;
 
 export const SyncButton = styled.button`
-    color: rgba(17, 17, 17, 0.5);
+    color: ${({ theme }) => convertHexToRGBA(theme.palette.contrast, 0.5)};
     font-family: Poppins, sans-serif;
     font-size: 11px;
     font-style: normal;
@@ -46,15 +47,15 @@ export const SyncButton = styled.button`
     transition: color 0.2s ease-in-out;
 
     svg {
-        stroke: #7d7d7d;
+        stroke: ${({ theme }) => convertHexToRGBA(theme.palette.contrast, 0.5)};
         transition: stroke 0.2s ease-in-out;
     }
 
     &:hover {
-        color: #000;
+        color: ${({ theme }) => convertHexToRGBA(theme.palette.contrast, 1)};
 
         svg {
-            stroke: #000;
+            stroke: ${({ theme }) => convertHexToRGBA(theme.palette.contrast, 1)};
         }
     }
 `;

--- a/src/components/transactions/wallet/wallet.styles.ts
+++ b/src/components/transactions/wallet/wallet.styles.ts
@@ -6,3 +6,55 @@ export const Wrapper = styled.div`
     width: 100%;
     max-height: clamp(10vh, 400px, 45vh);
 `;
+
+export const TabsWarapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    padding: 0 6px;
+
+    transform: translateY(-3px);
+`;
+
+export const TabsTitle = styled.div`
+    color: rgba(17, 17, 17, 0.5);
+    font-family: Poppins, sans-serif;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+`;
+
+export const SyncButton = styled.button`
+    color: rgba(17, 17, 17, 0.5);
+    font-family: Poppins, sans-serif;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+    letter-spacing: -0.44px;
+
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    background: transparent;
+    border: none;
+    cursor: pointer;
+
+    transition: color 0.2s ease-in-out;
+
+    svg {
+        stroke: #7d7d7d;
+        transition: stroke 0.2s ease-in-out;
+    }
+
+    &:hover {
+        color: #000;
+
+        svg {
+            stroke: #000;
+        }
+    }
+`;

--- a/src/containers/navigation/components/Wallet/Wallet.styles.ts
+++ b/src/containers/navigation/components/Wallet/Wallet.styles.ts
@@ -27,7 +27,6 @@ export const WalletBalanceContainer = styled(m.div)`
     color: ${({ theme }) => theme.palette.text.secondary};
 
     padding-top: 10px;
-    padding-bottom: 10px;
 `;
 
 export const BalanceVisibilityButton = styled(IconButton)`


### PR DESCRIPTION
Added a `Sync with phone` button above the history list. I also added a `Available Balance` label to balance out the space. 

In the future we'll replace `Available Balance` with `Rewards / Transactions` tabs.

![CleanShot 2025-05-01 at 15 04 14@2x](https://github.com/user-attachments/assets/4689e14a-53b0-4641-a8c1-69cb304bbfad)

![CleanShot 2025-05-01 at 15 21 10@2x](https://github.com/user-attachments/assets/811e2e61-dc05-4187-88ca-ebad137a36cd)

![CleanShot 2025-05-01 at 15 04 43@2x](https://github.com/user-attachments/assets/abe5fa84-6859-4c0a-869e-14a2c8fd141f)

![CleanShot 2025-05-01 at 15 04 58@2x](https://github.com/user-attachments/assets/60cc36b0-63bd-49fc-a6a6-f515958553a3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new section in the wallet interface to display "Available Balance" and a "Sync with Phone" button, visible when certain conditions are met.
  - Introduced a right-arrow icon for enhanced visual cues in the sync button.

- **Localization**
  - Added new translation keys for "Available Balance" and "Sync with Phone" in multiple languages, with English placeholder text in untranslated locales.

- **Style**
  - Updated wallet component styles for the new section and sync button, including interactive and theme-consistent visuals.
  - Adjusted wallet balance container spacing for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->