### PR TITLE
fix: websocket events manager panicking due to early startup

### DIFF
--- a/src-tauri/src/mining_status_manager.rs
+++ b/src-tauri/src/mining_status_manager.rs
@@ -104,12 +104,8 @@ impl MiningStatusManager {
         let cpu_miner_status_watch_rx = self.cpu_miner_status_watch_rx.clone();
         let gpu_latest_miner_stats = self.gpu_latest_miner_stats.clone();
         let node_latest_status = self.node_latest_status.clone();
-        let app_version = self
-            .app
-            .clone()
-            .map(|handle| handle.package_info().version.clone())
-            .expect("no app version present in WebsocketEventsManager")
-            .to_string();
+        let app_cloned = self.app.clone();
+
         let close_channel_tx = self.close_channel_tx.clone();
         let app_in_config_memory = self.app_in_memory_config.clone();
         let app_id = ConfigCore::content().await.anon_id().clone();
@@ -123,6 +119,10 @@ impl MiningStatusManager {
 
             tokio::spawn(async move {
                 loop {
+                    let app_version_option = app_cloned
+                        .clone()
+                        .map(|handle| handle.package_info().version.clone().to_string());
+
                     let jwt_token = ConfigCore::content()
                         .await
                         .airdrop_tokens()
@@ -132,7 +132,7 @@ impl MiningStatusManager {
 
                     tokio::select! {
                             _ = interval.tick() => {
-                            if let Some(jwt) = jwt_token {
+                            if let (Some(jwt), Some(app_version))= (jwt_token, app_version_option){
                                 if let Some(message) = MiningStatusManager::assemble_mining_status(cpu_miner_status_watch_rx.clone(),gpu_latest_miner_stats.clone(),node_latest_status.clone(),app_id.clone(),app_version.clone(),jwt.clone(),).await {
                                     let client = reqwest::Client::new();
                                     let url = format!("{}/miner/mining-status",base_url);


### PR DESCRIPTION
Description
---

Fixes the websocket events manager panicking due to early startup, where the app_handle is not yet set.


Motivation and Context
---

How Has This Been Tested?
---

Locally.

What process can a PR reviewer use to test or verify this change?
---

Test against airdrop dev/prod

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of application version checks during mining status updates, enhancing stability by verifying version presence at runtime without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->