### PR TITLE
feat: only show rewards / animations once 3 blocks have passed

### DIFF
--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -156,18 +156,14 @@ let latestBlockPayload:
 
 const checkPendingWins = async (currentBlockHeight: number) => {
     const state = useBlockchainVisualisationStore.getState();
-    const winsToProcess = state.pendingWins.filter(
-        win => currentBlockHeight >= win.winBlockHeight + 3
-    );
-    
+    const winsToProcess = state.pendingWins.filter((win) => currentBlockHeight >= win.winBlockHeight + 3);
+
     if (winsToProcess.length > 0) {
         // Remove processed wins from pending
-        useBlockchainVisualisationStore.setState(prev => ({
-            pendingWins: prev.pendingWins.filter(
-                win => currentBlockHeight < win.winBlockHeight + 3
-            )
+        useBlockchainVisualisationStore.setState((prev) => ({
+            pendingWins: prev.pendingWins.filter((win) => currentBlockHeight < win.winBlockHeight + 3),
         }));
-        
+
         // Process each pending win
         for (const win of winsToProcess) {
             await handleWin(win.coinbase_transaction, win.balance, win.canAnimate);
@@ -182,25 +178,25 @@ async function processNewBlock(payload: {
 }) {
     // Always check for pending wins first
     await checkPendingWins(payload.block_height);
-    
+
     if (useMiningStore.getState().isCpuMiningInitiated || useMiningStore.getState().isGpuMiningInitiated) {
         const minimized = await appWindow?.isMinimized();
         const documentIsVisible = document?.visibilityState === 'visible' || false;
         const canAnimate = !minimized && documentIsVisible;
-        
+
         if (payload.coinbase_transaction) {
             // Instead of processing win immediately, queue it for 3 blocks later
             const pendingWin: PendingWin = {
                 coinbase_transaction: payload.coinbase_transaction,
                 balance: payload.balance,
                 canAnimate,
-                winBlockHeight: payload.block_height
+                winBlockHeight: payload.block_height,
             };
-            
-            useBlockchainVisualisationStore.setState(prev => ({
-                pendingWins: [...prev.pendingWins, pendingWin]
+
+            useBlockchainVisualisationStore.setState((prev) => ({
+                pendingWins: [...prev.pendingWins, pendingWin],
             }));
-            
+
             console.info(`Block #${payload.block_height} win queued - will show in 3 blocks`);
         } else {
             await handleFail(payload.block_height, payload.balance, canAnimate);


### PR DESCRIPTION
Description
---
Implement 3-block confirmation delay for mining reward animations and wallet display. When mining with p2pool or solo mining, block wins are now queued and only displayed (animation + wallet reward) after 3 blocks have passed. This prevents showing rewards that may be lost due to chain reorganizations.

Motivation and Context
---
Previously, mining reward animations and wallet updates would show immediately when a block was won, which could be misleading if a chain reorg occurred shortly after. Users would see rewards that they didn't actually receive, creating confusion. By adding a 3-block delay, we ensure that only confirmed rewards are displayed to users.

How Has This Been Tested?
---
- Code changes tested locally with mining operations
- Verified that pending wins are properly queued in the blockchain visualization store
- Confirmed that animations and wallet updates only trigger after the 3-block delay
- Tested that failed blocks (non-wins) still update immediately as expected

What process can a PR reviewer use to test or verify this change?
---
1. Start p2pool or solo mining
2. Monitor console logs for "Block #X win queued - will show in 3 blocks" messages when winning blocks
3. Verify that the block winning animation and wallet update only occur 3 blocks after the actual win
4. Confirm that the `pendingWins` array in the blockchain visualization store properly tracks queued wins
5. Test that mining continues to work normally for both wins and non-wins

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify