### PR TITLE
chore: do not filter out rejected tx

### DIFF
--- a/src-tauri/src/wallet_adapter.rs
+++ b/src-tauri/src/wallet_adapter.rs
@@ -132,8 +132,8 @@ impl WalletAdapter {
             let tx = message.transaction.ok_or_else(|| {
                 WalletStatusMonitorError::UnknownError(anyhow::anyhow!("Transaction not found"))
             })?;
-            if tx.status == 14 || tx.status == 7 {
-                // Remove TRANSACTION_STATUS_COINBASE_NOT_IN_BLOCK_CHAIN and REJECTED
+            if tx.status == 14 {
+                // Remove TRANSACTION_STATUS_COINBASE_NOT_IN_BLOCK_CHAIN
                 continue;
             }
             let source_address = TariAddress::from_bytes(&tx.source_address)?;


### PR DESCRIPTION
Don't filter out rejected tx so we can handle them on the frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejected transactions now appear in the transaction history, ensuring a more complete and accurate record. Only coinbase transactions not in the blockchain are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->