### PR TITLE
feat: exchange multiple ci

### DIFF
--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -31,7 +31,7 @@ jobs:
           echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT
   builds:
     needs: read-exchanges
-    name: Building ${{ matrix.platform }}${{ matrix.extra }}
+    name: Building ${{ matrix.exchange }} ${{ matrix.platform }}${{ matrix.extra }}
     # best effort disabled by default
     continue-on-error: ${{ matrix.best_effort || false }}
     permissions:
@@ -40,10 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS) }}
-        name: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_NAMES) }}
-        include:
-          - exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS)[0] }}
-            name: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_NAMES)[0] }}
+        platforms:
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
             extra: '-x64'
@@ -62,7 +59,7 @@ jobs:
             args: '--bundles msi'
           - platform: 'macos-latest'
             args: '--target universal-apple-darwin'
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platforms.platform }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: Release-Exchange
 
 'on':
   workflow_dispatch:

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -213,8 +213,8 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
           EXCHANGE_ID: ${{ matrix.exchange.id }}
         with:
-          tagName: ${{ env.tagName }}
-          releaseName: ${{ env.releaseName }}
+          # tagName: ${{ env.tagName }}
+          # releaseName: ${{ env.releaseName }}
           releaseBody: 'Tari Universe - See the assets to download this version and install'
           releaseDraft: false
           prerelease: true

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -31,7 +31,7 @@ jobs:
           echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT
   builds:
     needs: read-exchanges
-    name: Building ${{ matrix.exchange }} ${{ matrix.platform }}${{ matrix.extra }}
+    name: Building ${{ matrix.exchange }}${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
     # best effort disabled by default
     continue-on-error: ${{ matrix.best_effort || false }}
     permissions:

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -3,6 +3,22 @@ name: Release-Exchange
 
 'on':
   workflow_dispatch:
+    inputs:
+      destination:
+        description: 'Artifacts destination'
+        required: true
+        type: choice
+        options:
+          - 'github'
+          - 'aws'
+      network:
+        description: 'Network to build for'
+        required: true
+        type: choice
+        options:
+          - 'mainnet'
+          - 'nextnet'
+          - 'esmeralda'
 
 concurrency:
   # https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix
@@ -41,21 +57,21 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
             extra: '-x64'
-          - platform: 'ubuntu-24.04-arm'
-            args: '--bundles deb,appimage'
-            best_effort: true
-          - platform: 'ubuntu-22.04'
-            args: '--bundles rpm'
-            extra: '-x64-rpm'
-            best_effort: true
-          - platform: 'ubuntu-24.04-arm'
-            args: '--bundles rpm'
-            extra: '-rpm'
-            best_effort: true
-          - platform: 'windows-latest'
-            args: '--bundles msi'
-          - platform: 'macos-latest'
-            args: '--target universal-apple-darwin'
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles deb,appimage'
+          #   best_effort: true
+          # - platform: 'ubuntu-22.04'
+          #   args: '--bundles rpm'
+          #   extra: '-x64-rpm'
+          #   best_effort: true
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles rpm'
+          #   extra: '-rpm'
+          #   best_effort: true
+          # - platform: 'windows-latest'
+          #   args: '--bundles msi'
+          # - platform: 'macos-latest'
+          #   args: '--target universal-apple-darwin'
     runs-on: ${{ matrix.platforms.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +95,7 @@ jobs:
         shell: bash
         run: |
           #set -xueo pipefail
-          echo "TARI_NETWORK=mainnet" >> $GITHUB_ENV
+          echo "TARI_NETWORK=${{ inputs.network }}" >> $GITHUB_ENV
           echo "TARI_TARGET_NETWORK=mainnet" >> $GITHUB_ENV
           echo "AIRDROP_WEBSOCKET_CRYPTO_KEY=${{ env.AIRDROP_WEBSOCKET_CRYPTO_KEY }}" >> $GITHUB_ENV
           cd "${GITHUB_WORKSPACE}/src-tauri"
@@ -325,13 +341,6 @@ jobs:
             exit 1
           }
 
-      - name: Bundled Windows installer upload
-        if: ${{ startsWith(runner.os,'Windows') && ( ! startsWith(github.ref, 'refs/heads/release') ) }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{matrix.exchange.id}}_${{ steps.build.outputs.appVersion }}_x64_en-US
-          path: ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe
-
       - name: Locate artifacts path
         continue-on-error: true
         env:
@@ -342,12 +351,91 @@ jobs:
           MSI_FILE=$( echo '${{ env.artifactPaths }}' | jq -r '[.[] | select(endswith(".msi"))] | join(" ")' )
           echo "MSI_FILE=$MSI_FILE" >> $GITHUB_ENV
 
-      - name: Builds - Upload assets
-        if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
+      - name: Builds - Upload assets [ GitHub ]
+        if: ${{( startsWith(inputs.destination, 'github' )) }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.exchange.id}}_${{ steps.build.outputs.appVersion }}_${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
           path: "${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }}"
+
+      - name: Bundled Windows installer upload [ GitHub ]
+        if: ${{ startsWith(runner.os,'Windows') && ( startsWith(inputs.destination, 'github' ) ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.exchange.id}}_${{ steps.build.outputs.appVersion }}_x64_en-US
+          path: ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe
+
+      - name: Builds - Upload assets [ AWS ]
+        if: ${{( startsWith(inputs.destination, 'aws' )) && ( env.AWS_SECRET_ACCESS_KEY != '' ) && runner.name != 'self-hosted' }}
+        env:
+          BASE_URL: ${{ secrets.BASE_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          EXCHANGE_NAME: ${{ secrets[matrix.exchange.secret_name] }}
+          S3CMD: 'cp'
+          S3OPTIONS: '--content-type "application/octet-stream"'
+        run: |
+          docker run --rm -t \
+            -v ${PWD}:/work/data \
+            -w /work/data \
+            -e AWS_ACCESS_KEY_ID="${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e AWS_SECRET_ACCESS_KEY="${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e AWS_ENDPOINT_URL="${{ env.AWS_ENDPOINT_URL }}" \
+            -e AWS_DEFAULT_REGION="WEUR" \
+            amazon/aws-cli:2.22.35 \
+              s3 ${{ env.S3CMD }} ${{ env.S3OPTIONS }} \
+                ${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }} \
+                s3://${{ env.BASE_URL }}/exchanges/${{ steps.build.outputs.appVersion }}/${{ env.EXCHANGE_NAME }}/
+
+      - name: Bundled Windows installer upload [ AWS ]
+        if: ${{ ( startsWith(runner.os,'Windows') ) && ( startsWith(inputs.destination, 'aws' ) ) && ( env.AWS_SECRET_ACCESS_KEY != '' ) && runner.name != 'self-hosted' }}
+        env:
+          BASE_URL: ${{ secrets.BASE_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          EXCHANGE_NAME: ${{ secrets[matrix.exchange.secret_name] }}
+          S3CMD: 'cp'
+          S3OPTIONS: '--content-type "application/octet-stream"'
+        run: |
+          docker run --rm -t \
+            -v ${PWD}:/work/data \
+            -w /work/data \
+            -e AWS_ACCESS_KEY_ID="${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e AWS_SECRET_ACCESS_KEY="${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e AWS_ENDPOINT_URL="${{ env.AWS_ENDPOINT_URL }}" \
+            -e AWS_DEFAULT_REGION="WEUR" \
+            amazon/aws-cli:2.22.35 \
+              s3 ${{ env.S3CMD }} ${{ env.S3OPTIONS }} \
+                ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe \
+                s3://${{ env.BASE_URL }}/exchanges/${{ steps.build.outputs.appVersion }}/${{ env.EXCHANGE_NAME }}/
+
+      # - name: sync assets to S3
+      #   continue-on-error: true
+      #   if: ${{ env.AWS_SECRET_ACCESS_KEY != '' && runner.name != 'self-hosted' }}
+      #   env:
+      #     BASE_URL: ${{ secrets.BASE_URL }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #     S3CMD: 'cp'
+      #     S3OPTIONS: '--content-type "text/plain; charset=utf-8"'
+      #   run: |
+      #     docker run --rm -t \
+      #       -v ${PWD}:/work/data \
+      #       -w /work/data \
+      #       -e AWS_ACCESS_KEY_ID="${{ env.AWS_ACCESS_KEY_ID }}" \
+      #       -e AWS_SECRET_ACCESS_KEY="${{ env.AWS_SECRET_ACCESS_KEY }}" \
+      #       -e AWS_ENDPOINT_URL="${{ env.AWS_ENDPOINT_URL }}" \
+      #       -e AWS_DEFAULT_REGION="WEUR" \
+      #       amazon/aws-cli:2.22.35 \
+      #         s3 ${{ env.S3CMD }} ${{ env.S3OPTIONS }} \
+      #           CHANGELOG.md \
+      #           s3://${{ env.BASE_URL }}/
 
       - name: Windows debug symbols - Upload asset
         if: startsWith(runner.os,'Windows')

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -329,7 +329,7 @@ jobs:
         if: ${{ startsWith(runner.os,'Windows') && ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         uses: actions/upload-artifact@v4
         with:
-          name: tari-universe_${{ steps.build.outputs.appVersion }}_x64_en-US
+          name: ${{matrix.exchange.id}}_${{ steps.build.outputs.appVersion }}_x64_en-US
           path: ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe
 
       - name: Locate artifacts path
@@ -346,7 +346,7 @@ jobs:
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         uses: actions/upload-artifact@v4
         with:
-          name: tari-universe_${{ steps.build.outputs.appVersion }}_${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
+          name: ${{matrix.exchange.id}}_${{ steps.build.outputs.appVersion }}_${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
           path: "${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }}"
 
       - name: Windows debug symbols - Upload asset

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -87,9 +87,9 @@ jobs:
           # Don't mess with the double quotes and inner escaped quotes
           yq eval ".productName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
           yq eval ".mainBinaryName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
-          yq eval ".app.windows[0].title = \"${{ secrets[matrix.exchange.secret_name]}} v${TU_VERSION}\"" --output-format=json -i tauri.conf.json
+          yq eval ".app.windows[0].title = \"Tari Universe v${TU_VERSION} - ${{ secrets[matrix.exchange.secret_name]}}\"" --output-format=json -i tauri.conf.json
           yq eval ".identifier = \"com.tari.universe\"" --output-format=json -i tauri.conf.json
-          yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\", \"https://cdn-universe.tari.com/tari-project/universe/updater/latest.json\"]" \
+          yq eval ".plugins.updater.endpoints = [\"https://cdn-universe.tari.com/tari-project/universe/updater/\(env(exchange.id))/latest.json\"]" \
             --output-format=json -i tauri.conf.json
 
       - name: Setup Node

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -57,21 +57,21 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
             extra: '-x64'
-          # - platform: 'ubuntu-24.04-arm'
-          #   args: '--bundles deb,appimage'
-          #   best_effort: true
-          # - platform: 'ubuntu-22.04'
-          #   args: '--bundles rpm'
-          #   extra: '-x64-rpm'
-          #   best_effort: true
-          # - platform: 'ubuntu-24.04-arm'
-          #   args: '--bundles rpm'
-          #   extra: '-rpm'
-          #   best_effort: true
-          # - platform: 'windows-latest'
-          #   args: '--bundles msi'
-          # - platform: 'macos-latest'
-          #   args: '--target universal-apple-darwin'
+          - platform: 'ubuntu-24.04-arm'
+            args: '--bundles deb,appimage'
+            best_effort: true
+          - platform: 'ubuntu-22.04'
+            args: '--bundles rpm'
+            extra: '-x64-rpm'
+            best_effort: true
+          - platform: 'ubuntu-24.04-arm'
+            args: '--bundles rpm'
+            extra: '-rpm'
+            best_effort: true
+          - platform: 'windows-latest'
+            args: '--bundles msi'
+          - platform: 'macos-latest'
+            args: '--target universal-apple-darwin'
     runs-on: ${{ matrix.platforms.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -413,30 +413,6 @@ jobs:
                 ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe \
                 s3://${{ env.BASE_URL }}/exchanges/${{ steps.build.outputs.appVersion }}/${{ env.EXCHANGE_NAME }}/
 
-      # - name: sync assets to S3
-      #   continue-on-error: true
-      #   if: ${{ env.AWS_SECRET_ACCESS_KEY != '' && runner.name != 'self-hosted' }}
-      #   env:
-      #     BASE_URL: ${{ secrets.BASE_URL }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      #     S3CMD: 'cp'
-      #     S3OPTIONS: '--content-type "text/plain; charset=utf-8"'
-      #   run: |
-      #     docker run --rm -t \
-      #       -v ${PWD}:/work/data \
-      #       -w /work/data \
-      #       -e AWS_ACCESS_KEY_ID="${{ env.AWS_ACCESS_KEY_ID }}" \
-      #       -e AWS_SECRET_ACCESS_KEY="${{ env.AWS_SECRET_ACCESS_KEY }}" \
-      #       -e AWS_ENDPOINT_URL="${{ env.AWS_ENDPOINT_URL }}" \
-      #       -e AWS_DEFAULT_REGION="WEUR" \
-      #       amazon/aws-cli:2.22.35 \
-      #         s3 ${{ env.S3CMD }} ${{ env.S3OPTIONS }} \
-      #           CHANGELOG.md \
-      #           s3://${{ env.BASE_URL }}/
-
       - name: Windows debug symbols - Upload asset
         if: startsWith(runner.os,'Windows')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -38,12 +38,12 @@ jobs:
       matrix:
         exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS) }}
         platforms:
-          # - platform: 'ubuntu-22.04'
-          #   args: '--bundles deb,appimage'
-          #   extra: '-x64'
-          - platform: 'ubuntu-24.04-arm'
+          - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
-            best_effort: true
+            extra: '-x64'
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles deb,appimage'
+          #   best_effort: true
           # - platform: 'ubuntu-22.04'
           #   args: '--bundles rpm'
           #   extra: '-x64-rpm'

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -89,7 +89,7 @@ jobs:
           yq eval ".mainBinaryName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
           yq eval ".app.windows[0].title = \"Tari Universe v${TU_VERSION} - ${{ secrets[matrix.exchange.secret_name]}}\"" --output-format=json -i tauri.conf.json
           yq eval ".identifier = \"com.tari.universe\"" --output-format=json -i tauri.conf.json
-          yq eval ".plugins.updater.endpoints = [\"https://cdn-universe.tari.com/tari-project/universe/updater/\(env(exchange.id))/latest.json\"]" \
+          yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\", \"https://cdn-universe.tari.com/tari-project/universe/updater/latest.json\"]" \
             --output-format=json -i tauri.conf.json
 
       - name: Setup Node

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -72,7 +72,6 @@ jobs:
           sudo bash ./scripts/check-get-yq.sh
 
       - name: Set environment variables
-        if: ${{ startsWith(github.ref, 'refs/heads/release') }}
         env:
           AIRDROP_WEBSOCKET_CRYPTO_KEY: ${{ secrets.PROD_AIRDROP_WEBSOCKET_CRYPTO_KEY }}
           # Used for linux formatting

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -18,6 +18,7 @@ jobs:
     name: Read exchanges
     outputs:
       EXCHANGES_IDS: ${{ steps.read-exchanges.outputs.EXCHANGES_IDS }}
+      EXCHANGES_NAMES: ${{ steps.read-exchanges.outputs.EXCHANGES_NAMES }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,8 +26,9 @@ jobs:
         id: read-exchanges
         run: |
           EXCHANGES_IDS=$(jq -c '.exchanges | map(.id)' exchanges.json)
+          EXCHANGES_NAMES=$(jq -c '.exchanges | map(.secret_name)' exchanges.json)
           echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
-
+          echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT
   builds:
     needs: read-exchanges
     name: Building ${{ matrix.platform }}${{ matrix.extra }}
@@ -38,7 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS) }}
+        name: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_NAMES) }}
         include:
+          - exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS)[0] }}
+            name: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_NAMES)[0] }}
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
             extra: '-x64'

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -14,6 +14,18 @@ env:
   TS_FEATURES: release-ci
 
 jobs:
+  read-exchanges:
+    name: Read exchanges
+    outputs:
+      EXCHANGES_IDS: ${{ steps.read-exchanges.outputs.EXCHANGES_IDS }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read exchanges
+        id: read-exchanges
+        run: |
+          EXCHANGES_IDS=$(jq -c '.exchanges | map(.id)' exchanges.json)
+          echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
+
   builds:
     name: Building ${{ matrix.platform }}${{ matrix.extra }}
     # best effort disabled by default
@@ -23,6 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS) }}
         include:
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
@@ -203,7 +216,7 @@ jobs:
           tagName: ${{ env.tagName }}
           releaseName: ${{ env.releaseName }}
           releaseBody: 'Tari Universe - See the assets to download this version and install'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: true
           includeDebug: false
           includeRelease: true
@@ -318,19 +331,12 @@ jobs:
             exit 1
           }
 
-      - name: Add bundled Windows installer to release
-        if: ${{ startsWith(runner.os,'Windows') && startsWith(github.ref, 'refs/heads/release') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          gh release view "v${{ steps.build.outputs.appVersion }}"
-          cd tari-win-bundler
-          ls -la "${{ env.TARI_UNIVERSE_BUNDLER_NAME }}.exe"
-          gh release view "v${{ steps.build.outputs.appVersion }}"
-          gh release upload "v${{ steps.build.outputs.appVersion }}" \
-            "${{ env.TARI_UNIVERSE_BUNDLER_NAME }}.exe"
-          gh release view "v${{ steps.build.outputs.appVersion }}"
+      - name: Bundled Windows installer upload
+        if: ${{ startsWith(runner.os,'Windows') && ( ! startsWith(github.ref, 'refs/heads/release') ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tari-universe_${{ steps.build.outputs.appVersion }}_x64_en-US
+          path: ./tari-win-bundler/${{ env.TARI_UNIVERSE_BUNDLER_NAME }}*.exe
 
       - name: Locate artifacts path
         continue-on-error: true
@@ -341,6 +347,13 @@ jobs:
           echo -e "Artifact paths: \n${{ join(fromJSON( env.artifactPaths ), '\n') }}"
           MSI_FILE=$( echo '${{ env.artifactPaths }}' | jq -r '[.[] | select(endswith(".msi"))] | join(" ")' )
           echo "MSI_FILE=$MSI_FILE" >> $GITHUB_ENV
+
+      - name: Builds - Upload assets
+        if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tari-universe_${{ steps.build.outputs.appVersion }}_${{ matrix.platform }}${{ matrix.extra }}
+          path: "${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }}"
 
       - name: Windows debug symbols - Upload asset
         if: startsWith(runner.os,'Windows')

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -20,6 +20,7 @@ jobs:
       EXCHANGES_IDS: ${{ steps.read-exchanges.outputs.EXCHANGES_IDS }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Read exchanges
         id: read-exchanges
         run: |
@@ -27,6 +28,7 @@ jobs:
           echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
 
   builds:
+    needs: read-exchanges
     name: Building ${{ matrix.platform }}${{ matrix.extra }}
     # best effort disabled by default
     continue-on-error: ${{ matrix.best_effort || false }}

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Read exchanges
         id: read-exchanges
         run: |
-          EXCHANGES_IDS=$(jq -c '.exchanges)' exchanges.json)
+          EXCHANGES_IDS=$(jq -c '.exchanges' exchanges.json)
           EXCHANGES_NAMES=$(jq -c '.exchanges | map(.secret_name)' exchanges.json)
           echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
           echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -41,21 +41,21 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: '--bundles deb,appimage'
             extra: '-x64'
-          # - platform: 'ubuntu-24.04-arm'
-          #   args: '--bundles deb,appimage'
-          #   best_effort: true
-          # - platform: 'ubuntu-22.04'
-          #   args: '--bundles rpm'
-          #   extra: '-x64-rpm'
-          #   best_effort: true
-          # - platform: 'ubuntu-24.04-arm'
-          #   args: '--bundles rpm'
-          #   extra: '-rpm'
-          #   best_effort: true
-          # - platform: 'windows-latest'
-          #   args: '--bundles msi'
-          # - platform: 'macos-latest'
-          #   args: '--target universal-apple-darwin'
+          - platform: 'ubuntu-24.04-arm'
+            args: '--bundles deb,appimage'
+            best_effort: true
+          - platform: 'ubuntu-22.04'
+            args: '--bundles rpm'
+            extra: '-x64-rpm'
+            best_effort: true
+          - platform: 'ubuntu-24.04-arm'
+            args: '--bundles rpm'
+            extra: '-rpm'
+            best_effort: true
+          - platform: 'windows-latest'
+            args: '--bundles msi'
+          - platform: 'macos-latest'
+            args: '--target universal-apple-darwin'
     runs-on: ${{ matrix.platforms.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -18,7 +18,6 @@ jobs:
     name: Read exchanges
     outputs:
       EXCHANGES_IDS: ${{ steps.read-exchanges.outputs.EXCHANGES_IDS }}
-      EXCHANGES_NAMES: ${{ steps.read-exchanges.outputs.EXCHANGES_NAMES }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,14 +25,12 @@ jobs:
         id: read-exchanges
         run: |
           EXCHANGES_IDS=$(jq -c '.exchanges' exchanges.json)
-          EXCHANGES_NAMES=$(jq -c '.exchanges | map(.secret_name)' exchanges.json)
           echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
-          echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT
   builds:
     needs: read-exchanges
-    name: Building ${{ matrix.exchange.secret_name }} | ${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
+    name: Building ${{ matrix.exchange.id }} | ${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
     # best effort disabled by default
-    continue-on-error: ${{ matrix.best_effort || false }}
+    continue-on-error: ${{ matrix.platforms.best_effort || false }}
     permissions:
       contents: write
     strategy:
@@ -95,7 +92,7 @@ jobs:
           # Don't mess with the double quotes and inner escaped quotes
           yq eval ".productName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
           yq eval ".mainBinaryName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
-          yq eval ".app.windows[0].title = \"${{ secrets.EXCHANGE_NAME}} v${TU_VERSION}\"" --output-format=json -i tauri.conf.json
+          yq eval ".app.windows[0].title = \"${{ secrets[matrix.exchange.secret_name]}} v${TU_VERSION}\"" --output-format=json -i tauri.conf.json
           yq eval ".identifier = \"com.tari.universe\"" --output-format=json -i tauri.conf.json
           yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\", \"https://cdn-universe.tari.com/tari-project/universe/updater/latest.json\"]" \
             --output-format=json -i tauri.conf.json
@@ -109,7 +106,7 @@ jobs:
       - name: Rust Setup
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platforms.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Cache Cargo files and outputs
         if: ${{ ( ! startsWith(github.ref, 'refs/heads/release') ) && ( ! startsWith(github.ref, 'refs/tags/v') ) }}
@@ -130,7 +127,7 @@ jobs:
             protobuf-compiler
 
       - name: Install Dependencies - Linux/AppImage
-        if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.args, 'appimage') ) }}
+        if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.platforms.args, 'appimage') ) }}
         run: |
           sudo apt-get install --no-install-recommends --assume-yes \
             appstream
@@ -145,7 +142,7 @@ jobs:
         # We set "bundleMediaFramework" to true, it should bundle into appimage all needed libraries for playing videos
         # It requires us to set ARCH environment variable
       - name: BundleMediaFramework fix - [ Linux Appimage ]
-        if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.args, 'appimage') ) }}
+        if: ${{ ( startsWith(runner.os,'Linux') ) && ( contains(matrix.platforms.args, 'appimage') ) }}
         run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
       - name: Install Dependencies - macOS
@@ -215,7 +212,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           NODE_OPTIONS: '--max_old_space_size=4096'
-          EXCHANGE_ID: ${{ secrets.EXCHANGE_ID }}
+          EXCHANGE_ID: ${{ matrix.exchange.id }}
         with:
           tagName: ${{ env.tagName }}
           releaseName: ${{ env.releaseName }}
@@ -224,7 +221,7 @@ jobs:
           prerelease: true
           includeDebug: false
           includeRelease: true
-          args: ${{ matrix.args }} --features "${{ env.TS_FEATURES }}"
+          args: ${{ matrix.platforms.args }} --features "${{ env.TS_FEATURES }}"
 
       - name: Add msbuild to PATH (windows)
         uses: microsoft/setup-msbuild@v2
@@ -356,7 +353,7 @@ jobs:
         if: ${{ ( github.event_name == 'schedule' ) || ( ! startsWith(github.ref, 'refs/heads/release') ) }}
         uses: actions/upload-artifact@v4
         with:
-          name: tari-universe_${{ steps.build.outputs.appVersion }}_${{ matrix.platform }}${{ matrix.extra }}
+          name: tari-universe_${{ steps.build.outputs.appVersion }}_${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
           path: "${{ join(fromJSON(steps.build.outputs.artifactPaths), '\n') }}"
 
       - name: Windows debug symbols - Upload asset

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -79,10 +79,6 @@ jobs:
         shell: bash
         run: |
           #set -xueo pipefail
-          # Setup tauri action envs
-          echo "tagName=v__VERSION__" >> $GITHUB_ENV
-          echo "releaseName=Tari Universe v__VERSION__" >> $GITHUB_ENV
-          #echo "releaseId=" >> $GITHUB_ENV
           echo "TARI_NETWORK=mainnet" >> $GITHUB_ENV
           echo "TARI_TARGET_NETWORK=mainnet" >> $GITHUB_ENV
           echo "AIRDROP_WEBSOCKET_CRYPTO_KEY=${{ env.AIRDROP_WEBSOCKET_CRYPTO_KEY }}" >> $GITHUB_ENV
@@ -213,8 +209,6 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
           EXCHANGE_ID: ${{ matrix.exchange.id }}
         with:
-          # tagName: ${{ env.tagName }}
-          # releaseName: ${{ env.releaseName }}
           releaseBody: 'Tari Universe - See the assets to download this version and install'
           releaseDraft: false
           prerelease: true

--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Read exchanges
         id: read-exchanges
         run: |
-          EXCHANGES_IDS=$(jq -c '.exchanges | map(.id)' exchanges.json)
+          EXCHANGES_IDS=$(jq -c '.exchanges)' exchanges.json)
           EXCHANGES_NAMES=$(jq -c '.exchanges | map(.secret_name)' exchanges.json)
           echo "EXCHANGES_IDS=$EXCHANGES_IDS" >> $GITHUB_OUTPUT
           echo "EXCHANGES_NAMES=$EXCHANGES_NAMES" >> $GITHUB_OUTPUT
   builds:
     needs: read-exchanges
-    name: Building ${{ matrix.exchange }}${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
+    name: Building ${{ matrix.exchange.secret_name }} | ${{ matrix.platforms.platform }}${{ matrix.platforms.extra }}
     # best effort disabled by default
     continue-on-error: ${{ matrix.best_effort || false }}
     permissions:
@@ -41,24 +41,24 @@ jobs:
       matrix:
         exchange: ${{ fromJson(needs.read-exchanges.outputs.EXCHANGES_IDS) }}
         platforms:
-          - platform: 'ubuntu-22.04'
-            args: '--bundles deb,appimage'
-            extra: '-x64'
+          # - platform: 'ubuntu-22.04'
+          #   args: '--bundles deb,appimage'
+          #   extra: '-x64'
           - platform: 'ubuntu-24.04-arm'
             args: '--bundles deb,appimage'
             best_effort: true
-          - platform: 'ubuntu-22.04'
-            args: '--bundles rpm'
-            extra: '-x64-rpm'
-            best_effort: true
-          - platform: 'ubuntu-24.04-arm'
-            args: '--bundles rpm'
-            extra: '-rpm'
-            best_effort: true
-          - platform: 'windows-latest'
-            args: '--bundles msi'
-          - platform: 'macos-latest'
-            args: '--target universal-apple-darwin'
+          # - platform: 'ubuntu-22.04'
+          #   args: '--bundles rpm'
+          #   extra: '-x64-rpm'
+          #   best_effort: true
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles rpm'
+          #   extra: '-rpm'
+          #   best_effort: true
+          # - platform: 'windows-latest'
+          #   args: '--bundles msi'
+          # - platform: 'macos-latest'
+          #   args: '--target universal-apple-darwin'
     runs-on: ${{ matrix.platforms.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
           # Don't mess with the double quotes and inner escaped quotes
           yq eval ".productName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
           yq eval ".mainBinaryName = \"${{ env.OS_BINARY_NAME }}\"" --output-format=json -i tauri.conf.json
-          yq eval ".app.windows[0].title = \"${{ secrets.EXCHANGE_MINER_NAME}} v${TU_VERSION}\"" --output-format=json -i tauri.conf.json
+          yq eval ".app.windows[0].title = \"${{ secrets.EXCHANGE_NAME}} v${TU_VERSION}\"" --output-format=json -i tauri.conf.json
           yq eval ".identifier = \"com.tari.universe\"" --output-format=json -i tauri.conf.json
           yq eval ".plugins.updater.endpoints = [\"https://raw.githubusercontent.com/tari-project/universe/main/.updater/latest.json\", \"https://cdn-universe.tari.com/tari-project/universe/updater/latest.json\"]" \
             --output-format=json -i tauri.conf.json

--- a/exchanges.json
+++ b/exchanges.json
@@ -1,0 +1,8 @@
+{
+    "exchanges": [
+        {
+            "id": "46d881c4-c351-4d94-a070-d77c47fe8e71",
+            "secret_name": "yolo"
+        }
+    ]
+}

--- a/exchanges.json
+++ b/exchanges.json
@@ -6,7 +6,7 @@
         },
         {
             "id": "22d881c4-c351-4d94-a070-d77c47fe8e00",
-            "secret_name": "not-yolo"
+            "secret_name": "notyolo"
         }
     ]
 }

--- a/exchanges.json
+++ b/exchanges.json
@@ -1,10 +1,12 @@
 {
     "exchanges": [
         {
+            "order": 0,
             "id": "46d881c4-c351-4d94-a070-d77c47fe8e71",
             "secret_name": "yolo"
         },
         {
+            "order": 1,
             "id": "22d881c4-c351-4d94-a070-d77c47fe8e00",
             "secret_name": "not-yolo"
         }

--- a/exchanges.json
+++ b/exchanges.json
@@ -3,6 +3,10 @@
         {
             "id": "46d881c4-c351-4d94-a070-d77c47fe8e71",
             "secret_name": "yolo"
+        },
+        {
+            "id": "22d881c4-c351-4d94-a070-d77c47fe8e00",
+            "secret_name": "not-yolo"
         }
     ]
 }

--- a/exchanges.json
+++ b/exchanges.json
@@ -2,11 +2,11 @@
     "exchanges": [
         {
             "id": "46d881c4-c351-4d94-a070-d77c47fe8e71",
-            "secret_name": "yolo"
+            "secret_name": "b035a622"
         },
         {
             "id": "22d881c4-c351-4d94-a070-d77c47fe8e00",
-            "secret_name": "notyolo"
+            "secret_name": "aaa1e352"
         }
     ]
 }

--- a/exchanges.json
+++ b/exchanges.json
@@ -1,12 +1,10 @@
 {
     "exchanges": [
         {
-            "order": 0,
             "id": "46d881c4-c351-4d94-a070-d77c47fe8e71",
             "secret_name": "yolo"
         },
         {
-            "order": 1,
             "id": "22d881c4-c351-4d94-a070-d77c47fe8e00",
             "secret_name": "not-yolo"
         }


### PR DESCRIPTION
### [ Summary ]
- Added new job for reading exchanges.json
- Extended matrix to include all exchanges
- Added steps for uploading artifacts either to github or aws

### [ Before merge ]
- Adjust exchanges.json file with id that is present on cms
- Add repository secrets for each secret_name in the file

### [ TODO ]
- release-exchange.yml and release.yml have duplicated code, implement solution for it
- Handle updater files for each exchange miner 