### PR TITLE
chore: enable send/recv by default

### DIFF
--- a/src/store/actions/airdropStoreActions.ts
+++ b/src/store/actions/airdropStoreActions.ts
@@ -54,7 +54,7 @@ const clearState: AirdropStoreState = {
     userPoints: undefined,
     bonusTiers: undefined,
     flareAnimationType: undefined,
-    uiSendRecvEnabled: false,
+    uiSendRecvEnabled: true,
 };
 
 const fetchBackendInMemoryConfig = async () => {
@@ -251,7 +251,7 @@ export async function fetchWarmupFeatureFlag() {
 
 export async function fetchUiSendRecvFeatureFlag() {
     const response = await fetchFeatureFlag(FEATURES.FF_UI_TX);
-    useAirdropStore.setState({ uiSendRecvEnabled: response?.access || false });
+    useAirdropStore.setState({ uiSendRecvEnabled: response?.access || true });
     return response;
 }
 

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -122,7 +122,7 @@ const initialState: AirdropStoreState = {
     flareAnimationType: undefined,
     latestXSpaceEvent: null,
     pollingEnabled: undefined,
-    uiSendRecvEnabled: false,
+    uiSendRecvEnabled: true,
 };
 
 export const useAirdropStore = create<AirdropStoreState>()(() => ({ ...initialState }));


### PR DESCRIPTION
enable send/recv by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The send/receive feature in the airdrop UI is now enabled by default for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->