### PR TITLE
fix: adjust balances after sending tx

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Jou transaksie is ingedien!\nDit sal in jou geskiedenis verskyn nadat \"n paar blokke gemyn is.",
   "empty-tx": "Geen transaksies gevind nie",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "My belonings",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "您的交易已提交！\n在挖掘几个区块后，它将显示在您的历史记录中。",
   "empty-tx": "未找到交易",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "我的奖励",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Ihre Transaktion wurde übermittelt!\nSie wird in Ihrer Historie angezeigt, nachdem einige Blöcke gemined wurden.",
   "empty-tx": "Keine Transaktionen gefunden",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Meine Belohnungen",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Your transaction has been submitted!\nIt will show up in your history after mining a few blocks.",
   "empty-tx": "No transactions found",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "My rewards",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Votre transaction a été soumise !\nElle apparaîtra dans votre historique après le minage de quelques blocs.",
   "empty-tx": "Aucune transaction trouvée",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Mes récompenses",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "आपका लेन-देन सबमिट कर दिया गया है!\nकुछ ब्लॉकों के माइनिंग के बाद यह आपके इतिहास में दिखाई देगा।",
   "empty-tx": "कोई लेन-देन नहीं मिला",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "मेरे पुरस्कार",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Transaksi Anda telah dikirim!\nIni akan muncul dalam riwayat Anda setelah menambang beberapa blok.",
   "empty-tx": "Tidak ada transaksi ditemukan",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Hadiah saya",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "トランザクションが送信されました！\nいくつかのブロックをマイニングした後、履歴に表示されます。",
   "empty-tx": "トランザクションが見つかりません",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "私の報酬",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "거래가 제출되었습니다!\n몇 개의 블록을 채굴한 후 기록에 표시됩니다.",
   "empty-tx": "거래를 찾을 수 없음",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "내 보상",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Twoja transakcja została przesłana!\nPojawi się w historii po wykopaniu kilku bloków.",
   "empty-tx": "Nie znaleziono transakcji",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Moje nagrody",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "Ваша транзакция отправлена!\nОна появится в Вашей истории после добычи нескольких блоков.",
   "empty-tx": "Транзакции не найдены",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Мои награды",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -2,7 +2,7 @@
   "confirmation-message": "İşleminiz gönderildi!\nBirkaç blok madenciliğinden sonra geçmişinizde görünecektir.",
   "empty-tx": "İşlem bulunamadı",
   "history": {
-    "available-balance": "Available:",
+    "available-balance": "Available",
     "label-rewards": "Ödüllerim",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -68,7 +68,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                     destination: data.address,
                     paymentId: data.message,
                 };
-                invoke('send_one_sided_to_stealth_address', {
+                await invoke('send_one_sided_to_stealth_address', {
                     ...payload,
                     amount: payload.amount.toString(),
                 });

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -68,7 +68,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
                     destination: data.address,
                     paymentId: data.message,
                 };
-                await invoke('send_one_sided_to_stealth_address', {
+                invoke('send_one_sided_to_stealth_address', {
                     ...payload,
                     amount: payload.amount.toString(),
                 });

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -63,5 +63,17 @@ export const setWalletAddress = (addresses: WalletAddress) => {
 export const setWalletBalance = (balance: WalletBalance) => {
     const calculated_balance =
         balance.available_balance + balance.timelocked_balance + balance.pending_incoming_balance;
-    useWalletStore.setState({ balance, calculated_balance });
+
+    const pendingSendAmount = useWalletStore
+        .getState()
+        .pending_transactions.reduce((total, tx) => total + tx.amount, 0);
+
+    useWalletStore.setState({
+        balance: {
+            ...balance,
+            available_balance: balance.available_balance - pendingSendAmount,
+            pending_outgoing_balance: balance.pending_outgoing_balance + pendingSendAmount,
+        },
+        calculated_balance,
+    });
 };

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -77,9 +77,9 @@ const handleWin = async (coinbase_transaction: TransactionInfo, balance: WalletB
         }
         winTimeout = setTimeout(async () => {
             useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight, earnings: undefined });
-            setWalletBalance(balance);
             await refreshTransactions();
             refreshPendingTransactions();
+            setWalletBalance(balance);
             setMiningControlsEnabled(true);
         }, 2000);
     } else {
@@ -101,10 +101,10 @@ const handleFail = async (blockHeight: number, balance: WalletBalance, canAnimat
         }
         failTimeout = setTimeout(async () => {
             useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight });
-            setWalletBalance(balance);
             setMiningControlsEnabled(true);
             await refreshTransactions();
             refreshPendingTransactions();
+            setWalletBalance(balance);
         }, 1000);
     } else {
         useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight });

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -1,6 +1,6 @@
 import { create } from './create';
 import { TransactionInfo, WalletBalance } from '../types/app-status.ts';
-import { refreshTransactions } from './actions/walletStoreActions.ts';
+import { refreshTransactions, setWalletBalance } from './actions/walletStoreActions.ts';
 import { deepEqual } from '@app/utils/objectDeepEqual.ts';
 
 interface PendingTransaction {
@@ -73,6 +73,10 @@ export const addPendingTransaction = (payload: { amount: number; destination: st
     useWalletStore.setState((state) => ({
         pending_transactions: [transaction, ...state.pending_transactions],
     }));
+    const balance = useWalletStore.getState().balance;
+    if (balance) {
+        setWalletBalance(balance);
+    }
 };
 
 export const updateWalletScanningProgress = (payload: {


### PR DESCRIPTION
Description
---
adjust balances after sending tx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display of wallet balances to account for pending outgoing transactions, ensuring more accurate balance information.
  - Improved synchronization of wallet balance updates after adding pending transactions and after transaction refreshes.

- **Style**
  - Updated localization strings in multiple languages by removing the trailing colon from the "Available" label for wallet balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->