### PR TITLE
chore(wallet): use envs instead of passing args for keys in minotari_console_wallet

### DIFF
--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -342,10 +342,6 @@ impl ProcessAdapter for WalletAdapter {
         let mut args: Vec<String> = vec![
             "-b".to_string(),
             formatted_working_dir,
-            "--view-private-key".to_string(),
-            self.view_private_key.clone(),
-            "--spend-key".to_string(),
-            self.spend_key.clone(),
             "--non-interactive-mode".to_string(),
             format!(
                 "--log-config={}",
@@ -452,6 +448,14 @@ impl ProcessAdapter for WalletAdapter {
         envs.insert(
             "MINOTARI_WALLET_PASSWORD".to_string(),
             "asjhfahjajhdfvarehnavrahuyg28397823yauifh24@@$@84y8".to_string(),
+        );
+        envs.insert(
+            "MINOTARI_WALLET_VIEW_PRIVATE_KEY".to_string(),
+            self.view_private_key.clone(),
+        );
+        envs.insert(
+            "MINOTARI_WALLET_SPEND_KEY".to_string(),
+            self.spend_key.clone(),
         );
 
         Ok((


### PR DESCRIPTION
Description
---
### **This should be merged only after new minotari_console_wallet is released with this [PR](https://github.com/tari-project/tari/pull/7035) merged**

Use environment variables instead of  passiing `spend-key` and and `view-private-key` to minotari_console_wallet.

How Has This Been Tested?
---
Build new minotari_console_wallet and swap it in cache directory the launch app and check if it initialize successfully and check logs which shows what arguments were passed to `minotari_console_wallet`:
```
14:03:35 INFO  Starting wallet process with args: -b /home/maciej/.local/share/com.tari.universe.alpha/wallet --non-interactive-mode --log-config=/home/maciej/.local/share/com.tari.universe.alpha/logs/wallet/configs/log4rs_config_wallet.yml --grpc-enabled --grpc-address /ip4/127.0.0.1/tcp/36491 -p wallet.custom_base_node=e8cfbd6ab3c8560a5548fe1ea911fd1044e64be7f32df6192fb32745aaeda45c::/ip4/127.0.0.1/tcp/32783 --birthday 1196 -p wallet.base_node.base_node_monitor_max_refresh_interval=1 -p wallet.p2p.transport.type=tcp -p wallet.p2p.public_addresses=/ip4/127.0.0.1/tcp/42531 -p wallet.p2p.transport.tcp.listener_address=/ip4/0.0.0.0/tcp/42531 -p esmeralda.p2p.seeds.dns_seeds=ip4.seeds.esmeralda.tari.com,ip6.seeds.esmeralda.tari.com
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Sensitive wallet keys are now provided via environment variables instead of command-line arguments during wallet process initialization. This enhances the handling of private key information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->