### PR TITLE
fix(ui): available balance not hidden + ruler mark numbers

### DIFF
--- a/src/containers/main/Dashboard/MiningView/components/Ruler.tsx
+++ b/src/containers/main/Dashboard/MiningView/components/Ruler.tsx
@@ -35,7 +35,7 @@ export function Ruler() {
         const renderNumber = heightSegment && heightSegment > diff;
 
         if (renderNumber && heightSegment) {
-            heightSegment -= diff;
+            heightSegment = heightSegment - diff * (i + 1);
         }
 
         const prevSegment = (heightSegment || 0) + diff;

--- a/src/hooks/wallet/useTariBalance.ts
+++ b/src/hooks/wallet/useTariBalance.ts
@@ -15,7 +15,9 @@ function useTariBalance() {
     const formattedBalance = formatNumber(calculated_balance || 0, FormatPreset.XTM_COMPACT);
     const formattedLongBalance = formatNumber(calculated_balance || 0, FormatPreset.XTM_LONG);
     const numericAvailableBalance = Number(Math.floor((balance?.available_balance || 0) / 1_000_000).toFixed(2));
-    const formattedAvailableBalance = formatNumber(available_balance || 0, FormatPreset.XTM_LONG);
+    const formattedAvailableBalance = hideWalletBalance
+        ? '****'
+        : formatNumber(available_balance || 0, FormatPreset.XTM_LONG);
 
     const isWalletScanning = useWalletStore((s) => s.wallet_scanning?.is_scanning);
 


### PR DESCRIPTION
Description
---

- hide available balance too
- fix the decrement(sp.?) on block height ruler display

Motivation and Context
---
- https://github.com/tari-project/universe/issues/2089
- and @PanchoBubble noticed and LMK

How Has This Been Tested?
---


| before | after |
| :---: | :---: |
| ![optimised_13-05_14-46_369](https://github.com/user-attachments/assets/cd17e045-de8b-4c32-96de-14079c56d157) | ![optimised_13-05_14-41_365](https://github.com/user-attachments/assets/13606928-9583-45be-a5d6-1201def32145) |
| ![optimised_13-05_14-45_368](https://github.com/user-attachments/assets/20745daa-08dd-45df-958d-95643f118130) | ![optimised_13-05_14-41_366](https://github.com/user-attachments/assets/68e3eca6-0798-40b1-9058-9d6faa0e5aa5) |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of ruler segment spacing and displayed values in the mining dashboard view.
  - Wallet balance display now properly masks the available balance with asterisks when the privacy setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->