### PR TITLE
fix: tor url for tari cdn

### DIFF
--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -41,7 +41,7 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
     async fn fetch_releases_list(&self) -> Result<Vec<VersionDownloadInfo>, Error> {
         let platform = get_platform_name();
         let cdn_tor_bundle_url = format!(
-            "https://cdn-universe.tari.com/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz",
+            "https://cdn-universe.tari.com/tor-package-archive/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz",
             platform
         );
         let mut cdn_responded = false;


### PR DESCRIPTION
Description
---
Fixes our cdn url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the download link for the Tor expert bundle to ensure it fetches from the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->