### PR TITLE
fix: initial visible main view

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -34,7 +34,7 @@ function CurrentAppSection({ showSplashscreen, isShuttingDown }: CurrentAppSecti
 
         if (showMainView) {
             return (
-                <AppContentContainer key="main" initial="dashboardInitial">
+                <AppContentContainer key="main" initial="visible">
                     <MainView />
                 </AppContentContainer>
             );


### PR DESCRIPTION
Description
---
* We set `AppContentContainer key="main" initial="visible"` which should be later switched to the "visible". For some reason it does not happen when app is unminimized/unfocused

My fix, directly uses visible value

Problem was:
![image](https://github.com/user-attachments/assets/1091e7b6-d338-46e4-a77d-4f93cd527345)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the initial animation or visual state of the main application view for a smoother or different appearance when loading the main content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->