### PR TITLE
fix: appimage missing gstreamer plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,12 @@ jobs:
             opencl-headers \
             ocl-icd-opencl-dev
 
+        # We set "bundleMediaFramework" to true, it should bundle into appimage all needed libraries for playing videos
+        # It requires us to set ARCH environment variable
+      - name: BundleMediaFramework fix - [ Linux Appimage ]
+        if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.args, 'appimage') ) }}
+        run: export ARCH=x86_64
+
       - name: Install Dependencies - macOS
         if: startsWith(runner.os,'macOS')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,15 +188,7 @@ jobs:
         # It requires us to set ARCH environment variable
       - name: BundleMediaFramework fix - [ Linux Appimage ]
         if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.args, 'appimage') ) }}
-        run: |
-          if [ "$(uname -m)" = "x86_64" ]; then
-            export ARCH=x86_64
-          elif [ "$(uname -m)" = "aarch64" ]; then
-            export ARCH=aarch64
-          else
-            echo "Unsupported architecture: $(uname -m)"
-            exit 1
-          fi
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
       - name: Install Dependencies - macOS
         if: startsWith(runner.os,'macOS')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,15 @@ jobs:
         # It requires us to set ARCH environment variable
       - name: BundleMediaFramework fix - [ Linux Appimage ]
         if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.args, 'appimage') ) }}
-        run: export ARCH=x86_64
+        run: |
+          if [ "$(uname -m)" = "x86_64" ]; then
+            export ARCH=x86_64
+          elif [ "$(uname -m)" = "aarch64" ]; then
+            export ARCH=aarch64
+          else
+            echo "Unsupported architecture: $(uname -m)"
+            exit 1
+          fi
 
       - name: Install Dependencies - macOS
         if: startsWith(runner.os,'macOS')

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,11 @@
         "macOS": {
             "providerShortName": "Tari Labs, LLC"
         },
+        "linux": {
+            "appimage": {
+                "bundleMediaFramework": true
+            }
+        },
         "icon": [
             "icons/32x32.png",
             "icons/128x128.png",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Linux AppImage builds to include all necessary libraries for video playback by enabling media framework bundling.

- **Chores**
  - Updated build and configuration settings to support enhanced AppImage packaging for Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->