### PR TITLE
feat: create different directories for each network

### DIFF
--- a/src-tauri/src/p2pool_adapter.rs
+++ b/src-tauri/src/p2pool_adapter.rs
@@ -83,7 +83,9 @@ impl ProcessAdapter for P2poolAdapter {
 
         info!(target: LOG_TARGET, "Starting p2pool node");
 
-        let working_dir = data_dir.join("sha-p2pool");
+        let working_dir = data_dir
+            .join("sha-p2pool")
+            .join(Network::get_current_or_user_setting_or_default().to_string());
         std::fs::create_dir_all(&working_dir).unwrap_or_else(|error| {
             warn!(target: LOG_TARGET, "Could not create p2pool working directory - {}", error);
         });


### PR DESCRIPTION
Description
---
Separates `p2pool_private.key` between different networks. Previously there was only one that looked like this:
```
├── sha-p2pool
│   └── p2pool_private.key
```

Now this looks like this:
```
sha-p2pool
├── esmeralda
│   └── p2pool_private.key
└── nextnet
    └── p2pool_private.key
```
Everything worked fine - I was able to mine and join mining pool
![Screenshot from 2025-05-05 17-00-02](https://github.com/user-attachments/assets/14b2e7f3-fa3d-4e15-9f5c-686c41fc88bb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the storage location for node data to use a network-specific subdirectory, improving organization of data files for different networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->