### PR TITLE
fix: remove no tx text flickering when fetching tx list

### DIFF
--- a/src/components/transactions/history/HistoryList.tsx
+++ b/src/components/transactions/history/HistoryList.tsx
@@ -69,7 +69,7 @@ const HistoryList = memo(function HistoryList() {
         listMarkup
     );
 
-    const isEmpty = !walletScanning.is_scanning && !is_transactions_history_loading && !combinedTransactions?.length;
+    const isEmpty = !walletScanning.is_scanning && !combinedTransactions?.length;
     const emptyMarkup = isEmpty ? <Typography variant="h6">{t('empty-tx')}</Typography> : null;
 
     return (


### PR DESCRIPTION
Description
---
don't display loading indicator when no tx so the text won't flicker

Issue was
--
https://github.com/user-attachments/assets/e7a736b0-90d0-4c24-807c-bcee5d8a01b7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for displaying an empty transaction history by removing the loading state check. The list is now considered empty if the wallet is not scanning and there are no transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->