### PR TITLE
fix(ui): fix layout shift caused by the video on the setup screen

### DIFF
--- a/src/containers/main/Sync/sync.styles.ts
+++ b/src/containers/main/Sync/sync.styles.ts
@@ -49,8 +49,10 @@ export const HeaderGraphic = styled.div`
     width: min(220px, 24vh);
     user-select: none;
     max-width: 100%;
+
     video {
-        max-width: 100%;
+        width: 169px;
+        height: 176px;
     }
 `;
 


### PR DESCRIPTION
There was a jump / layout shift on the setup screen caused by the video loading in. This is a simple fix. 

![CleanShot 2025-05-09 at 14 39 44@2x](https://github.com/user-attachments/assets/5257850d-a116-4f2c-bdc8-8fee71d14d79)
