### PR TITLE
feat: add newly mined block server call

### DIFF
--- a/src-tauri/src/airdrop.rs
+++ b/src-tauri/src/airdrop.rs
@@ -21,10 +21,17 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use log::{info, warn};
+use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
 
-use crate::{mm_proxy_adapter::MergeMiningProxyConfig, UniverseAppState};
+use crate::{
+    configs::{config_core::ConfigCore, trait_config::ConfigImpl},
+    mm_proxy_adapter::MergeMiningProxyConfig,
+    tasks_tracker::TasksTrackers,
+    UniverseAppState,
+};
 
 const LOG_TARGET: &str = "tari::universe::airdrop";
 
@@ -36,6 +43,14 @@ pub struct AirdropAccessToken {
     pub provider: String,
     pub role: String,
     pub scope: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirdropMinedBlockMessage {
+    pub hashed_view_private_key: String,
+    pub app_id: String,
+    pub block_height: u64,
 }
 
 pub fn decode_jwt_claims(t: &str) -> Option<AirdropAccessToken> {
@@ -115,4 +130,41 @@ pub async fn restart_mm_proxy_with_new_telemetry_id(
         .map_err(|e| e.to_string());
     info!(target: LOG_TARGET, "mm_proxy restarted");
     Ok(())
+}
+
+pub async fn send_new_block_mined(app: AppHandle, block_height: u64) {
+    TasksTrackers::current().wallet_phase.get_task_tracker().await.spawn(async move {
+        let wallet_manager = app.state::<UniverseAppState>().wallet_manager.clone();
+        let app_in_config_memory = app.state::<UniverseAppState>().in_memory_config.clone();
+        let config = ConfigCore::content().await;
+        let app_id = config.anon_id().to_string();
+
+        let view_private_key = wallet_manager.get_view_private_key().await;
+        let hashed_view_private_key = hex::encode(Sha256::digest(view_private_key));
+
+        let client = reqwest::Client::new();
+        let base_url = app_in_config_memory.read().await.airdrop_api_url.clone();
+        let url = format!("{}/miner/mined-block", base_url);
+        let message = AirdropMinedBlockMessage {
+            hashed_view_private_key,
+            app_id,
+            block_height
+        };
+        if let Ok(response) = client
+            .post(url)
+            .json(&message)
+            .send()
+            .await
+            .inspect_err(|e| {
+                error!("error at sending newly mined block to /miner/mined-block {}", e.to_string());
+            })
+        {
+            let status = response.status();
+            if status.is_success() {
+                info!(target:LOG_TARGET," successfully sent newly mined block data to /miner/mined-block");
+            } else {
+                error!(target:LOG_TARGET,"error at sending to /miner/mined-block {:?}",response.text().await);
+            }
+        }
+    });
 }

--- a/src-tauri/src/airdrop.rs
+++ b/src-tauri/src/airdrop.rs
@@ -48,7 +48,7 @@ pub struct AirdropAccessToken {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AirdropMinedBlockMessage {
-    pub hashed_view_private_key: String,
+    pub wallet_view_key_hashed: String,
     pub app_id: String,
     pub block_height: u64,
 }
@@ -150,7 +150,7 @@ pub async fn send_new_block_mined(app: AppHandle, block_height: u64) {
         let base_url = app_in_config_memory.read().await.airdrop_api_url.clone();
         let url = format!("{}/miner/mined-block", base_url);
         let message = AirdropMinedBlockMessage {
-            hashed_view_private_key,
+            wallet_view_key_hashed: hashed_view_private_key,
             app_id,
             block_height
         };

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -72,15 +72,17 @@ impl EventsManager {
                         } else {
                             None
                         };
-
+                        
                         EventsEmitter::emit_new_block_mined(
                             &app_clone,
                             block_height,
-                            coinbase_tx,
+                            coinbase_tx.clone(),
                             Some(balance),
                         )
                         .await;
-                        send_new_block_mined(app_clone.clone(), block_height).await;
+                        if coinbase_tx.is_some() {
+                            send_new_block_mined(app_clone.clone(), block_height).await;
+                        }
                     } else {
                         error!(target: LOG_TARGET, "Wallet balance is None after new block height #{}", block_height);
                         EventsEmitter::emit_new_block_mined(

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -26,6 +26,7 @@ use log::error;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tauri::{AppHandle, Manager};
 
+use crate::airdrop::send_new_block_mined;
 use crate::configs::config_mining::ConfigMiningContent;
 use crate::configs::config_wallet::ConfigWalletContent;
 use crate::events::ConnectionStatusPayload;
@@ -79,6 +80,7 @@ impl EventsManager {
                             Some(balance),
                         )
                         .await;
+                        send_new_block_mined(app_clone.clone(), block_height).await;
                     } else {
                         error!(target: LOG_TARGET, "Wallet balance is None after new block height #{}", block_height);
                         EventsEmitter::emit_new_block_mined(

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::airdrop;
+use crate::airdrop::get_wallet_view_key_hashed;
 use crate::app_config::MiningMode;
 use crate::app_in_memory_config::AppInMemoryConfig;
 use crate::commands::CpuMinerStatus;
@@ -199,6 +200,7 @@ pub struct TelemetryData {
     pub download_speed: f64,
     pub upload_speed: f64,
     pub latency: f64,
+    pub wallet_view_key_hashed: String,
 }
 
 pub struct TelemetryManager {
@@ -323,7 +325,7 @@ impl TelemetryManager {
                         let airdrop_access_token = airdrop_tokens.map(|tokens| tokens.token);
                         if allow_telemetry {
                             let airdrop_access_token_validated = airdrop::validate_jwt(airdrop_access_token).await;
-                            let telemetry_data = cancellable_get_telemetry_data(&cpu_miner_status_watch_rx, &gpu_status, &node_status, &p2pool_status,
+                            let telemetry_data = cancellable_get_telemetry_data(app_handle.clone(),&cpu_miner_status_watch_rx, &gpu_status, &node_status, &p2pool_status,
                                 &tor_status, network, uptime, &stats_collector, &node_manager, &mut (shutdown_signal.clone())).await;
                             let airdrop_api_url = in_memory_config_cloned.read().await.airdrop_api_url.clone();
                             handle_telemetry_data(telemetry_data, airdrop_api_url, airdrop_access_token_validated, app_handle.clone(), &mut (shutdown_signal.clone())).await;
@@ -342,6 +344,7 @@ impl TelemetryManager {
 
 #[allow(clippy::too_many_arguments)]
 async fn cancellable_get_telemetry_data(
+    app_handle: tauri::AppHandle,
     cpu_miner_status_watch_rx: &watch::Receiver<CpuMinerStatus>,
     gpu_latest_miner_stats: &watch::Receiver<GpuMinerStatus>,
     node_latest_status: &watch::Receiver<BaseNodeStatus>,
@@ -353,7 +356,7 @@ async fn cancellable_get_telemetry_data(
     node_manager: &NodeManager,
     shutdown_signal: &mut ShutdownSignal,
 ) -> Result<TelemetryData, TelemetryManagerError> {
-    tokio::select! {result = get_telemetry_data(cpu_miner_status_watch_rx, gpu_latest_miner_stats, node_latest_status, p2pool_latest_status, tor_latest_status, network, started, stats_collector, node_manager) => {
+    tokio::select! {result = get_telemetry_data(app_handle.clone(),cpu_miner_status_watch_rx, gpu_latest_miner_stats, node_latest_status, p2pool_latest_status, tor_latest_status, network, started, stats_collector, node_manager) => {
             result
         }
         _ = shutdown_signal.wait() => {
@@ -365,6 +368,7 @@ async fn cancellable_get_telemetry_data(
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::too_many_arguments)]
 async fn get_telemetry_data(
+    app_handle: tauri::AppHandle,
     cpu_miner_status_watch_rx: &watch::Receiver<CpuMinerStatus>,
     gpu_latest_miner_stats: &watch::Receiver<GpuMinerStatus>,
     node_latest_status: &watch::Receiver<BaseNodeStatus>,
@@ -382,6 +386,7 @@ async fn get_telemetry_data(
         ..
     } = *node_latest_status.borrow();
 
+    let wallet_view_key_hashed = get_wallet_view_key_hashed(app_handle.clone()).await;
     let cpu_miner_status = cpu_miner_status_watch_rx.borrow().clone();
     let gpu_status = gpu_latest_miner_stats.borrow().clone();
     let config = ConfigCore::content().await;
@@ -676,6 +681,7 @@ async fn get_telemetry_data(
         download_speed,
         upload_speed,
         latency,
+        wallet_view_key_hashed,
     };
     Ok(data)
 }

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -145,6 +145,10 @@ impl WalletManager {
         process_watcher.adapter.spend_key = spend_key;
     }
 
+    pub async fn get_view_private_key(&self) -> String {
+        self.watcher.read().await.adapter.view_private_key.clone()
+    }
+
     pub fn is_initial_scan_completed(&self) -> bool {
         self.initial_scan_completed
             .load(std::sync::atomic::Ordering::Relaxed)


### PR DESCRIPTION
Description
---

Adds better wallet-based push notification based on wallet info.

Motivation and Context
---

How Has This Been Tested?
---

Locally

What process can a PR reviewer use to test or verify this change?
---

Hard to test

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reporting of newly mined blocks to an external airdrop API, including wallet and block information.
  - Enhanced telemetry data to include a hashed wallet view key for improved traceability.

- **Bug Fixes**
  - Improved logging for error handling during API requests.

- **Other Improvements**
  - Added a method to retrieve the wallet's view private key for internal processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->