### PR TITLE
chore: edit monero address icon

### DIFF
--- a/src/components/elements/inputs/Input.tsx
+++ b/src/components/elements/inputs/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode, useCallback, useState } from 'react';
+import { InputHTMLAttributes, ReactNode, useCallback, useState, forwardRef } from 'react';
 import { InputWrapper, StyledInput, StyledInputLabel } from './Input.styles.ts';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -8,36 +8,41 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     hasError?: boolean;
 }
 
-export function Input({ labelText, endAdornment, hasError, ...props }: InputProps) {
-    const isNumber = props.type == 'number';
-    const [value, setValue] = useState(isNumber ? 0 : '');
-    const inputName = props.name || 'input-x';
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+    ({ labelText, endAdornment, hasError, ...props }, ref) => {
+        const isNumber = props.type == 'number';
+        const [value, setValue] = useState(isNumber ? 0 : '');
+        const inputName = props.name || 'input-x';
 
-    const handleChange = useCallback(
-        (e) => {
-            const canShowNumber = !isNaN(parseFloat(e?.target?.value));
-            if (isNumber && !canShowNumber) {
-                return;
-            } else {
-                setValue(e.target.value);
-            }
-            props.onChange?.(e);
-        },
-        [isNumber, props]
-    );
+        const handleChange = useCallback(
+            (e) => {
+                const canShowNumber = !isNaN(parseFloat(e?.target?.value));
+                if (isNumber && !canShowNumber) {
+                    return;
+                } else {
+                    setValue(e.target.value);
+                }
+                props.onChange?.(e);
+            },
+            [isNumber, props]
+        );
 
-    return (
-        <InputWrapper>
-            {labelText ? <StyledInputLabel htmlFor={inputName}>{labelText}</StyledInputLabel> : null}
-            <StyledInput
-                id={inputName}
-                name={inputName}
-                onChange={handleChange}
-                value={value}
-                $hasError={hasError}
-                {...props}
-            />
-            <div>{endAdornment}</div>
-        </InputWrapper>
-    );
-}
+        return (
+            <InputWrapper>
+                {labelText ? <StyledInputLabel htmlFor={inputName}>{labelText}</StyledInputLabel> : null}
+                <StyledInput
+                    id={inputName}
+                    name={inputName}
+                    onChange={handleChange}
+                    value={value}
+                    $hasError={hasError}
+                    ref={ref}
+                    {...props}
+                />
+                <div>{endAdornment}</div>
+            </InputWrapper>
+        );
+    }
+);
+
+Input.displayName = 'Input';

--- a/src/containers/floating/Settings/sections/wallet/MoneroAddressMarkup/MoneroAddressEditor.tsx
+++ b/src/containers/floating/Settings/sections/wallet/MoneroAddressMarkup/MoneroAddressEditor.tsx
@@ -88,10 +88,9 @@ const MoneroAddressEditor = ({ initialAddress, onApply }: MoneroAddressEditorPro
                         },
                     }}
                     render={({ field }) => {
-                        const { ref: _ref, ...rest } = field;
                         return (
                             <StyledInput
-                                {...rest}
+                                {...field}
                                 type="text"
                                 hasError={!!errors.address}
                                 onFocus={() => setEditing(true)}

--- a/src/containers/floating/Settings/sections/wallet/MoneroAddressMarkup/MoneroAddressEditor.tsx
+++ b/src/containers/floating/Settings/sections/wallet/MoneroAddressMarkup/MoneroAddressEditor.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import { IoCopyOutline, IoCheckmarkOutline, IoCloseOutline } from 'react-icons/io5';
+import { IoCopyOutline, IoCheckmarkOutline, IoCloseOutline, IoPencil } from 'react-icons/io5';
 import { Stack } from '@app/components/elements/Stack.tsx';
 import { Input } from '@app/components/elements/inputs/Input';
 import styled from 'styled-components';
 import { useCopyToClipboard } from '@app/hooks';
 import { IconButton } from '@app/components/elements/buttons/IconButton.tsx';
+import { IconContainer } from '@app/containers/floating/Settings/sections/wallet/components/SeedWords.styles.ts';
 
 const moneroAddressRegex = /^4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}$/;
 interface MoneroAddressEditorProps {
@@ -24,7 +25,7 @@ const StyledInput = styled(Input)`
 const StyledForm = styled.form`
     width: 100%;
     // Reserve space for error message
-    min-height: 53px;
+    min-height: 60px;
 `;
 
 const MoneroAddressEditor = ({ initialAddress, onApply }: MoneroAddressEditorProps) => {
@@ -33,16 +34,21 @@ const MoneroAddressEditor = ({ initialAddress, onApply }: MoneroAddressEditorPro
         watch,
         handleSubmit,
         setValue,
+        setFocus,
         reset,
         trigger,
-        formState: { errors },
+        formState: { errors, isDirty },
     } = useForm({
         defaultValues: { address: initialAddress },
     });
+    const [editing, setEditing] = useState(false);
     const { copyToClipboard, isCopied } = useCopyToClipboard();
-
     const address = watch('address');
 
+    function handleEditClick() {
+        setFocus('address', { shouldSelect: true });
+        setEditing(true);
+    }
     useEffect(() => {
         setValue('address', initialAddress);
     }, [initialAddress, setValue]);
@@ -56,11 +62,18 @@ const MoneroAddressEditor = ({ initialAddress, onApply }: MoneroAddressEditorPro
 
     const handleReset = useCallback(() => {
         reset({ address: initialAddress });
+        setEditing(false);
     }, [initialAddress, reset]);
 
     useEffect(() => {
         trigger('address');
     }, [address, trigger]);
+
+    const editIconMarkup = !editing ? (
+        <IconButton size="small" onClick={() => handleEditClick()} type="button">
+            <IoPencil />
+        </IconButton>
+    ) : null;
 
     return (
         <StyledForm onSubmit={handleSubmit(handleApply)} onReset={handleReset}>
@@ -76,23 +89,32 @@ const MoneroAddressEditor = ({ initialAddress, onApply }: MoneroAddressEditorPro
                     }}
                     render={({ field }) => {
                         const { ref: _ref, ...rest } = field;
-                        return <StyledInput type="text" hasError={!!errors.address} {...rest} />;
+                        return (
+                            <StyledInput
+                                {...rest}
+                                type="text"
+                                hasError={!!errors.address}
+                                onFocus={() => setEditing(true)}
+                            />
+                        );
                     }}
                 />
-                {address !== initialAddress ? (
+                {editIconMarkup}
+                {editing ? (
                     <>
-                        {!errors.address && (
-                            <IconButton type="submit">
+                        <IconContainer style={{ gap: 2 }}>
+                            <IconButton type="submit" size="small" disabled={!isDirty || !!errors.address}>
                                 <IoCheckmarkOutline />
                             </IconButton>
-                        )}
-                        <IconButton type="reset">
-                            <IoCloseOutline />
-                        </IconButton>
+                            <IconButton type="reset" size="small">
+                                <IoCloseOutline />
+                            </IconButton>
+                        </IconContainer>
                     </>
                 ) : (
                     <IconButton
                         size="small"
+                        type="button"
                         onClick={(e) => {
                             e.preventDefault();
                             copyToClipboard(address);

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/SeedWordsEdit.tsx
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/SeedWordsEdit.tsx
@@ -145,6 +145,7 @@ export const SeedWordsEdit = ({ seedWords, seedWordsFetching, toggleEdit }: Seed
                                 disabled={seedWordsFetching}
                                 onPaste={handlePaste}
                                 minHeight="80px"
+                                autoFocus
                                 {...rest}
                             />
                         );


### PR DESCRIPTION
#2067 Co-authored with @shanimal08 

Description
---
* add edit(pencil) icon to the monero address
* handle reference the Input component

 

https://github.com/user-attachments/assets/d625b524-63cf-4950-b130-92296e1e1ad3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic focus to the seed words input area for improved usability.
	- Enhanced Monero address editor with explicit editing mode, including edit, submit, and reset buttons for better user interaction.
- **Refactor**
	- Updated the input component to support forwarding refs for improved integration with other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->