### PR TITLE
feat(ui): update autoplay logic

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1911,3 +1911,12 @@ pub async fn set_node_type(
 
     Ok(())
 }
+
+#[tauri::command]
+pub async fn set_warmup_seen(warmup_seen: bool) -> Result<(), String> {
+    ConfigUI::update_field(ConfigUIContent::set_warmup_seen, Some(warmup_seen))
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1914,7 +1914,7 @@ pub async fn set_node_type(
 
 #[tauri::command]
 pub async fn set_warmup_seen(warmup_seen: bool) -> Result<(), String> {
-    ConfigUI::update_field(ConfigUIContent::set_warmup_seen, Some(warmup_seen))
+    ConfigUI::update_field(ConfigUIContent::set_warmup_seen, warmup_seen)
         .await
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -53,6 +53,7 @@ pub struct ConfigUIContent {
     sharing_enabled: bool,
     visual_mode: bool,
     show_experimental_settings: bool,
+    warmup_seen: Option<bool>,
 }
 
 impl Default for ConfigUIContent {
@@ -69,6 +70,7 @@ impl Default for ConfigUIContent {
             sharing_enabled: true,
             visual_mode: true,
             show_experimental_settings: false,
+            warmup_seen: None,
         }
     }
 }
@@ -161,6 +163,7 @@ impl ConfigImpl for ConfigUI {
                 sharing_enabled: old_config.sharing_enabled(),
                 visual_mode: old_config.visual_mode(),
                 show_experimental_settings: old_config.show_experimental_settings(),
+                warmup_seen: None,
             };
             let _unused = Self::_save_config(self.content.clone());
         } else {

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -53,7 +53,7 @@ pub struct ConfigUIContent {
     sharing_enabled: bool,
     visual_mode: bool,
     show_experimental_settings: bool,
-    warmup_seen: Option<bool>,
+    warmup_seen: bool,
 }
 
 impl Default for ConfigUIContent {
@@ -70,7 +70,7 @@ impl Default for ConfigUIContent {
             sharing_enabled: true,
             visual_mode: true,
             show_experimental_settings: false,
-            warmup_seen: None,
+            warmup_seen: false,
         }
     }
 }
@@ -163,7 +163,7 @@ impl ConfigImpl for ConfigUI {
                 sharing_enabled: old_config.sharing_enabled(),
                 visual_mode: old_config.visual_mode(),
                 show_experimental_settings: old_config.show_experimental_settings(),
-                warmup_seen: None,
+                warmup_seen: false,
             };
             let _unused = Self::_save_config(self.content.clone());
         } else {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1305,7 +1305,8 @@ fn main() {
             commands::verify_address_for_send,
             commands::validate_minotari_amount,
             commands::trigger_phases_restart,
-            commands::set_node_type
+            commands::set_node_type,
+            commands::set_warmup_seen
         ])
         .build(tauri::generate_context!())
         .inspect_err(

--- a/src/containers/main/Banner/Banner.tsx
+++ b/src/containers/main/Banner/Banner.tsx
@@ -1,28 +1,39 @@
 import { FaPlay } from 'react-icons/fa6';
 import { Button } from '@app/components/elements/buttons/Button.tsx';
 import { BodyCopy, DashboardBanner, FlexSection, TagLine, VideoPreview } from './styles.ts';
-import { setDialogToShow } from '@app/store';
+import { setDialogToShow, useConfigUIStore } from '@app/store';
 import { VideoModal } from '@app/components/VideoModal/VideoModal.tsx';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Typography } from '@app/components/elements/Typography.tsx';
+import { setWarmupSeens } from '@app/store/actions/appConfigStoreActions.ts';
 
 const VIDEO_SRC = 'https://static.tari.com/Tari-Announcement-BG.mp4';
 
 export default function Banner() {
     const { t } = useTranslation(['common', 'components']);
+    const warmup_seen = useConfigUIStore((s) => s.warmup_seen);
     const [expandPlayer, setExpandPlayer] = useState(false);
+
     function handleClick() {
         setDialogToShow('warmup');
     }
-    function handleVideoClick() {
+    function handleExpandPlayer() {
         setExpandPlayer((c) => !c);
     }
+
+    useEffect(() => {
+        if (!warmup_seen) {
+            setExpandPlayer(true);
+            setWarmupSeens(true);
+        }
+    }, [warmup_seen]);
+
     return (
         <>
             <DashboardBanner>
                 <FlexSection>
-                    <VideoPreview onClick={handleVideoClick}>
+                    <VideoPreview onClick={handleExpandPlayer}>
                         <FaPlay />
                         <video src={VIDEO_SRC} />
                     </VideoPreview>
@@ -44,7 +55,7 @@ export default function Banner() {
                     </Button>
                 </FlexSection>
             </DashboardBanner>
-            <VideoModal open={expandPlayer} onOpenChange={handleVideoClick} src={VIDEO_SRC} />
+            <VideoModal open={expandPlayer} onOpenChange={handleExpandPlayer} src={VIDEO_SRC} />
         </>
     );
 }

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -301,6 +301,6 @@ export const setWarmupSeens = (warmupSeen: boolean) => {
     invoke('set_warmup_seen', { warmupSeen }).catch((e) => {
         console.error('Could not set seen', e);
         setError('Could not change seen');
-        useConfigUIStore.setState({ visual_mode: !warmupSeen });
+        useConfigUIStore.setState({ warmup_seen: !warmupSeen });
     });
 };

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -295,3 +295,12 @@ export const setNodeType = async (nodeType: NodeType) => {
         updateNodeTypeForNodeStore(nodeType);
     });
 };
+
+export const setWarmupSeens = (warmupSeen: boolean) => {
+    useConfigUIStore.setState({ warmup_seen: warmupSeen });
+    invoke('set_warmup_seen', { warmupSeen }).catch((e) => {
+        console.error('Could not set seen', e);
+        setError('Could not change seen');
+        useConfigUIStore.setState({ visual_mode: !warmupSeen });
+    });
+};

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -57,6 +57,7 @@ const configUIInitialState: UIConfigStoreState = {
     show_experimental_settings: false,
     should_always_use_system_language: false,
     visual_mode: true,
+    warmup_seen: false,
 };
 
 export const useConfigCoreStore = create<ConfigCore>()(() => ({

--- a/src/types/configs.ts
+++ b/src/types/configs.ts
@@ -40,6 +40,7 @@ export interface ConfigUI {
     sharing_enabled: boolean;
     visual_mode: boolean;
     show_experimental_settings: boolean;
+    warmup_seen?: boolean;
 }
 export interface ConfigMining {
     created_at: string;

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -114,4 +114,5 @@ declare module '@tauri-apps/api/core' {
     function invoke(param: 'validate_minotari_amount', payload: { amount: string }): Promise<string>;
     function invoke(param: 'trigger_phases_restart'): Promise<void>;
     function invoke(param: 'set_node_type', payload: { nodeType: NodeType }): Promise<void>;
+    function invoke(param: 'set_warmup_seen', payload: { warmupSeen: boolean }): Promise<void>;
 }


### PR DESCRIPTION
Description
---
- add config item for auto-playing video once


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The video player in the Banner section now automatically expands on first view if the warmup has not been seen.
  - The app tracks whether the warmup has been seen, enabling a more personalized user experience.

- **Bug Fixes**
  - Improved synchronization between UI state and backend when updating the warmup seen status.

- **Chores**
  - Added support for storing and updating the warmup seen status in app configuration and backend commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->