### PR TITLE
fix: wallet balance validation when sending

### DIFF
--- a/src/components/transactions/wallet/Wallet.tsx
+++ b/src/components/transactions/wallet/Wallet.tsx
@@ -35,6 +35,7 @@ const Wallet = memo(function Wallet({ section, setSection }: Props) {
     const uiSendRecvEnabled = useAirdropStore((s) => s.uiSendRecvEnabled);
     const setShowPaperWalletModal = usePaperWalletStore((s) => s.setShowModal);
     const walletAddress = useWalletStore((state) => state.tari_address_base58);
+    const availableBalance = useWalletStore((s) => s.balance?.available_balance);
     const displayAddress = truncateMiddle(walletAddress, 4);
 
     const { isWalletScanning, formattedAvailableBalance } = useTariBalance();
@@ -71,7 +72,7 @@ const Wallet = memo(function Wallet({ section, setSection }: Props) {
                             onClick={() => setSection('send')}
                             $isActive={section === 'send'}
                             aria-selected={section === 'send'}
-                            disabled={isWalletScanning}
+                            disabled={isWalletScanning || !availableBalance}
                         >
                             <NavButtonContent>
                                 <SendSVG />


### PR DESCRIPTION
Description
---
* disable send button when no available balance
* instead of relying on the global `isValid` flag, track the validity of individual fields.
* dont allow sending tx when no available balance

Motivation
---
When you update one input (e.g., `address`), `react-hook-form` re-runs the validation for all fields in the form. If another field (e.g., `amount`) has an error or is invalid, the `isValid` flag will be set to `false`

![image](https://github.com/user-attachments/assets/ac08f953-dd22-4ac3-ae36-9e6bebb73c32)
