### PR TITLE
fix: wallet constantly loading

### DIFF
--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -9,7 +9,7 @@ import { BlockTimeData } from '@app/types/mining.ts';
 import { setAnimationState } from '@tari-project/tari-tower';
 import { TransactionInfo, WalletBalance } from '@app/types/app-status.ts';
 import { setMiningControlsEnabled } from './actions/miningStoreActions.ts';
-import { refreshPendingTransactions } from './useWalletStore.ts';
+import { refreshPendingTransactions, updateWalletScanningProgress, useWalletStore } from './useWalletStore.ts';
 
 const appWindow = getCurrentWindow();
 
@@ -170,6 +170,15 @@ export const handleNewBlock = async (payload: {
     balance: WalletBalance;
 }) => {
     latestBlockPayload = payload;
+
+    const isWalletScanned = !useWalletStore.getState().wallet_scanning?.is_scanning;
+    if (!isWalletScanned) {
+        updateWalletScanningProgress({
+            progress: 1,
+            scanned_height: payload.block_height,
+            total_height: payload.block_height,
+        });
+    }
 
     if (newBlockDebounceTimeout) {
         clearTimeout(newBlockDebounceTimeout);


### PR DESCRIPTION
Description
---
Initial wallet scan flag might not be set due to new block mined in the meantime.

* Check  is_scanned flag when new block event(it's triggered after initial wallet scan is completed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wallet scanning progress updates to reflect the latest block height when new blocks are received during scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->