### PR TITLE
chore: hide tx_id from the details ui

### DIFF
--- a/src/components/transactions/history/ExpandedItem.tsx
+++ b/src/components/transactions/history/ExpandedItem.tsx
@@ -31,7 +31,7 @@ const ItemExpand = memo(function ItemExpand({ item, expanded, handleClose }: Pro
         payment_id: 'send.transaction-description',
     };
 
-    const hiddenKeys = ['direction', 'excess_sig'];
+    const hiddenKeys = ['direction', 'excess_sig', 'tx_id'];
 
     const capitalizeKey = (key: string): string => {
         return key

--- a/src/components/transactions/send/SendReview/SendReview.tsx
+++ b/src/components/transactions/send/SendReview/SendReview.tsx
@@ -86,10 +86,10 @@ export function SendReview({
             label: t('send.transaction-description'),
             value: message,
         },
-        {
-            label: t('send.transaction-id'),
-            value: status === 'processing' ? <LoadingDots /> : latestTx?.tx_id,
-        },
+        // {
+        //     label: t('send.transaction-id'),
+        //     value: status === 'processing' ? <LoadingDots /> : latestTx?.tx_id,
+        // },
         // {
         //     label: t('send.tari-txn'),
         //     value: status === 'processing' ? <LoadingDots /> : `0x12345..12789`,


### PR DESCRIPTION
Description
---
tx_id is randomly generated for local purposes

Motivation and Context
---
hide tx_id from the details ui

![Screenshot 2025-05-19 at 16 09 11](https://github.com/user-attachments/assets/94462e89-6ab7-441b-99ea-cca31f650184)
![Screenshot 2025-05-19 at 15 52 20](https://github.com/user-attachments/assets/11599a6c-3cf0-4b35-9dff-c566ec9220a6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The transaction ID is now hidden from transaction history details unless hidden fields are explicitly shown.
  - The transaction ID is no longer displayed in the send review status list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->