### PR TITLE
fix: shutdown for websocket events manager

### DIFF
--- a/src-tauri/src/websocket_events_manager.rs
+++ b/src-tauri/src/websocket_events_manager.rs
@@ -111,7 +111,7 @@ impl WebsocketEventsManager {
                 return Ok(());
             }
 
-            tokio::spawn(async move {
+            TasksTrackers::current().common.get_task_tracker().await.spawn(async move {
                 loop {
                     let jwt_token = ConfigCore::content()
                         .await


### PR DESCRIPTION
Description
---
Use `common` task tracker to allow graceful shutdown of websocket events manager


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->