### PR TITLE
fix: network value for mining_status_manager

### DIFF
--- a/src-tauri/src/mining_status_manager.rs
+++ b/src-tauri/src/mining_status_manager.rs
@@ -177,11 +177,7 @@ impl MiningStatusManager {
 
         let cpu_miner_status = cpu_miner_status_watch_rx.borrow().clone();
         let gpu_status = gpu_latest_miner_stats.borrow().clone();
-        let network = match Network::get_current_or_user_setting_or_default() {
-            Network::Esmeralda => "esmeralda".to_owned(),
-            Network::NextNet => "nextnet".to_owned(),
-            _ => "unknown".to_owned(),
-        };
+        let network = Network::get_current_or_user_setting_or_default().as_key_str();
         let is_mining_active = cpu_miner_status.hash_rate > 0.0 || gpu_status.hash_rate > 0.0;
 
         if let Some(claims) = decode_jwt_claims_without_exp(&jwt_token) {


### PR DESCRIPTION
Description
---


Fix network value for mining_status_manager

Motivation and Context
---

How Has This Been Tested?
---

Locally against esme

What process can a PR reviewer use to test or verify this change?
---


Won't be able to - it won't throw an error in airdrop.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

