### PR TITLE
fix: update initial balance when block height changed during sync

### DIFF
--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -288,7 +288,7 @@ impl WalletManager {
                             break;
                         }
 
-                        if scanned_height > 0 {
+                        if scanned_height > 0 && progress < 1.0 {
                             log::info!(target: LOG_TARGET, "Initial wallet scanning: {}% ({}/{})", progress, scanned_height, current_target_height);
                             EventsEmitter::emit_init_wallet_scanning_progress(
                                 &app_clone,


### PR DESCRIPTION
Description
---
`emit_init_wallet_scanning_progress` was emitted even though block height has change during the initial wallet scan

Await until it's really completed