### PR TITLE
fix: more reliable speedtest values

### DIFF
--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -365,6 +365,7 @@ impl SetupManager {
         let setup_features = self.features.read().await.clone();
         let hardware_phase_setup = PhaseBuilder::new()
             .with_setup_timeout_duration(Duration::from_secs(60 * 10)) // 10 minutes
+            .with_listeners_for_required_phases_statuses(vec![self.core_phase_status.subscribe()])
             .build::<HardwareSetupPhase>(
                 app_handle.clone(),
                 self.hardware_phase_status.clone(),
@@ -386,6 +387,7 @@ impl SetupManager {
 
         let node_phase_setup = PhaseBuilder::new()
             .with_setup_timeout_duration(timeout_duration)
+            .with_listeners_for_required_phases_statuses(vec![self.core_phase_status.subscribe()])
             .build::<NodeSetupPhase>(
                 app_handle.clone(),
                 self.node_phase_status.clone(),


### PR DESCRIPTION
### [ Summary ]
- Start `core_phase` before `node_phase` and `hardware_phase` so binaries download won't influence download speed in speedtest 