### PR TITLE
fix: [ exchange miner ] improve modal status handling

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -629,7 +629,7 @@ pub async fn set_tari_address(address: String, app_handle: tauri::AppHandle) -> 
 pub async fn confirm_exchange_address(
     address: String,
     app: tauri::AppHandle,
-) -> Result<(), String> {
+) -> Result<(), InvokeError> {
     let timer = Instant::now();
     let config_path = app
         .path()
@@ -649,9 +649,9 @@ pub async fn confirm_exchange_address(
     )
     .await;
     SetupManager::get_instance()
-        .init_exchange_modal_status()
+        .mark_exchange_modal_as_completed()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(InvokeError::from_anyhow)?;
     if timer.elapsed() > MAX_ACCEPTABLE_COMMAND_TIME {
         warn!(target: LOG_TARGET, "set_exchange_address took too long: {:?}", timer.elapsed());
     }

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -59,6 +59,20 @@ static LOG_TARGET: &str = "tari::universe::setup_manager";
 
 static INSTANCE: LazyLock<SetupManager> = LazyLock::new(SetupManager::new);
 
+#[derive(Clone, Default)]
+pub enum ExchangeModalStatus {
+    #[default]
+    None,
+    WaitForComplition,
+    Completed,
+}
+
+impl ExchangeModalStatus {
+    pub fn is_completed(&self) -> bool {
+        matches!(self, ExchangeModalStatus::Completed) | matches!(self, ExchangeModalStatus::None)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
 pub enum SetupPhase {
     Core,
@@ -154,7 +168,7 @@ pub struct SetupManager {
     node_phase_status: Sender<PhaseStatus>,
     wallet_phase_status: Sender<PhaseStatus>,
     unknown_phase_status: Sender<PhaseStatus>,
-    exchange_modal_status: Sender<PhaseStatus>,
+    exchange_modal_status: Sender<ExchangeModalStatus>,
     is_app_unlocked: Mutex<bool>,
     is_wallet_unlocked: Mutex<bool>,
     is_mining_unlocked: Mutex<bool>,
@@ -177,6 +191,7 @@ impl SetupManager {
     async fn pre_setup(&self, app_handle: AppHandle) {
         info!(target: LOG_TARGET, "Pre Setup");
         let state = app_handle.state::<UniverseAppState>();
+        let in_memory_config = state.in_memory_config.clone();
 
         let _unused = state
             .telemetry_manager
@@ -254,6 +269,22 @@ impl SetupManager {
         state.node_manager.set_node_type(node_type).await;
         EventsManager::handle_node_type_update(&app_handle).await;
 
+        let config_path = app_handle
+            .path()
+            .app_config_dir()
+            .expect("Could not get config dir");
+        let internal_wallet = InternalWallet::load_or_create(config_path)
+            .await
+            .expect("Could not load or create internal wallet");
+        let is_address_generated = internal_wallet.get_is_tari_address_generated();
+        let is_exchange_id_default =
+            in_memory_config.read().await.exchange_id == DEFAULT_EXCHANGE_ID;
+        if is_address_generated && !is_exchange_id_default {
+            let _unused = self
+                .exchange_modal_status
+                .send(ExchangeModalStatus::WaitForComplition);
+        }
+
         info!(target: LOG_TARGET, "Pre Setup Finished");
     }
 
@@ -305,38 +336,20 @@ impl SetupManager {
     }
 
     async fn setup_unknown_phase(&self, app_handle: AppHandle) {
-        let state = app_handle.state::<UniverseAppState>();
-        let in_memory_config = state.in_memory_config.clone();
-        let required_statuses = {
-            let mut statuses = vec![
-                self.node_phase_status.subscribe(),
-                self.hardware_phase_status.subscribe(),
-            ];
-            let config_path = app_handle
-                .path()
-                .app_config_dir()
-                .expect("Could not get config dir");
-            let internal_wallet = InternalWallet::load_or_create(config_path)
-                .await
-                .expect("Could not load or create internal wallet");
-            let is_address_generated = internal_wallet.get_is_tari_address_generated();
-            let is_exchange_id_default =
-                in_memory_config.read().await.exchange_id == DEFAULT_EXCHANGE_ID;
-            if is_address_generated && !is_exchange_id_default {
-                statuses.push(self.exchange_modal_status.subscribe());
-            }
-            statuses
-        };
         let unknown_phase_setup = PhaseBuilder::new()
             .with_setup_timeout_duration(Duration::from_secs(60 * 10)) // 10 minutes
-            .with_listeners_for_required_phases_statuses(required_statuses)
+            .with_listeners_for_required_phases_statuses(vec![
+                self.node_phase_status.subscribe(),
+                self.hardware_phase_status.subscribe(),
+            ])
             .build::<UnknownSetupPhase>(app_handle.clone(), self.unknown_phase_status.clone())
             .await;
         unknown_phase_setup.setup().await;
     }
 
-    pub async fn init_exchange_modal_status(&self) -> Result<(), anyhow::Error> {
-        self.exchange_modal_status.send(PhaseStatus::Success)?;
+    pub async fn mark_exchange_modal_as_completed(&self) -> Result<(), anyhow::Error> {
+        self.exchange_modal_status
+            .send(ExchangeModalStatus::Completed)?;
         Ok(())
     }
 
@@ -347,6 +360,7 @@ impl SetupManager {
         let mut node_phase_status_subscriber = self.node_phase_status.subscribe();
         let mut wallet_phase_status_subscriber = self.wallet_phase_status.subscribe();
         let mut unknown_phase_status_subscriber = self.unknown_phase_status.subscribe();
+        let mut exchange_modal_status_subscriber = self.exchange_modal_status.subscribe();
 
         let cacellation_token = self.cancellation_token.lock().await.clone();
 
@@ -363,6 +377,7 @@ impl SetupManager {
                     let is_node_phase_succeeded = node_phase_status_subscriber.borrow().is_success();
                     let is_wallet_phase_succeeded = wallet_phase_status_subscriber.borrow().is_success();
                     let is_unknown_phase_succeeded = unknown_phase_status_subscriber.borrow().is_success();
+                    let is_exchange_modal_completed = exchange_modal_status_subscriber.borrow().is_completed();
 
                     info!(target: LOG_TARGET, "Checking unlock conditions: Core: {}, Hardware: {}, Node: {}, Wallet: {}, Unknown: {}",
                         is_core_phase_succeeded,
@@ -425,6 +440,7 @@ impl SetupManager {
                     if is_app_unlocked
                         && is_wallet_unlocked
                         && is_mining_unlocked
+                        && is_exchange_modal_completed
                         && !is_initial_setup_finished
                     {
                         *SetupManager::get_instance()
@@ -453,6 +469,7 @@ impl SetupManager {
                         _ = node_phase_status_subscriber.changed() => { continue; }
                         _ = wallet_phase_status_subscriber.changed() => { continue; }
                         _ = unknown_phase_status_subscriber.changed() => { continue; }
+                        _ = exchange_modal_status_subscriber.changed() => { continue; }
                     };
                 }
             });


### PR DESCRIPTION
###  [ Summary ]
- Replaced enum for modal status ( `PhaseStatus` => `ExchangeModalStatus` )
- Change behavior to only blocking entering to the main screen when the exchange address is not set instead of blocking unknown_phase execution