### PR TITLE
fix(exchange-miner): rely on single source of truth for tari wallet address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tari-universe",
-    "version": "1.0.8",
+    "version": "1.0.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "1.0.8",
+            "version": "1.0.10",
             "dependencies": {
                 "@floating-ui/react": "^0.27.7",
                 "@lottiefiles/dotlottie-react": "^0.13.2",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1535,7 +1535,14 @@ pub async fn start_mining<'r>(
         info!(target: LOG_TARGET, "3. Starting gpu miner");
 
         let cpu_miner_config = state.cpu_miner_config.read().await;
-        let tari_address = cpu_miner_config.tari_address.clone();
+        let config_path = app
+            .path()
+            .app_config_dir()
+            .expect("Could not get config dir");
+        let tari_address = InternalWallet::load_or_create(config_path)
+            .await
+            .map_err(|e| e.to_string())?
+            .get_tari_address();
         drop(cpu_miner_config);
 
         let mut gpu_miner = state.gpu_miner.write().await;

--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -118,7 +118,6 @@ impl ConfigWallet {
 
         match InternalWallet::load_or_create(old_config_path.clone()).await {
             Ok(wallet) => {
-                state.cpu_miner_config.write().await.tari_address = wallet.get_tari_address();
                 state
                     .wallet_manager
                     .set_view_private_key_and_spend_key(

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -36,7 +36,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tari_common_types::tari_address::TariAddress;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::ShutdownSignal;
 use tokio::select;
@@ -48,7 +47,6 @@ const ECO_MODE_CPU_USAGE: u32 = 30;
 
 pub struct CpuMinerConfig {
     pub node_connection: CpuMinerConnection,
-    pub tari_address: TariAddress,
     pub eco_mode_xmrig_options: Vec<String>,
     pub ludicrous_mode_xmrig_options: Vec<String>,
     pub custom_mode_xmrig_options: Vec<String>,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1042,7 +1042,6 @@ fn main() {
 
     let cpu_config = Arc::new(RwLock::new(CpuMinerConfig {
         node_connection: CpuMinerConnection::BuiltInProxy,
-        tari_address: TariAddress::default(),
         eco_mode_xmrig_options: vec![],
         ludicrous_mode_xmrig_options: vec![],
         custom_mode_xmrig_options: vec![],

--- a/src-tauri/src/setup/phase_unknown.rs
+++ b/src-tauri/src/setup/phase_unknown.rs
@@ -24,6 +24,7 @@ use crate::{
     binaries::{Binaries, BinaryResolver},
     configs::{config_core::ConfigCore, trait_config::ConfigImpl},
     events_manager::EventsManager,
+    internal_wallet::InternalWallet,
     p2pool_manager::P2poolConfig,
     progress_tracker_old::ProgressTracker,
     progress_trackers::{
@@ -176,7 +177,14 @@ impl SetupPhaseImpl for UnknownSetupPhase {
         let mut progress_stepper = self.progress_stepper.lock().await;
         let (data_dir, config_dir, log_dir) = self.get_app_dirs()?;
         let state = self.app_handle.state::<UniverseAppState>();
-        let tari_address = state.cpu_miner_config.read().await.tari_address.clone();
+        let config_path = self
+            .app_handle
+            .path()
+            .app_config_dir()
+            .expect("Could not get config dir");
+        let tari_address = InternalWallet::load_or_create(config_path)
+            .await?
+            .get_tari_address();
         let telemetry_id = state
             .telemetry_manager
             .read()


### PR DESCRIPTION
Description
---
Cpu mining config was importing wallet address at initialization was wouldn't update even after changing address.