### PR TITLE
fix(ui): transaction details triple click to toggle some fields

### DIFF
--- a/src/components/transactions/history/ExpandedItem.tsx
+++ b/src/components/transactions/history/ExpandedItem.tsx
@@ -3,7 +3,7 @@ import { TransactionInfo } from '@app/types/app-status.ts';
 import TransactionModal from '@app/components/TransactionModal/TransactionModal.tsx';
 import { StatusList } from '../components/StatusList/StatusList.tsx';
 import { useTranslation } from 'react-i18next';
-import { TransactionDirection } from '@app/types/transactions.ts';
+
 interface Props {
     item: TransactionInfo;
     expanded: boolean;

--- a/src/components/transactions/history/ExpandedItem.tsx
+++ b/src/components/transactions/history/ExpandedItem.tsx
@@ -1,8 +1,9 @@
-import { memo } from 'react';
+import { memo, useState, useCallback, useRef } from 'react';
 import { TransactionInfo } from '@app/types/app-status.ts';
 import TransactionModal from '@app/components/TransactionModal/TransactionModal.tsx';
 import { StatusList } from '../components/StatusList/StatusList.tsx';
 import { useTranslation } from 'react-i18next';
+import { TransactionDirection } from '@app/types/transactions.ts';
 interface Props {
     item: TransactionInfo;
     expanded: boolean;
@@ -12,12 +13,53 @@ interface Props {
 
 const ItemExpand = memo(function ItemExpand({ item, expanded, handleClose }: Props) {
     const { t } = useTranslation('wallet');
+    const [showHidden, setShowHidden] = useState(false);
+    const clickCountRef = useRef(0);
+    const clickTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-    const entries = Object.entries(item).map(([key, value]) => ({ label: key, value }));
+    const keyTranslations: Record<string, string> = {
+        tx_id: 'send.transaction-id',
+        payment_id: 'send.transaction-description',
+    };
+
+    const hiddenKeys = ['status', 'excess_sig', 'source_address', 'dest_address', 'direction'];
+
+    const capitalizeKey = (key: string): string => {
+        return key
+            .split('_')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+    };
+
+    const handleClick = useCallback(() => {
+        clickCountRef.current += 1;
+
+        if (clickTimerRef.current) {
+            clearTimeout(clickTimerRef.current);
+        }
+
+        clickTimerRef.current = setTimeout(() => {
+            if (clickCountRef.current >= 3) {
+                setShowHidden(!showHidden);
+            }
+            clickCountRef.current = 0;
+        }, 300);
+    }, [showHidden]);
+
+    const entries = Object.entries(item)
+        .filter(([key]) => showHidden || !hiddenKeys.includes(key))
+        .map(([key, value]) => {
+            return {
+                label: key in keyTranslations ? t(keyTranslations[key]) : capitalizeKey(key),
+                value,
+            };
+        });
 
     return (
         <TransactionModal show={expanded} title={t(`history.transaction-details`)} handleClose={handleClose}>
-            <StatusList entries={entries} />
+            <div onClick={handleClick}>
+                <StatusList entries={entries} />
+            </div>
         </TransactionModal>
     );
 });


### PR DESCRIPTION
This hides some of the fields in the Transaction Details modal behind a "triple click". It also updates the labels so they are words, not just keys. 

Hidden: `'status', 'excess_sig', 'source_address', 'dest_address', 'direction'`

We can un-hide fields as they make sense. I just hid the ones where I wasn't sure how they should be displayed. 

Initial View

![CleanShot 2025-05-01 at 18 32 51@2x](https://github.com/user-attachments/assets/86cc4a10-c886-44b3-a98f-6f566081bf76)

After triple click. 

![CleanShot 2025-05-01 at 18 32 24@2x](https://github.com/user-attachments/assets/73c0d404-37a5-4e19-b49b-c25c4c3bb6b5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a triple-click interaction to reveal or hide additional hidden transaction details in the transaction history.
  - Improved labeling of transaction fields for better readability and localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->