### PR TITLE
fix: sidebar gems displayed as 0 when value is under 10k

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -81,6 +81,9 @@ const formatDecimalCompact = (value: number) => formatValue(value, { maximumFrac
 export function formatNumber(value: number, preset: FormatPreset): string {
     switch (preset) {
         case FormatPreset.COMPACT:
+            if (value < 10000) {
+                return formatDecimalCompact(value);
+            }
             return formatValue(roundCompactDecimals(value), {
                 maximumFractionDigits: 2,
                 notation: 'compact',


### PR DESCRIPTION
Found a bug where Gems were showing as "0" in the sidebar if the value was under 10000. 

Bug

![96821](https://github.com/user-attachments/assets/479ee19e-07a4-4b60-b809-eef28f17f460)

Fixed

![CleanShot 2025-05-26 at 18 06 23@2x](https://github.com/user-attachments/assets/d7b27f74-e834-4d34-a54f-b698aa634189)

How it looks with 10000+ gems

![CleanShot 2025-05-26 at 18 06 53@2x](https://github.com/user-attachments/assets/2082f38a-ce38-4bc7-b15a-7ae38607c9ad)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved number formatting for values below 10,000 in compact mode to display in decimal style instead of compact notation. Values 10,000 and above continue to use compact formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->