### PR TITLE
chore: do not use mini pool

### DIFF
--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -132,16 +132,10 @@ impl ProcessAdapter for P2poolAdapter {
         let pid_file_name = self.pid_file_name().to_string();
 
         args.push("--squad-prefix".to_string());
-        let mut squad_prefix = "default";
-        let mut num_squads = 3;
-        if let Some(benchmark) = config.cpu_benchmark_hashrate {
-            if benchmark < 4000 {
-                squad_prefix = "mini";
-                num_squads = 1;
-            }
-        }
+        let squad_prefix = "default";
         args.push(squad_prefix.to_string());
         args.push("--num-squads".to_string());
+        let num_squads = 3;
         args.push(num_squads.to_string());
         let mut envs = HashMap::new();
         match Network::get_current_or_user_setting_or_default() {


### PR DESCRIPTION
Description
---
Do not use mini pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the configuration to always use the default squad settings, removing adjustments based on CPU benchmark values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->