### PR TITLE
fix: use windows-x64 for glytex

### DIFF
--- a/src-tauri/src/binaries/adapter_cdn.rs
+++ b/src-tauri/src/binaries/adapter_cdn.rs
@@ -1,26 +1,4 @@
-// Copyright 2024. The Tari Project
-//
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-// following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-// disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
-// following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
-// products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, ops::Deref, path::PathBuf, str::FromStr};
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -212,7 +190,7 @@ impl LatestVersionApiAdapter for CDNReleaseAdapter {
     ) -> Result<VersionAsset, Error> {
         let mut name_suffix = "";
         if cfg!(target_os = "windows") {
-            name_suffix = r"windows-x64.zip";
+            name_suffix = r"windows-x64.exe.zip";
         }
 
         if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
@@ -247,6 +225,16 @@ impl LatestVersionApiAdapter for CDNReleaseAdapter {
             .ok_or(anyhow::anyhow!("Failed to get platform asset"))?;
 
         info!(target: LOG_TARGET, "Found platform: {:?}", platform);
+
+        if cfg!(target_os = "windows") {
+            let mut platform = platform.clone();
+            // remove all "*" occurences from the url and name
+            platform.url = platform.url.replace("*", "");
+            platform.name = platform.name.replace("*", "");
+            platform.url = platform.url.replace("\n", "");
+            return Ok(platform.clone());
+        }
+
         Ok(platform.clone())
     }
 }

--- a/src-tauri/src/binaries/adapter_cdn.rs
+++ b/src-tauri/src/binaries/adapter_cdn.rs
@@ -1,3 +1,25 @@
+// Copyright 2024. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use anyhow::Error;

--- a/src-tauri/src/binaries/adapter_cdn.rs
+++ b/src-tauri/src/binaries/adapter_cdn.rs
@@ -190,7 +190,7 @@ impl LatestVersionApiAdapter for CDNReleaseAdapter {
     ) -> Result<VersionAsset, Error> {
         let mut name_suffix = "";
         if cfg!(target_os = "windows") {
-            name_suffix = r"windows-x86_64.zip";
+            name_suffix = r"windows-x64.zip";
         }
 
         if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {

--- a/src-tauri/src/binaries/adapter_cdn.rs
+++ b/src-tauri/src/binaries/adapter_cdn.rs
@@ -1,4 +1,26 @@
-use std::{collections::HashMap, ops::Deref, path::PathBuf, str::FromStr};
+// Copyright 2024. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use anyhow::Error;
 use async_trait::async_trait;


### PR DESCRIPTION
Description
---
use `windows-x64` instead of x84_64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of Windows platform assets by updating the expected filename suffix for downloads.
  - Enhanced Windows asset handling by cleaning up download links for better reliability.

- **Chores**
  - Added a copyright and license header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->