### PR TITLE
chore: remove rpm builds

### DIFF
--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -67,14 +67,15 @@ jobs:
           - platform: 'ubuntu-24.04-arm'
             args: '--bundles deb,appimage'
             best_effort: true
-          - platform: 'ubuntu-22.04'
-            args: '--bundles rpm'
-            extra: '-x64-rpm'
-            best_effort: true
-          - platform: 'ubuntu-24.04-arm'
-            args: '--bundles rpm'
-            extra: '-rpm'
-            best_effort: true
+          # Too slow. Maybe some day though... some day...
+          # - platform: 'ubuntu-22.04'
+          #   args: '--bundles rpm'
+          #   extra: '-x64-rpm'
+          #   best_effort: true
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles rpm'
+          #   extra: '-rpm'
+          #   best_effort: true
           - platform: 'windows-latest'
             args: '--bundles msi'
           - platform: 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,15 @@ jobs:
           - platform: 'ubuntu-24.04-arm'
             args: '--bundles deb,appimage'
             best_effort: true
-          - platform: 'ubuntu-22.04'
-            args: '--bundles rpm'
-            extra: '-x64-rpm'
-            best_effort: true
-          - platform: 'ubuntu-24.04-arm'
-            args: '--bundles rpm'
-            extra: '-rpm'
-            best_effort: true
+          # Too slow. Maybe some day though... some day...
+          # - platform: 'ubuntu-22.04'
+          #   args: '--bundles rpm'
+          #   extra: '-x64-rpm'
+          #   best_effort: true
+          # - platform: 'ubuntu-24.04-arm'
+          #   args: '--bundles rpm'
+          #   extra: '-rpm'
+          #   best_effort: true
           - platform: 'windows-latest'
             args: '--bundles msi'
           - platform: 'macos-latest'


### PR DESCRIPTION
Description
---
Remove rpm builds. They aren't added to the site to download, only available on github. They take way too long to make and aren't worth the free CI time. 
