### PR TITLE
fix(ui): x spaces notification overlapping with the mainnet banner

### DIFF
--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -5,8 +5,8 @@ import styled, { css } from 'styled-components';
 
 export const BannerContent = styled(m.div)`
     position: fixed;
-    top: 16px;
-    right: 32px;
+    top: 86px;
+    right: 10px;
     z-index: 99999;
     display: flex;
     align-items: center;


### PR DESCRIPTION
The `X` spaces announcement banner was overlapping with the `Mainnet Live` banner. I just moved it down.

Note: When the MainNet banner is removed we'll need to manually adjust this notification again so it appears in the top right. 

Issue:

![CleanShot 2025-05-14 at 15 05 50@2x](https://github.com/user-attachments/assets/1931ad18-4a72-47e9-97ca-3f09c175b09a)

Fixed:

![CleanShot 2025-05-14 at 15 01 31@2x](https://github.com/user-attachments/assets/a0ef322f-1c3f-4c8a-a6e4-7d70d9131d4c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the position of the banner, moving it further down and closer to the right edge of the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->