### PR TITLE
chore: ensure we do not left behind spend wallet dir

### DIFF
--- a/src-tauri/src/spend_wallet_adapter.rs
+++ b/src-tauri/src/spend_wallet_adapter.rs
@@ -91,6 +91,7 @@ impl SpendWalletAdapter {
         self.log_dir = Some(log_dir);
         self.wallet_binary = Some(wallet_binary);
 
+        let _unused = self.erase_related_data().await;
         std::fs::create_dir_all(self.get_working_dir())?;
         setup_logging(
             &self.get_log_config_file(),
@@ -157,6 +158,7 @@ impl SpendWalletAdapter {
             let exit_code = instance.wait().await?;
 
             if exit_code != 0 {
+                let _unused = self.erase_related_data().await;
                 return Err(anyhow::anyhow!(
                     "Command '{}' failed with exit code: {}",
                     command.name,


### PR DESCRIPTION
Remove `spend_wallet_dir`:
* on spend wallet init: DB might be corrupted due to force quit etc
* when cli command returns exit code for some reason


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data cleanup by ensuring related data is erased during wallet initialization and after certain wallet command errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->