### PR TITLE
fix: pending tx timestamp

### DIFF
--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -66,7 +66,7 @@ export const addPendingTransaction = (payload: { amount: number; destination: st
         payment_id: payload.paymentId,
         direction: 2,
         status: 1,
-        timestamp: Date.now(),
+        timestamp: Math.floor(Date.now() / 1000),
     };
 
     useWalletStore.setState((state) => ({


### PR DESCRIPTION
Description
---
Pending tx was using milliseconds instead of seconds

Before
--
![Screenshot from 2025-05-12 08-04-30](https://github.com/user-attachments/assets/d4271c64-9832-4597-a793-128adc1d95ac)

After
--
![Screenshot from 2025-05-12 08-31-28](https://github.com/user-attachments/assets/1c4ccb7e-6c9d-469f-92ca-5da3dac0a5e4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of transaction timestamps by recording them in seconds instead of milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->