### PR TITLE
fix: multi monero node addresses

### DIFF
--- a/src-tauri/src/mm_proxy_adapter.rs
+++ b/src-tauri/src/mm_proxy_adapter.rs
@@ -156,7 +156,7 @@ impl ProcessAdapter for MergeMiningProxyAdapter {
         shuffled_nodes.shuffle(&mut thread_rng());
         args.push("-p".to_string());
         args.push(format!(
-            "merge_mining_proxy.monerod_url=[{}]",
+            "merge_mining_proxy.monerod_url={}",
             shuffled_nodes.join(",")
         ));
 


### PR DESCRIPTION
Description
---
Multiple monero URL's were passed to the proxy in a strange format causing issues with the urls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of merge mining proxy URLs by updating their formatting in command-line arguments. URLs are now passed as a plain comma-separated list, eliminating unnecessary brackets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->