### PR TITLE
fix(ui): fixed no transactions state in the ui

### DIFF
--- a/src/components/transactions/history/HistoryList.tsx
+++ b/src/components/transactions/history/HistoryList.tsx
@@ -6,11 +6,11 @@ import { ListItemWrapper, ListWrapper } from './TxHistory.styles.ts';
 import { HistoryListItem } from './ListItem.tsx';
 import { fetchTransactionsHistory } from '@app/store';
 import { useTranslation } from 'react-i18next';
-import { Typography } from '@app/components/elements/Typography.tsx';
 import { TransactionInfo } from '@app/types/app-status.ts';
 import ListLoadingAnimation from '@app/containers/navigation/components/Wallet/ListLoadingAnimation/ListLoadingAnimation.tsx';
 import ItemExpand from './ExpandedItem.tsx';
 import { PlaceholderItem } from './ListItem.styles.ts';
+import { LoadingText } from '@app/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts';
 
 const HistoryList = memo(function HistoryList() {
     const { t } = useTranslation('wallet');
@@ -98,7 +98,7 @@ const HistoryList = memo(function HistoryList() {
     );
 
     const isEmpty = !walletScanning.is_scanning && !combinedTransactions?.length;
-    const emptyMarkup = isEmpty ? <Typography variant="h6">{t('empty-tx')}</Typography> : null;
+    const emptyMarkup = isEmpty ? <LoadingText>{t('empty-tx')}</LoadingText> : null;
 
     return (
         <>

--- a/src/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts
+++ b/src/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts
@@ -38,13 +38,14 @@ export const LoadingText = styled(m.div)`
     text-align: center;
     z-index: 1;
 
-    margin-top: 8px;
+    margin-top: 7px;
 
     background-color: ${({ theme }) => (theme.mode === 'dark' ? '#2E2E2E' : '#fff')};
     color: ${({ theme }) => (theme.mode === 'dark' ? '#fff' : '#000')};
     padding: 8px 20px;
     border-radius: 100px;
-    width: fit-content;
+    width: max-content;
+    max-width: 220px;
 
     box-shadow: 0px 0px 115px 0px rgba(0, 0, 0, 0.35);
 `;


### PR DESCRIPTION
Issue: 

The "No transactions found" state was not updated to match the new ui. 

![54417](https://github.com/user-attachments/assets/e3cef189-8625-4d56-8ffe-dcfb12b9fbdf)

Fix:

Here's how it should look.

![image](https://github.com/user-attachments/assets/23428cbc-a8b0-4ae2-be5b-71bf13f9810e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance and layout of the loading text in the transaction history, including adjustments to spacing and width for improved display.
- **Refactor**
  - Replaced the component used for displaying the empty state message in the transaction history for consistency with loading animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->