### PR TITLE
chore: node and tor healthcheck improvements

### DIFF
--- a/src-tauri/src/node/local_node_adapter.rs
+++ b/src-tauri/src/node/local_node_adapter.rs
@@ -342,7 +342,7 @@ impl ProcessAdapter for LocalNodeAdapter {
                     file_path: binary_version_path,
                     envs: None,
                     args,
-                    data_dir,
+                    data_dir: data_dir.clone(),
                     pid_file_name: self.pid_file_name().to_string(),
                     name: self.name().to_string(),
                 },
@@ -355,6 +355,7 @@ impl ProcessAdapter for LocalNodeAdapter {
                 ),
                 self.status_broadcast.clone(),
                 Arc::new(AtomicU64::new(0)),
+                Some(data_dir),
             ),
         ))
     }

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -28,7 +28,10 @@ use async_trait::async_trait;
 use minotari_node_grpc_client::grpc::{
     BlockHeader, Empty, GetBlocksRequest, GetNetworkStateRequest, SyncState,
 };
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
+use tari_utilities::epoch_time::EpochTime;
+use tokio::fs;
 
 use chrono::{NaiveDateTime, TimeZone, Utc};
 use log::{error, info, warn};
@@ -375,8 +378,8 @@ pub(crate) struct NodeStatusMonitor {
     node_type: NodeType,
     node_service: NodeAdapterService,
     status_broadcast: watch::Sender<BaseNodeStatus>,
-    #[allow(dead_code)]
     last_block_time: Arc<AtomicU64>,
+    base_path: Option<PathBuf>,
 }
 
 impl NodeStatusMonitor {
@@ -385,19 +388,21 @@ impl NodeStatusMonitor {
         node_service: NodeAdapterService,
         status_broadcast: watch::Sender<BaseNodeStatus>,
         last_block_time: Arc<AtomicU64>,
+        base_path: Option<PathBuf>,
     ) -> Self {
         Self {
             node_type,
             node_service,
             status_broadcast,
             last_block_time,
+            base_path,
         }
     }
 }
 
 #[async_trait]
 impl StatusMonitor for NodeStatusMonitor {
-    async fn check_health(&self, _uptime: Duration, timeout_duration: Duration) -> HealthStatus {
+    async fn check_health(&self, uptime: Duration, timeout_duration: Duration) -> HealthStatus {
         match timeout(timeout_duration, self.node_service.get_network_state()).await {
             Ok(res) => match res {
                 Ok(status) => {
@@ -409,6 +414,26 @@ impl StatusMonitor for NodeStatusMonitor {
                             status.clone()
                         );
                         return HealthStatus::Warning;
+                    }
+
+                    if self
+                        .last_block_time
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                        == status.block_time
+                    {
+                        if uptime.as_secs() > 3600
+                            && EpochTime::now()
+                                .checked_sub(EpochTime::from_secs_since_epoch(status.block_time))
+                                .unwrap_or(EpochTime::from(0))
+                                .as_u64()
+                                > 3600
+                        {
+                            warn!(target: LOG_TARGET, "Base node height has not changed in an hour");
+                            return HealthStatus::Unhealthy;
+                        }
+                    } else {
+                        self.last_block_time
+                            .store(status.block_time, std::sync::atomic::Ordering::SeqCst);
                     }
                     HealthStatus::Healthy
                 }
@@ -440,6 +465,22 @@ impl StatusMonitor for NodeStatusMonitor {
                 }
             }
         }
+    }
+
+    async fn handle_unhealthy(&self) -> Result<(), anyhow::Error> {
+        if let Some(ref base_path) = self.base_path {
+            fs::remove_dir_all(
+                base_path
+                    .join("node")
+                    .join(Network::get_current().to_string().to_lowercase())
+                    .join("peer_db"),
+            )
+            .await?;
+
+            fs::remove_dir_all(base_path.join("tor-data")).await?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -469,15 +469,21 @@ impl StatusMonitor for NodeStatusMonitor {
 
     async fn handle_unhealthy(&self) -> Result<(), anyhow::Error> {
         if let Some(ref base_path) = self.base_path {
-            fs::remove_dir_all(
+            let _unused = fs::remove_dir_all(
                 base_path
                     .join("node")
                     .join(Network::get_current().to_string().to_lowercase())
                     .join("peer_db"),
             )
-            .await?;
-
-            fs::remove_dir_all(base_path.join("tor-data")).await?;
+            .await;
+            let _unused = fs::remove_dir_all(
+                base_path
+                    .join("node")
+                    .join(Network::get_current().to_string().to_lowercase())
+                    .join("libtor"),
+            )
+            .await;
+            let _unused = fs::remove_dir_all(base_path.join("tor-data")).await;
         }
 
         Ok(())

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -468,6 +468,11 @@ impl StatusMonitor for NodeStatusMonitor {
     }
 
     async fn handle_unhealthy(&self) -> Result<(), anyhow::Error> {
+        if self.node_type == NodeType::Remote {
+            // Do not clear local node files for remote nodes
+            return Ok(());
+        }
+
         if let Some(ref base_path) = self.base_path {
             let _unused = fs::remove_dir_all(
                 base_path

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use minotari_node_grpc_client::grpc::{
     BlockHeader, Empty, GetBlocksRequest, GetNetworkStateRequest, SyncState,
 };
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use tari_utilities::epoch_time::EpochTime;
 use tokio::fs;

--- a/src-tauri/src/node/remote_node_adapter.rs
+++ b/src-tauri/src/node/remote_node_adapter.rs
@@ -187,6 +187,7 @@ impl ProcessAdapter for RemoteNodeAdapter {
                 NodeAdapterService::new(address, 1),
                 self.status_broadcast.clone(),
                 Arc::new(AtomicU64::new(0)),
+                None, // Used only by Local Node
             ),
         ))
     }

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -125,6 +125,9 @@ pub enum HealthStatus {
 #[async_trait]
 pub(crate) trait StatusMonitor: Clone + Sync + Send + 'static {
     async fn check_health(&self, uptime: Duration, timeout_duration: Duration) -> HealthStatus;
+    async fn handle_unhealthy(&self) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
 }
 
 // TODO: Rename to ProcessInstance

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -326,6 +326,12 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
             *uptime = Instant::now();
             stats.num_restarts += 1;
             stats.current_uptime = uptime.elapsed();
+            match status_monitor3.handle_unhealthy().await {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(target: LOG_TARGET, "Failed to handle unhealthy {} status: {}", name, e)
+                }
+            }
             child.start(task_tracker).await?;
             // Wait for a bit before checking health again
             // sleep(Duration::from_secs(10)).await;


### PR DESCRIPTION
Node
---
* additional **UNHEALTHY** check when node hasn't changed the block height for **an hour**

Process Watcher and Status Monitor
-- 
implement `handle_unhealthy` method which is used to proceed with some actions before the restart after Unhealthy process is stopped

* For NODE: clean `{base_path}/com.tari.universe.alpha/node/esmeralda/peer_db`  and `{base_path}/com.tari.universe.alpha/tor-data`

* For TOR: clean `{base_path}/com.tari.universe.alpha/tor-data`

Questions
--
Should I increase Tor startup time? its:
```
const STARTUP_TIMEOUT: u64 = 180; // 3mins
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved node health monitoring with a new liveness check to detect stalled nodes.
	- Automatic cleanup of specific node and Tor data directories when unhealthy node status is detected.
- **Bug Fixes**
	- Enhanced reliability in node process management by ensuring proper handling of unhealthy states.
- **Chores**
	- Updated health check logic to include additional parameters and asynchronous cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->