### PR TITLE
fix(ui): mainnet video first seen x close btn on windows

### DIFF
--- a/src/components/VideoModal/VideoModal.tsx
+++ b/src/components/VideoModal/VideoModal.tsx
@@ -3,13 +3,12 @@ import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog.ts
 import { Video, Wrapper, CTA } from './styles.ts';
 
 interface VideoModalProps {
-    src: string;
     open: boolean;
     onOpenChange: (open: boolean) => void;
     firstPlay?: boolean;
 }
-
-export function VideoModal({ src, open, onOpenChange, firstPlay = false }: VideoModalProps) {
+const VIDEO_SRC = 'https://static.tari.com/Tari-Announcement-BG.mp4';
+export function VideoModal({ open, onOpenChange, firstPlay = false }: VideoModalProps) {
     function handleEnded() {
         if (open && firstPlay) {
             onOpenChange(false);
@@ -23,8 +22,8 @@ export function VideoModal({ src, open, onOpenChange, firstPlay = false }: Video
                     <CTA onClick={() => onOpenChange(false)}>
                         <IoClose />
                     </CTA>
-                    <Video autoPlay controls preload="auto" onEnded={handleEnded}>
-                        <source src={src} />
+                    <Video autoPlay controls playsInline onEnded={() => handleEnded()}>
+                        <source src={VIDEO_SRC} type="video/mp4" />
                     </Video>
                 </Wrapper>
             </DialogContent>

--- a/src/components/VideoModal/styles.ts
+++ b/src/components/VideoModal/styles.ts
@@ -11,6 +11,7 @@ export const Wrapper = styled.div`
 `;
 
 export const Video = styled.video`
+    position: relative;
     width: calc(100% + 2px);
     height: auto;
 `;
@@ -28,6 +29,7 @@ export const CTA = styled.button`
     background: rgba(0, 0, 0, 0.45);
     transition: transform 0.2s ease-in;
     color: ${({ theme }) => theme.colors.greyscale[100]};
+    z-index: 1;
     &:hover {
         transform: scale(1.15);
     }

--- a/src/containers/main/Banner/Banner.tsx
+++ b/src/containers/main/Banner/Banner.tsx
@@ -11,7 +11,7 @@ import { setWarmupSeen } from '@app/store/actions/appConfigStoreActions.ts';
 export default function Banner() {
     const { t } = useTranslation(['common', 'components']);
     const warmup_seen = useConfigUIStore((s) => s.warmup_seen);
-    const firstPlay = useRef(!warmup_seen);
+    const firstPlay = useRef(warmup_seen !== null && !warmup_seen);
     const [expandPlayer, setExpandPlayer] = useState(false);
 
     function handleClick() {
@@ -22,7 +22,7 @@ export default function Banner() {
     }
 
     useEffect(() => {
-        if (warmup_seen || !firstPlay.current) return;
+        if (warmup_seen === null || warmup_seen) return;
         setExpandPlayer(true);
         setWarmupSeen(true);
         firstPlay.current = false;

--- a/src/containers/main/Banner/Banner.tsx
+++ b/src/containers/main/Banner/Banner.tsx
@@ -8,13 +8,11 @@ import { useTranslation } from 'react-i18next';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { setWarmupSeen } from '@app/store/actions/appConfigStoreActions.ts';
 
-const VIDEO_SRC = 'https://static.tari.com/Tari-Announcement-BG.mp4';
-
 export default function Banner() {
     const { t } = useTranslation(['common', 'components']);
     const warmup_seen = useConfigUIStore((s) => s.warmup_seen);
-    const [expandPlayer, setExpandPlayer] = useState(false);
     const firstPlay = useRef(!warmup_seen);
+    const [expandPlayer, setExpandPlayer] = useState(false);
 
     function handleClick() {
         setDialogToShow('warmup');
@@ -24,10 +22,10 @@ export default function Banner() {
     }
 
     useEffect(() => {
-        if (!warmup_seen) {
-            setExpandPlayer(true);
-            setWarmupSeen(true);
-        }
+        if (warmup_seen || !firstPlay.current) return;
+        setExpandPlayer(true);
+        setWarmupSeen(true);
+        firstPlay.current = false;
     }, [warmup_seen]);
 
     return (
@@ -36,7 +34,6 @@ export default function Banner() {
                 <FlexSection>
                     <VideoPreview onClick={() => handleOpenChange(true)}>
                         <FaPlay />
-                        {/*}<video src={VIDEO_SRC} autoPlay={true} loop={true} muted={true} controls={false} />{*/}
                     </VideoPreview>
                     <TagLine>
                         <div>{t('tari')}</div>
@@ -51,17 +48,12 @@ export default function Banner() {
                         </Typography>
                         <Typography variant="h6">{t('components:banner.body-copy')}</Typography>
                     </BodyCopy>
-                    <Button onClick={handleClick} variant="primary" color="primary" size="small">
+                    <Button onClick={() => handleClick()} variant="primary" color="primary" size="small">
                         {t('learn-more')}
                     </Button>
                 </FlexSection>
             </DashboardBanner>
-            <VideoModal
-                open={expandPlayer}
-                onOpenChange={handleOpenChange}
-                src={VIDEO_SRC}
-                firstPlay={firstPlay.current}
-            />
+            <VideoModal open={expandPlayer} onOpenChange={handleOpenChange} firstPlay={firstPlay.current} />
         </>
     );
 }

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -296,10 +296,12 @@ export const setNodeType = async (nodeType: NodeType) => {
 };
 
 export const setWarmupSeen = (warmupSeen: boolean) => {
-    useConfigUIStore.setState({ warmup_seen: warmupSeen });
-    invoke('set_warmup_seen', { warmupSeen }).catch((e) => {
-        console.error('Could not set seen', e);
-        setError('Could not change seen');
-        useConfigUIStore.setState({ warmup_seen: !warmupSeen });
-    });
+    invoke('set_warmup_seen', { warmupSeen })
+        .then(() => {
+            useConfigUIStore.setState({ warmup_seen: warmupSeen });
+        })
+        .catch((e) => {
+            console.error('Could not set seen', e);
+            setError('Could not change seen');
+        });
 };

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -57,7 +57,7 @@ const configUIInitialState: UIConfigStoreState = {
     show_experimental_settings: false,
     should_always_use_system_language: false,
     visual_mode: true,
-    warmup_seen: false,
+    warmup_seen: null,
 };
 
 export const useConfigCoreStore = create<ConfigCore>()(() => ({

--- a/src/types/configs.ts
+++ b/src/types/configs.ts
@@ -40,7 +40,7 @@ export interface ConfigUI {
     sharing_enabled: boolean;
     visual_mode: boolean;
     show_experimental_settings: boolean;
-    warmup_seen?: boolean;
+    warmup_seen: boolean | null;
 }
 export interface ConfigMining {
     created_at: string;


### PR DESCRIPTION
Description
---

- move video src since the preview doesn't use it anymore
- add playsinline, and z-indices for video (close button issue on windows)
- use early return for the first play check 


Motivation and Context
---
- some folks get the autoplaying video e v e r y new start up
- windows ppl couldn't use the close button


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved video modal behavior by using a fixed video source and refining how the player expands on first load.
	- Enhanced video and button layering and positioning within the modal for better visual consistency.
	- Adjusted state updates for marking the warmup as seen to ensure more reliable UI feedback after successful actions.
- **Style**
	- Updated video and button styles in the modal for improved stacking and positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->