### PR TITLE
fix(ui): update loaders and fix layout shift on miner tiles

### DIFF
--- a/src/components/transactions/WalletSidebarContent.tsx
+++ b/src/components/transactions/WalletSidebarContent.tsx
@@ -1,4 +1,3 @@
-// import { Send } from './send/Send';
 import { Receive } from './receive/Receive';
 import Wallet from './wallet/Wallet';
 import { WalletGreyBox, WalletSections } from './WalletSidebarContent.styles.ts';

--- a/src/containers/navigation/components/Miner/components/ExpandableTile.styles.ts
+++ b/src/containers/navigation/components/Miner/components/ExpandableTile.styles.ts
@@ -20,6 +20,7 @@ export const ExpandableTileItem = styled(m.div)`
     align-items: baseline;
     color: ${({ theme }) => theme.palette.text.primary};
 `;
+
 export const ExpandedWrapper = styled(m.div)`
     display: flex;
     background-color: ${({ theme }) => theme.palette.background.paper};

--- a/src/containers/navigation/components/Miner/components/ExpandableTile.tsx
+++ b/src/containers/navigation/components/Miner/components/ExpandableTile.tsx
@@ -1,4 +1,4 @@
-import { StatWrapper, TileItem, TileTop } from '../styles';
+import { LoaderWrapper, StatWrapper, TileItem, TileTop } from '../styles';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { ReactNode, useState } from 'react';
 import QuestionMarkSvg from '@app/components/svgs/QuestionMarkSvg.tsx';
@@ -7,7 +7,7 @@ import { ExpandedWrapper, TriggerWrapper } from './ExpandableTile.styles.ts';
 import { AnimatePresence } from 'motion/react';
 import { autoUpdate, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
 
-import { SpinnerIcon } from '@app/components/elements/loaders/SpinnerIcon.tsx';
+import LoadingDots from '@app/components/transactions/send/SendReview/icons/LoadingDots.tsx';
 
 interface ExpandableTileProps {
     title: string;
@@ -78,7 +78,13 @@ export function ExpandableTile({
                 )}
 
                 {!expanded &&
-                    (isLoading ? <SpinnerIcon /> : <StatWrapper $useLowerCase={useLowerCase}>{stats}</StatWrapper>)}
+                    (isLoading ? (
+                        <LoaderWrapper>
+                            <LoadingDots />
+                        </LoaderWrapper>
+                    ) : (
+                        <StatWrapper $useLowerCase={useLowerCase}>{stats}</StatWrapper>
+                    ))}
             </AnimatePresence>
         </TileItem>
     );

--- a/src/containers/navigation/components/Miner/components/Tile.tsx
+++ b/src/containers/navigation/components/Miner/components/Tile.tsx
@@ -1,10 +1,10 @@
-import { StatWrapper, TileItem, TileTop, Unit } from '../styles';
+import { LoaderWrapper, StatWrapper, TileItem, TileTop, Unit } from '../styles';
 import { truncateString } from '@app/utils/truncateString.ts';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { Chip } from '@app/components/elements/Chip.tsx';
 import { colorsAll } from '@app/theme/palettes/colors.ts';
-import { SpinnerIcon } from '@app/components/elements/loaders/SpinnerIcon.tsx';
 import { formatNumber, FormatPreset } from '@app/utils/formatters';
+import LoadingDots from '@app/components/transactions/send/SendReview/icons/LoadingDots';
 
 interface TileProps {
     title: string;
@@ -31,7 +31,9 @@ function Tile({ title, stats, chipValue = 0, unit, isLoading = false, useLowerCa
                 ) : null}
             </TileTop>
             {isLoading ? (
-                <SpinnerIcon />
+                <LoaderWrapper>
+                    <LoadingDots />
+                </LoaderWrapper>
             ) : (
                 <StatWrapper $useLowerCase={useLowerCase}>
                     {truncateString(stats, 8)}

--- a/src/containers/navigation/components/Miner/styles.ts
+++ b/src/containers/navigation/components/Miner/styles.ts
@@ -51,6 +51,12 @@ export const StatWrapper = styled.div<{ $useLowerCase?: boolean }>`
     text-transform: ${({ $useLowerCase }) => ($useLowerCase ? 'lowercase' : 'uppercase')};
 `;
 
+export const LoaderWrapper = styled.div`
+    height: 18px;
+    display: flex;
+    align-items: center;
+`;
+
 export const Unit = styled.div`
     color: ${({ theme }) => theme.palette.text.primary};
     font-size: 10px;


### PR DESCRIPTION
The mining tiles were layout shifting when changing between loading and non loading states. This is subtle, but also makes the UI look less polished. This update fixes the issue by adding a minimum height to the content area. 

I also updated the loading icons to the dots instead of spinners, it looks more modern. 

![CleanShot 2025-05-07 at 14 13 47@2x](https://github.com/user-attachments/assets/c7bb832c-d2fe-4e6b-9990-57a9ab8269d0)

![CleanShot 2025-05-07 at 14 14 37@2x](https://github.com/user-attachments/assets/73646f0b-f04a-4ff7-a27b-d1fd7c58dba2)

Before:

https://www.loom.com/share/88d2fd13b1ce43c6b19d4afed2fcaf83?sid=b1598410-775d-4ab6-a474-d35b6b75682f

After:

https://www.loom.com/share/eab27b05ca7d4befab5a73f843b8a595?sid=8f01fd7f-2c77-419a-8322-1cb47cf78f74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated loading indicators in Miner tiles to use a new visual style with animated loading dots, improving visual consistency.
  - Introduced a new layout for loading states to better align and center loading indicators.
- **Chores**
  - Cleaned up commented-out code and improved code formatting for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->