### PR TITLE
Fix tor startup failures on Linux

### DIFF
--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -22,6 +22,7 @@
 
 use std::path::PathBuf;
 use std::time::Duration;
+use std::collections::HashMap;
 
 use anyhow::{anyhow, Error};
 use async_trait::async_trait;
@@ -260,6 +261,13 @@ impl ProcessAdapter for TorAdapter {
             format!("notice file {}", log_dir_string),
         ];
 
+        let envs: Option<HashMap<String, String>> = Some([
+            // rust is hard :/
+            // getting borrowed after move error & should only be declared on linux
+            // ("LD_PRELOAD".to_string(), format!("{}/libevent-2.1.so.7", working_dir_string.clone())), 
+            ("LD_PRELOAD".to_string(), "/home/test/.cache/com.tari.universe.alpha/binaries/tor-binaries/esmeralda/14.5.1/tor/libevent-2.1.so.7".to_string()),
+        ].into_iter().collect());
+
         if self.config.use_bridges {
             // Used by tor bridges
             // TODO: This does not work when path has space on windows.
@@ -284,7 +292,7 @@ impl ProcessAdapter for TorAdapter {
                 handle: None,
                 startup_spec: ProcessStartupSpec {
                     file_path: binary_version_path,
-                    envs: None,
+                    envs,
                     args,
                     data_dir: data_dir.clone(),
                     pid_file_name: self.pid_file_name().to_string(),


### PR DESCRIPTION
Description
---
I am trying to implement a fix to the tor startup failures on Linux systems. However, my knowledge of rust is far from my understanding of Linux. This is only a crude implementation of a fix, demonstrating that it works. 

The issue is caused by an ABI break between the bundled `tor` and common distro builds of  `libevent`. See: https://github.com/tari-project/universe/issues/1573#issuecomment-2741814167

The goal of this PR is to _force_ the use of the bundled `libevent-2.1.so.7` when TU is being run on Linux.

What I _want_ to implement: 
 - Do nothing if we aren't on Linux.
 - Don't hardcode the path to the tor binary/libevent.so

Any help, pointers, etc, would be greatly appreciated.  I'm not very experienced with systems languages.

Lastly, I just noticed https://github.com/tari-project/universe/issues/1995 
I do not fully understand the context of the issue, but maybe fixing that will make my PR here unneeded. 

How Has This Been Tested?
---
Running `cargo tauri dev` results in a successful tor startup.



<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
