### PR TITLE
fix(exchange-miner): ignore coinbase check

### DIFF
--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -26,6 +26,7 @@ use log::error;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tauri::{AppHandle, Manager};
 
+use crate::app_in_memory_config::DEFAULT_EXCHANGE_ID;
 use crate::configs::config_mining::ConfigMiningContent;
 use crate::configs::config_wallet::ConfigWalletContent;
 use crate::events::ConnectionStatusPayload;
@@ -51,8 +52,13 @@ pub struct EventsManager;
 
 impl EventsManager {
     pub async fn handle_new_block_height(app: &AppHandle, block_height: u64) {
+        let state = app.state::<UniverseAppState>();
+        let in_memoery_config = state.in_memory_config.read().await;
+        if in_memoery_config.exchange_id.eq(DEFAULT_EXCHANGE_ID) {
+            return;
+        }
         let app_clone = app.clone();
-        let wallet_manager = app.state::<UniverseAppState>().wallet_manager.clone();
+        let wallet_manager = state.wallet_manager.clone();
 
         TasksTrackers::current().wallet_phase.get_task_tracker().await.spawn(async move {
             // Use a short timeout for processing new blocks


### PR DESCRIPTION
Description
---
Omits coinbase check in exchange miner. This should exists since wallet isn't initialized and we don't care about coinbase in miner blocked but also fixes error `ERROR Error waiting for wallet scan: Wallet not started`.