### PR TITLE
fix: app_id is now obtained from config-core

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1077,18 +1077,14 @@ fn main() {
         node_manager.clone(),
     );
 
-    let app_id = app_config_raw.anon_id().to_string();
-
     let websocket_manager = Arc::new(RwLock::new(WebsocketManager::new(
         app_in_memory_config.clone(),
         websocket_message_rx,
         websocket_manager_status_tx.clone(),
         websocket_manager_status_rx.clone(),
-        app_id.clone(),
     )));
 
     let websocket_events_manager = WebsocketEventsManager::new(
-        app_id.clone(),
         cpu_miner_status_watch_rx.clone(),
         gpu_status_rx.clone(),
         base_node_watch_rx.clone(),

--- a/src-tauri/src/websocket_events_manager.rs
+++ b/src-tauri/src/websocket_events_manager.rs
@@ -20,7 +20,8 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
 use futures::lock::Mutex;
 use log::{error, info};
@@ -47,7 +48,6 @@ pub struct WebsocketEventsManager {
     cpu_miner_status_watch_rx: watch::Receiver<CpuMinerStatus>,
     gpu_latest_miner_stats: watch::Receiver<GpuMinerStatus>,
     node_latest_status: watch::Receiver<BaseNodeStatus>,
-    app_id: String,
     websocket_tx_channel: Arc<tokio::sync::mpsc::Sender<WebsocketMessage>>,
     close_channel_tx: tokio::sync::broadcast::Sender<bool>,
     is_started: Arc<Mutex<bool>>,
@@ -55,7 +55,6 @@ pub struct WebsocketEventsManager {
 
 impl WebsocketEventsManager {
     pub fn new(
-        app_id: String,
         cpu_miner_status_watch_rx: watch::Receiver<CpuMinerStatus>,
         gpu_latest_miner_stats: watch::Receiver<GpuMinerStatus>,
         node_latest_status: watch::Receiver<BaseNodeStatus>,
@@ -66,7 +65,6 @@ impl WebsocketEventsManager {
             cpu_miner_status_watch_rx,
             gpu_latest_miner_stats,
             node_latest_status,
-            app_id,
             websocket_tx_channel: Arc::new(websocket_tx_channel),
             app: None,
             close_channel_tx,
@@ -95,7 +93,9 @@ impl WebsocketEventsManager {
         let cpu_miner_status_watch_rx = self.cpu_miner_status_watch_rx.clone();
         let gpu_latest_miner_stats = self.gpu_latest_miner_stats.clone();
         let node_latest_status = self.node_latest_status.clone();
-        let app_id = self.app_id.clone();
+
+        let app_id = ConfigCore::content().await.anon_id().clone();
+
         let app_version = self
             .app
             .clone()


### PR DESCRIPTION
This commit removes the `app_id` field from the `WebsocketManager` and `WebsocketEventsManager` structs.

The `app_id` is no longer passed as a parameter during the instantiation of these managers. Instead, it is retrieved directly from the `ConfigCore` within the `connect_to_url` function in `WebsocketManager` and within the `start` function in `WebsocketEventsManager` when needed.

This change simplifies the codebase by reducing the number of parameters passed around and ensures that the managers always use the most up-to-date `app_id` from the configuration. And, more importantly, returns the real annon_id


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified how anonymous IDs are managed for websocket connections by retrieving them internally when needed, rather than storing and passing them throughout the code. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->