### PR TITLE
fix: allow-only-cdn-download

### DIFF
--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -59,28 +59,26 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
             }
         }
 
-        // if cdn_responded {
+        if cdn_responded {
+            let version = VersionDownloadInfo {
+                version: "14.5.1".parse().expect("Bad tor version"),
+                assets: vec![VersionAsset {
+                    url: cdn_tor_bundle_url.to_string(),
+                    name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
+                }],
+            };
+            return Ok(vec![version]);
+        }
+
+        // Tor doesn't have a nice API for this so just return specific ones
         let version = VersionDownloadInfo {
             version: "14.5.1".parse().expect("Bad tor version"),
             assets: vec![VersionAsset {
-                url: cdn_tor_bundle_url.to_string(),
+                url: format!("https://dist.torproject.org/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz", platform),
                 name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
-            }],
+            }]
         };
-        //     return Ok(vec![version]);
-        // }
-
         Ok(vec![version])
-
-        // Tor doesn't have a nice API for this so just return specific ones
-        // let version = VersionDownloadInfo {
-        //     version: "14.5.1".parse().expect("Bad tor version"),
-        //     assets: vec![VersionAsset {
-        //         url: format!("https://dist.torproject.org/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz", platform),
-        //         name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
-        //     }]
-        // };
-        // Ok(vec![version])
     }
 
     async fn download_and_get_checksum_path(

--- a/src-tauri/src/binaries/adapter_tor.rs
+++ b/src-tauri/src/binaries/adapter_tor.rs
@@ -59,26 +59,28 @@ impl LatestVersionApiAdapter for TorReleaseAdapter {
             }
         }
 
-        if cdn_responded {
-            let version = VersionDownloadInfo {
-                version: "14.5.1".parse().expect("Bad tor version"),
-                assets: vec![VersionAsset {
-                    url: cdn_tor_bundle_url.to_string(),
-                    name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
-                }],
-            };
-            return Ok(vec![version]);
-        }
-
-        // Tor doesn't have a nice API for this so just return specific ones
+        // if cdn_responded {
         let version = VersionDownloadInfo {
             version: "14.5.1".parse().expect("Bad tor version"),
             assets: vec![VersionAsset {
-                url: format!("https://dist.torproject.org/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz", platform),
+                url: cdn_tor_bundle_url.to_string(),
                 name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
-            }]
+            }],
         };
+        //     return Ok(vec![version]);
+        // }
+
         Ok(vec![version])
+
+        // Tor doesn't have a nice API for this so just return specific ones
+        // let version = VersionDownloadInfo {
+        //     version: "14.5.1".parse().expect("Bad tor version"),
+        //     assets: vec![VersionAsset {
+        //         url: format!("https://dist.torproject.org/torbrowser/14.5.1/tor-expert-bundle-{}-14.5.1.tar.gz", platform),
+        //         name: format!("tor-expert-bundle-{}-14.5.1.tar.gz", platform),
+        //     }]
+        // };
+        // Ok(vec![version])
     }
 
     async fn download_and_get_checksum_path(

--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -36,7 +36,7 @@ use super::{
     Binaries,
 };
 
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 
 pub const LOG_TARGET: &str = "tari::universe::binary_manager";
 
@@ -481,6 +481,7 @@ impl BinaryManager {
             .map_err(|e| anyhow!("Error creating in progress folder. Error: {:?}", e))?;
         let in_progress_file_zip = in_progress_dir.join(asset.name.clone());
 
+        info!(target: LOG_TARGET, "Downloading binary: {} from url: {}", self.binary_name, asset.url);
         progress_tracker
             .send_last_action(format!(
                 "Downloading binary: {} with version: {}",

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -49,12 +49,12 @@ enum ReleaseSource {
     Mirror,
 }
 
-pub fn get_gh_url(repo_owner: &str, repo_name: &str) -> String {
-    format!(
-        "https://api.github.com/repos/{}/{}/releases",
-        repo_owner, repo_name
-    )
-}
+// pub fn get_gh_url(repo_owner: &str, repo_name: &str) -> String {
+//     format!(
+//         "https://api.github.com/repos/{}/{}/releases",
+//         repo_owner, repo_name
+//     )
+// }
 
 pub fn get_mirror_url(repo_owner: &str, repo_name: &str) -> String {
     format!(

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -125,7 +125,7 @@ async fn list_releases_from(
 ) -> Result<Vec<VersionDownloadInfo>, anyhow::Error> {
     let client = Client::new();
     let url = match source {
-        ReleaseSource::Github => get_gh_url(repo_owner, repo_name),
+        // ReleaseSource::Github => get_gh_url(repo_owner, repo_name),
         ReleaseSource::Mirror => get_mirror_url(repo_owner, repo_name),
     };
 
@@ -166,7 +166,7 @@ async fn list_releases_from(
                     &get_gh_download_url(repo_owner, repo_name),
                     &get_mirror_download_url(repo_owner, repo_name),
                 ),
-                ReleaseSource::Github => asset.browser_download_url,
+                // ReleaseSource::Github => asset.browser_download_url,
             };
             assets.push(VersionAsset {
                 url,

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -45,7 +45,7 @@ struct Asset {
 
 #[derive(Debug)]
 enum ReleaseSource {
-    Github,
+    // Github,
     Mirror,
 }
 

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -97,18 +97,18 @@ pub async fn list_releases(
         );
     };
     // Add any missing releases from github
-    let github_releases = list_releases_from(ReleaseSource::Github, repo_owner, repo_name)
-        .await
-        .inspect_err(|e| {
-            warn!(target: LOG_TARGET, "Failed to fetch releases from Github: {}", e);
-        })
-        .unwrap_or_default();
+    // let github_releases = list_releases_from(ReleaseSource::Github, repo_owner, repo_name)
+    //     .await
+    //     .inspect_err(|e| {
+    //         warn!(target: LOG_TARGET, "Failed to fetch releases from Github: {}", e);
+    //     })
+    //     .unwrap_or_default();
 
-    for release in &github_releases {
-        if !releases.iter().any(|r| r.version == release.version) {
-            releases.push(release.clone());
-        }
-    }
+    // for release in &github_releases {
+    //     if !releases.iter().any(|r| r.version == release.version) {
+    //         releases.push(release.clone());
+    //     }
+    // }
     Ok(releases)
 
     // if releases.as_ref().map_or(false, |r| !r.is_empty()) {


### PR DESCRIPTION
### [ Summary ]
- Comment out listing releases from github

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added an informational log message when starting a binary download, displaying the binary name and download URL.

- **Changes**
  - The app now fetches release information solely from the mirror source, no longer supplementing it with releases from GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->