### PR TITLE
fix: adjust universe log configs

### DIFF
--- a/src-tauri/log4rs/base_node_sample.yml
+++ b/src-tauri/log4rs/base_node_sample.yml
@@ -32,7 +32,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/base_node/log/network.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m} // {f}:{L}{n}"
@@ -48,7 +48,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/base_node/log/messages.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m} // {f}:{L}{n}"
@@ -65,7 +65,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/base_node/log/base_layer.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [{X(node-public-key)},{X(node-id)}] {l:5} {m} // {f}:{L}{n}"
@@ -82,7 +82,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/base_node/log/grpc.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {l:5} {m} // {f}:{L}{n}"
@@ -99,7 +99,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/base_node/log/other.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n} // {f}:{L} "

--- a/src-tauri/log4rs/proxy_sample.yml
+++ b/src-tauri/log4rs/proxy_sample.yml
@@ -26,11 +26,11 @@ appenders:
       kind: compound
       trigger:
         kind: size
-        limit: 2mb
+        limit: 5mb
       roller:
         kind: fixed_window
         base: 1
-        count: 50
+        count: 3
         pattern: "{{log_dir}}/proxy/log/proxy.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] {l:5} {m}{n}"

--- a/src-tauri/log4rs/spend_wallet_sample.yml
+++ b/src-tauri/log4rs/spend_wallet_sample.yml
@@ -41,7 +41,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/spend_wallet/log/network.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -58,7 +58,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/spend_wallet/log/base_layer.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -75,7 +75,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/spend_wallet/log/other.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -92,7 +92,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/spend_wallet/log/contacts.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"

--- a/src-tauri/log4rs/universe_sample.yml
+++ b/src-tauri/log4rs/universe_sample.yml
@@ -32,7 +32,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/universe/log/universe-web.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {l:5} {m}{n} "
@@ -49,7 +49,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/universe/log/universe.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {l:5} {m} // {f}:{L}{n}"
@@ -66,7 +66,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/universe/log/other.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {l:5} {m}{n} // {f}:{L} "

--- a/src-tauri/log4rs/wallet_sample.yml
+++ b/src-tauri/log4rs/wallet_sample.yml
@@ -41,7 +41,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/wallet/log/network.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -58,7 +58,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/wallet/log/base_layer.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -75,7 +75,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/wallet/log/other.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"
@@ -92,7 +92,7 @@ appenders:
       roller:
         kind: fixed_window
         base: 1
-        count: 5
+        count: 2
         pattern: "{{log_dir}}/wallet/log/contacts.{}.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} [{t}] [Thread:{I}] {l:5} {m}{n}"


### PR DESCRIPTION
### [ Summary ]
- Reduce roller count sizes from `5 to 2` for most of logs and from `50 to 3` for proxy logs
- Increased size from `2mb to 5mb` for proxy logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the number of rotated log files retained for several logging configurations, limiting backups to 2 files instead of 5 in most components.
  - For the proxy logging configuration, increased the log file size limit for rotation from 2 MB to 5 MB and reduced retained backups from 50 to 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->