### PR TITLE
fix: false positive for initial sync after reset

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -256,7 +256,12 @@ impl NodeAdapterService {
             progress_percentage_tx.send(percentage).ok();
             progress_params_tx.send(progress_params).ok();
 
-            if tip_res.initial_sync_achieved {
+            if tip_res.initial_sync_achieved
+                && tip_res
+                    .metadata
+                    .clone()
+                    .is_some_and(|metadata| metadata.best_block_height > 0)
+            {
                 info!(target: LOG_TARGET, "Initial sync achieved");
                 let tip_height = match tip_res.metadata {
                     Some(metadata) => metadata.best_block_height,


### PR DESCRIPTION
Description
---
Add additional check for verifying initial sync. This caused TU to exit initial setup with out of sync minotari node.

How Has This Been Tested?
---
Reset setting (I did it with wallet reset too) and relaunch app. On my first attempt I skipped initial sync and started from the very beginning. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization status checks to ensure initial sync is only marked complete when valid metadata with a positive block height is present, preventing premature sync completion notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->