### PR TITLE
fix: adjust stop_cpu_mining

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1645,15 +1645,6 @@ pub async fn stop_cpu_mining<'r>(
         .map_err(|e| e.to_string())?;
     info!(target:LOG_TARGET, "cpu miner stopped");
 
-    state
-        .gpu_miner
-        .write()
-        .await
-        .stop()
-        .await
-        .map_err(|e| e.to_string())?;
-    info!(target:LOG_TARGET, "gpu miner stopped");
-
     let timestamp_lock = state.cpu_miner_timestamp_mutex.lock().await;
     let current_mining_time_ms = *ConfigMining::content().await.mining_time();
 


### PR DESCRIPTION
### [ Summary ]
- `stop_cpu_mining` currently stops both cpu and gpu miners