### PR TITLE
chore: update auto close first play video | comment out release notes modal

### DIFF
--- a/src/components/VideoModal/VideoModal.tsx
+++ b/src/components/VideoModal/VideoModal.tsx
@@ -23,7 +23,7 @@ export function VideoModal({ src, open, onOpenChange, firstPlay = false }: Video
                     <CTA onClick={() => onOpenChange(false)}>
                         <IoClose />
                     </CTA>
-                    <Video autoPlay={open} controls playsInline preload="auto" loop={false} onEnded={handleEnded}>
+                    <Video autoPlay controls preload="auto" onEnded={handleEnded}>
                         <source src={src} />
                     </Video>
                 </Wrapper>

--- a/src/components/VideoModal/VideoModal.tsx
+++ b/src/components/VideoModal/VideoModal.tsx
@@ -5,18 +5,27 @@ import { Video, Wrapper, CTA } from './styles.ts';
 interface VideoModalProps {
     src: string;
     open: boolean;
-    onOpenChange: () => void;
+    onOpenChange: (open: boolean) => void;
+    firstPlay?: boolean;
 }
 
-export function VideoModal({ src, open, onOpenChange }: VideoModalProps) {
+export function VideoModal({ src, open, onOpenChange, firstPlay = false }: VideoModalProps) {
+    function handleEnded() {
+        if (open && firstPlay) {
+            onOpenChange(false);
+            return;
+        }
+    }
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent $unPadded>
                 <Wrapper>
-                    <CTA onClick={onOpenChange}>
+                    <CTA onClick={() => onOpenChange(false)}>
                         <IoClose />
                     </CTA>
-                    <Video autoPlay src={src} controls playsInline></Video>
+                    <Video autoPlay={open} controls playsInline preload="auto" loop={false} onEnded={handleEnded}>
+                        <source src={src} />
+                    </Video>
                 </Wrapper>
             </DialogContent>
         </Dialog>

--- a/src/containers/floating/FloatingElements.tsx
+++ b/src/containers/floating/FloatingElements.tsx
@@ -11,7 +11,8 @@ import AdminUI from '@app/components/AdminUI/AdminUI.tsx';
 import ToastStack from '@app/components/ToastStack/ToastStack.tsx';
 import CriticalProblemDialog from './CriticalProblemDialog/CriticalProblemDialog.tsx';
 import ShellOfSecrets from '../main/ShellOfSecrets/ShellOfSecrets.tsx';
-// import ReleaseNotesDialog from './ReleaseNotesDialog/ReleaseNotesDialog.tsx';
+// eslint-disable-next-line
+import ReleaseNotesDialog from './ReleaseNotesDialog/ReleaseNotesDialog.tsx';
 import LudicrousCofirmationDialog from './LudicrousCofirmationDialog/LudicrousCofirmationDialog.tsx';
 import { memo } from 'react';
 import ResumeApplicationModal from './ResumeApplicationModal/ResumeApplicationModal.tsx';

--- a/src/containers/floating/FloatingElements.tsx
+++ b/src/containers/floating/FloatingElements.tsx
@@ -11,7 +11,7 @@ import AdminUI from '@app/components/AdminUI/AdminUI.tsx';
 import ToastStack from '@app/components/ToastStack/ToastStack.tsx';
 import CriticalProblemDialog from './CriticalProblemDialog/CriticalProblemDialog.tsx';
 import ShellOfSecrets from '../main/ShellOfSecrets/ShellOfSecrets.tsx';
-import ReleaseNotesDialog from './ReleaseNotesDialog/ReleaseNotesDialog.tsx';
+// import ReleaseNotesDialog from './ReleaseNotesDialog/ReleaseNotesDialog.tsx';
 import LudicrousCofirmationDialog from './LudicrousCofirmationDialog/LudicrousCofirmationDialog.tsx';
 import { memo } from 'react';
 import ResumeApplicationModal from './ResumeApplicationModal/ResumeApplicationModal.tsx';
@@ -35,7 +35,7 @@ const FloatingElements = memo(function FloatingElements() {
             <ShellOfSecrets />
             <ToastStack />
             <CriticalProblemDialog />
-            <ReleaseNotesDialog />
+            {/*<ReleaseNotesDialog />*/}
             <ResumeApplicationModal />
             <XSpaceEventBanner />
             <CustomPowerLevelsDialogContainer />

--- a/src/containers/main/Banner/Banner.tsx
+++ b/src/containers/main/Banner/Banner.tsx
@@ -3,10 +3,10 @@ import { Button } from '@app/components/elements/buttons/Button.tsx';
 import { BodyCopy, DashboardBanner, FlexSection, TagLine, VideoPreview } from './styles.ts';
 import { setDialogToShow, useConfigUIStore } from '@app/store';
 import { VideoModal } from '@app/components/VideoModal/VideoModal.tsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Typography } from '@app/components/elements/Typography.tsx';
-import { setWarmupSeens } from '@app/store/actions/appConfigStoreActions.ts';
+import { setWarmupSeen } from '@app/store/actions/appConfigStoreActions.ts';
 
 const VIDEO_SRC = 'https://static.tari.com/Tari-Announcement-BG.mp4';
 
@@ -14,18 +14,19 @@ export default function Banner() {
     const { t } = useTranslation(['common', 'components']);
     const warmup_seen = useConfigUIStore((s) => s.warmup_seen);
     const [expandPlayer, setExpandPlayer] = useState(false);
+    const firstPlay = useRef(!warmup_seen);
 
     function handleClick() {
         setDialogToShow('warmup');
     }
-    function handleExpandPlayer() {
-        setExpandPlayer((c) => !c);
+    function handleOpenChange(open: boolean) {
+        setExpandPlayer(open);
     }
 
     useEffect(() => {
         if (!warmup_seen) {
             setExpandPlayer(true);
-            setWarmupSeens(true);
+            setWarmupSeen(true);
         }
     }, [warmup_seen]);
 
@@ -33,9 +34,9 @@ export default function Banner() {
         <>
             <DashboardBanner>
                 <FlexSection>
-                    <VideoPreview onClick={handleExpandPlayer}>
+                    <VideoPreview onClick={() => handleOpenChange(true)}>
                         <FaPlay />
-                        <video src={VIDEO_SRC} />
+                        <video src={VIDEO_SRC} autoPlay={false} loop={false} muted={true} controls={false} />
                     </VideoPreview>
                     <TagLine>
                         <div>{t('tari')}</div>
@@ -55,7 +56,12 @@ export default function Banner() {
                     </Button>
                 </FlexSection>
             </DashboardBanner>
-            <VideoModal open={expandPlayer} onOpenChange={handleExpandPlayer} src={VIDEO_SRC} />
+            <VideoModal
+                open={expandPlayer}
+                onOpenChange={handleOpenChange}
+                src={VIDEO_SRC}
+                firstPlay={firstPlay.current}
+            />
         </>
     );
 }

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -296,7 +296,7 @@ export const setNodeType = async (nodeType: NodeType) => {
     });
 };
 
-export const setWarmupSeens = (warmupSeen: boolean) => {
+export const setWarmupSeen = (warmupSeen: boolean) => {
     useConfigUIStore.setState({ warmup_seen: warmupSeen });
     invoke('set_warmup_seen', { warmupSeen }).catch((e) => {
         console.error('Could not set seen', e);


### PR DESCRIPTION
Description
---

- auto close if first play 
- comment out for modal overlap 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Video modals now support an automatic close feature after the first play, enhancing user experience.
- **Bug Fixes**
	- Corrected an issue with the video warmup state handling to ensure accurate tracking and behavior.
- **Chores**
	- Disabled the display of release notes in floating elements for now.
- **Style**
	- Improved clarity and consistency in video player controls and modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->