### PR TITLE
feat: timeouts improvements

### DIFF
--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -21,7 +21,10 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+};
 
 use crate::{
     app_in_memory_config::AppInMemoryConfig,
@@ -95,6 +98,18 @@ pub struct ProgressTrackerUpdatePayload {
     pub progress: f64,
     pub title_params: Option<HashMap<String, String>>,
     pub is_complete: bool,
+}
+
+impl Hash for ProgressTrackerUpdatePayload {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.phase_title.hash(state);
+        self.title.hash(state);
+        self.progress.to_bits().hash(state);
+        if let Some(params) = &self.title_params {
+            params.hasher();
+        }
+        self.is_complete.hash(state);
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -88,21 +88,11 @@ impl EventsEmitter {
     }
     pub async fn emit_progress_tracker_update(
         event_type: ProgressEvents,
-        phase_title: String,
-        title: String,
-        progress: f64,
-        title_params: Option<HashMap<String, String>>,
-        is_complete: bool,
+        payload: ProgressTrackerUpdatePayload,
     ) {
         let event = Event {
             event_type,
-            payload: ProgressTrackerUpdatePayload {
-                phase_title,
-                title,
-                progress,
-                title_params,
-                is_complete,
-            },
+            payload,
         };
         if let Err(e) = Self::get_app_handle()
             .await

--- a/src-tauri/src/progress_trackers/progress_stepper.rs
+++ b/src-tauri/src/progress_trackers/progress_stepper.rs
@@ -22,6 +22,7 @@
 
 use std::{
     collections::HashMap,
+    hash::Hash,
     ops::{Add, Mul},
 };
 
@@ -29,8 +30,12 @@ use serde_json::json;
 use tauri::{AppHandle, Manager};
 
 use log::warn;
+use tokio::sync::watch::Sender;
 
-use crate::{events_emitter::EventsEmitter, UniverseAppState};
+use crate::{
+    events::ProgressTrackerUpdatePayload, events_emitter::EventsEmitter,
+    setup::utils::timeout_watcher::hash_value, UniverseAppState,
+};
 
 use super::progress_plans::{ProgressEvent, ProgressPlans, ProgressStep};
 
@@ -41,6 +46,7 @@ pub struct ChanneledStepUpdate {
     step: ProgressPlans,
     step_percentage: f64,
     next_step_percentage: Option<f64>,
+    timeout_watcher_sender: Sender<u64>,
 }
 
 impl ChanneledStepUpdate {
@@ -52,21 +58,33 @@ impl ChanneledStepUpdate {
                 - self.step_percentage)
                 * current_step_percentage;
 
-        EventsEmitter::emit_progress_tracker_update(
-            self.step.get_event_type(),
-            self.step.get_phase_title(),
-            self.step.get_title(),
-            resolved_percentage.round(),
-            Some(params),
-            false,
-        )
-        .await;
+        let payload = ProgressTrackerUpdatePayload {
+            phase_title: self.step.get_phase_title(),
+            title: self.step.get_title(),
+            progress: resolved_percentage.round(),
+            title_params: Some(params.clone()),
+            is_complete: false,
+        };
+
+        let _unused = &self
+            .timeout_watcher_sender
+            .send(hash_value(&payload))
+            .inspect_err(|e| {
+                warn!(
+                    target: LOG_TARGET,
+                    "Failed to send timeout watcher signal: {}",
+                    e
+                );
+            });
+
+        EventsEmitter::emit_progress_tracker_update(self.step.get_event_type(), payload).await;
     }
 }
 pub struct ProgressStepper {
     plan: Vec<ProgressPlans>,
     percentage_steps: Vec<f64>,
     app_handle: AppHandle,
+    timeout_watcher_sender: Sender<u64>,
 }
 
 impl ProgressStepper {
@@ -79,15 +97,26 @@ impl ProgressStepper {
 
             let is_completed = self.plan.is_empty();
 
-            EventsEmitter::emit_progress_tracker_update(
-                event.get_event_type(),
-                resolved_step.get_phase_title(),
-                event.get_title(),
-                resolved_percentage,
-                None,
-                is_completed,
-            )
-            .await;
+            let payload = ProgressTrackerUpdatePayload {
+                phase_title: resolved_step.get_phase_title(),
+                title: event.get_title(),
+                progress: resolved_percentage,
+                title_params: None,
+                is_complete: is_completed,
+            };
+
+            let _unused = &self
+                .timeout_watcher_sender
+                .send(hash_value(&payload))
+                .inspect_err(|e| {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Failed to send timeout watcher signal: {}",
+                        e
+                    );
+                });
+
+            EventsEmitter::emit_progress_tracker_update(event.get_event_type(), payload).await;
             let app_state = self.app_handle.state::<UniverseAppState>();
             let _unused = app_state
                 .telemetry_service
@@ -128,6 +157,7 @@ impl ProgressStepper {
                         step: resolved_step.clone(),
                         step_percentage: resolved_percentage,
                         next_step_percentage,
+                        timeout_watcher_sender: self.timeout_watcher_sender.clone(),
                     };
 
                     return Some(channel_step_update);
@@ -137,6 +167,7 @@ impl ProgressStepper {
                     step: resolved_step.clone(),
                     step_percentage: resolved_percentage,
                     next_step_percentage: None,
+                    timeout_watcher_sender: self.timeout_watcher_sender.clone(),
                 };
 
                 return Some(channel_step_update);
@@ -201,12 +232,17 @@ impl ProgressStepperBuilder {
         self
     }
 
-    pub fn build(&mut self, app_handle: AppHandle) -> ProgressStepper {
+    pub fn build(
+        &mut self,
+        app_handle: AppHandle,
+        timeout_watcher_sender: Sender<u64>,
+    ) -> ProgressStepper {
         self.calculate_percentage_steps();
         ProgressStepper {
             plan: self.plan.clone().into_iter().rev().collect(),
             percentage_steps: self.percentage_steps.clone().into_iter().rev().collect(),
             app_handle,
+            timeout_watcher_sender,
         }
     }
 }

--- a/src-tauri/src/progress_trackers/progress_stepper.rs
+++ b/src-tauri/src/progress_trackers/progress_stepper.rs
@@ -22,7 +22,6 @@
 
 use std::{
     collections::HashMap,
-    hash::Hash,
     ops::{Add, Mul},
 };
 

--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -22,7 +22,7 @@
 
 pub mod setup_manager;
 mod trait_setup_phase;
-mod utils;
+pub mod utils;
 
 mod phase_core;
 mod phase_hardware;

--- a/src-tauri/src/setup/phase_core.rs
+++ b/src-tauri/src/setup/phase_core.rs
@@ -78,7 +78,7 @@ impl SetupPhaseImpl for CoreSetupPhase {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self {
-        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration.clone());
+        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration);
         Self {
             app_handle: app_handle.clone(),
             progress_stepper: Mutex::new(CoreSetupPhase::create_progress_stepper(
@@ -112,9 +112,6 @@ impl SetupPhaseImpl for CoreSetupPhase {
     }
     fn get_phase_id(&self) -> SetupPhase {
         SetupPhase::Core
-    }
-    fn get_status_sender(&self) -> Sender<PhaseStatus> {
-        self.status_sender.clone()
     }
     fn get_timeout_watcher(&self) -> &TimeoutWatcher {
         &self.timeout_watcher

--- a/src-tauri/src/setup/phase_core.rs
+++ b/src-tauri/src/setup/phase_core.rs
@@ -20,19 +20,18 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use log::{error, info, warn};
+use log::error;
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
-use tauri_plugin_sentry::sentry;
-use tokio::{
-    select,
-    sync::{watch::Sender, Mutex},
+use tokio::sync::{
+    watch::{Receiver, Sender},
+    Mutex,
 };
+use tokio_util::task::TaskTracker;
 
 use crate::{
     auto_launcher::AutoLauncher,
     configs::{config_core::ConfigCore, trait_config::ConfigImpl},
-    events::CriticalProblemPayload,
-    events_emitter::EventsEmitter,
     progress_trackers::{
         progress_plans::ProgressPlans, progress_stepper::ProgressStepperBuilder,
         ProgressSetupCorePlan, ProgressStepper,
@@ -40,13 +39,13 @@ use crate::{
     setup::setup_manager::SetupPhase,
     tasks_tracker::TasksTrackers,
     utils::{network_status::NetworkStatus, platform_utils::PlatformUtils},
-    UniverseAppState,
+    EventsEmitter, UniverseAppState,
 };
 
 use super::{
     setup_manager::{PhaseStatus, SetupFeaturesList},
     trait_setup_phase::{SetupConfiguration, SetupPhaseImpl},
-    utils::timeout_watcher::TimeoutWatcher,
+    utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
 static LOG_TARGET: &str = "tari::universe::phase_core";
@@ -100,6 +99,27 @@ impl SetupPhaseImpl for CoreSetupPhase {
         &self.app_handle
     }
 
+    async fn get_shutdown_signal(&self) -> ShutdownSignal {
+        TasksTrackers::current().core_phase.get_signal().await
+    }
+    async fn get_task_tracker(&self) -> TaskTracker {
+        TasksTrackers::current().core_phase.get_task_tracker().await
+    }
+    fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>> {
+        self.setup_configuration
+            .listeners_for_required_phases_statuses
+            .clone()
+    }
+    fn get_phase_id(&self) -> SetupPhase {
+        SetupPhase::Core
+    }
+    fn get_status_sender(&self) -> Sender<PhaseStatus> {
+        self.status_sender.clone()
+    }
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher {
+        &self.timeout_watcher
+    }
+
     fn create_progress_stepper(
         app_handle: AppHandle,
         timeout_watcher_sender: Sender<u64>,
@@ -124,55 +144,8 @@ impl SetupPhaseImpl for CoreSetupPhase {
         })
     }
 
-    async fn setup(mut self) {
-        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Core);
-        TasksTrackers::current().core_phase.get_task_tracker().await.spawn(async move {
-            let mut shutdown_signal = TasksTrackers::current().core_phase.get_signal().await;
-            for subscriber in &mut self.setup_configuration.listeners_for_required_phases_statuses.iter_mut() {
-                select! {
-                    _ = subscriber.wait_for(|value| value.is_success()) => {}
-                    _ = shutdown_signal.wait() => {
-                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Core);
-                        return;
-                    }
-                }
-            };
-            tokio::select! {
-                result = self.timeout_watcher.resolve_timeout() => {
-                    if result.is_some() {
-                        error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Core);
-                        let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Core);
-                        sentry::capture_message(&error_message, sentry::Level::Error);
-                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some(SetupPhase::Core.get_critical_problem_title()),
-                            description: Some(SetupPhase::Core.get_critical_problem_description()),
-                            error_message: Some(error_message),
-                        }).await;
-                    }
-                }
-                result = self.setup_inner() => {
-                    match result {
-                        Ok(_) => {
-                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", SetupPhase::Core);
-                            let _unused = self.finalize_setup().await;
-                        }
-                        Err(error) => {
-                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Core,error);
-                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Core,error);
-                            sentry::capture_message(&error_message, sentry::Level::Error);
-                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some(SetupPhase::Core.get_critical_problem_title()),
-                                description: Some(SetupPhase::Core.get_critical_problem_description()),
-                                error_message: Some(error_message),
-                            }).await;
-                        }
-                    }
-                }
-                _ = shutdown_signal.wait() => {
-                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Core);
-                }
-            }
-        });
+    async fn setup(self) {
+        let _unused = SetupDefaultAdapter::setup(self).await;
     }
 
     #[allow(clippy::too_many_lines)]

--- a/src-tauri/src/setup/phase_hardware.rs
+++ b/src-tauri/src/setup/phase_hardware.rs
@@ -25,7 +25,6 @@ use std::time::Duration;
 use crate::{
     binaries::{Binaries, BinaryResolver},
     configs::{config_mining::ConfigMining, trait_config::ConfigImpl},
-    events::CriticalProblemPayload,
     events_emitter::EventsEmitter,
     gpu_miner::EngineType,
     hardware::hardware_status_monitor::HardwareStatusMonitor,
@@ -42,21 +41,23 @@ use crate::{
     GpuMinerStatus, UniverseAppState,
 };
 use anyhow::Error;
-use log::{error, info, warn};
+use log::error;
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_sentry::sentry;
 use tokio::{
     select,
     sync::{
-        watch::{self, Sender},
+        watch::{self, Receiver, Sender},
         Mutex,
     },
 };
+use tokio_util::task::TaskTracker;
 
 use super::{
     setup_manager::{PhaseStatus, SetupFeaturesList},
     trait_setup_phase::{SetupConfiguration, SetupPhaseImpl},
-    utils::timeout_watcher::{self, TimeoutWatcher},
+    utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
 static LOG_TARGET: &str = "tari::universe::phase_hardware";
@@ -107,6 +108,26 @@ impl SetupPhaseImpl for HardwareSetupPhase {
     fn get_app_handle(&self) -> &AppHandle {
         &self.app_handle
     }
+    async fn get_shutdown_signal(&self) -> ShutdownSignal {
+        TasksTrackers::current().core_phase.get_signal().await
+    }
+    async fn get_task_tracker(&self) -> TaskTracker {
+        TasksTrackers::current().core_phase.get_task_tracker().await
+    }
+    fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>> {
+        self.setup_configuration
+            .listeners_for_required_phases_statuses
+            .clone()
+    }
+    fn get_phase_id(&self) -> SetupPhase {
+        SetupPhase::Hardware
+    }
+    fn get_status_sender(&self) -> Sender<PhaseStatus> {
+        self.status_sender.clone()
+    }
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher {
+        &self.timeout_watcher
+    }
 
     fn create_progress_stepper(
         app_handle: AppHandle,
@@ -135,56 +156,8 @@ impl SetupPhaseImpl for HardwareSetupPhase {
         Ok(HardwareSetupPhaseAppConfiguration { gpu_engine })
     }
 
-    async fn setup(mut self) {
-        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Hardware);
-
-        TasksTrackers::current().hardware_phase.get_task_tracker().await.spawn(async move {
-            let mut shutdown_signal = TasksTrackers::current().hardware_phase.get_signal().await;
-            for subscriber in &mut self.setup_configuration.listeners_for_required_phases_statuses.iter_mut() {
-                select! {
-                    _ = subscriber.wait_for(|value| value.is_success()) => {}
-                    _ = shutdown_signal.wait() => {
-                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Hardware);
-                        return;
-                    }
-                }
-            };
-            tokio::select! {
-                result = self.timeout_watcher.resolve_timeout() => {
-                    if result.is_some() {
-                        error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Hardware);
-                        let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Hardware);
-                        sentry::capture_message(&error_message, sentry::Level::Error);
-                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some(SetupPhase::Hardware.get_critical_problem_title()),
-                            description: Some(SetupPhase::Hardware.get_critical_problem_description()),
-                            error_message: Some(error_message),
-                        }).await;
-                    }
-                }
-                result = self.setup_inner() => {
-                    match result {
-                        Ok(_) => {
-                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", SetupPhase::Hardware);
-                            let _unused = self.finalize_setup().await;
-                        }
-                        Err(error) => {
-                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Hardware,error);
-                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Hardware,error);
-                            sentry::capture_message(&error_message, sentry::Level::Error);
-                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some(SetupPhase::Hardware.get_critical_problem_title()),
-                                description: Some(SetupPhase::Hardware.get_critical_problem_description()),
-                                error_message: Some(error_message),
-                            }).await;
-                        }
-                    }
-                }
-                _ = shutdown_signal.wait() => {
-                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Core);
-                }
-            };
-        });
+    async fn setup(self) {
+        let _unused = SetupDefaultAdapter::setup(self).await;
     }
 
     async fn setup_inner(&self) -> Result<(), Error> {

--- a/src-tauri/src/setup/phase_hardware.rs
+++ b/src-tauri/src/setup/phase_hardware.rs
@@ -90,7 +90,7 @@ impl SetupPhaseImpl for HardwareSetupPhase {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self {
-        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration.clone());
+        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration);
         Self {
             app_handle: app_handle.clone(),
             progress_stepper: Mutex::new(Self::create_progress_stepper(
@@ -121,9 +121,6 @@ impl SetupPhaseImpl for HardwareSetupPhase {
     }
     fn get_phase_id(&self) -> SetupPhase {
         SetupPhase::Hardware
-    }
-    fn get_status_sender(&self) -> Sender<PhaseStatus> {
-        self.status_sender.clone()
     }
     fn get_timeout_watcher(&self) -> &TimeoutWatcher {
         &self.timeout_watcher

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -88,7 +88,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self {
-        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration.clone());
+        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration);
         Self {
             app_handle: app_handle.clone(),
             progress_stepper: Mutex::new(Self::create_progress_stepper(
@@ -120,9 +120,6 @@ impl SetupPhaseImpl for NodeSetupPhase {
     }
     fn get_phase_id(&self) -> SetupPhase {
         SetupPhase::Node
-    }
-    fn get_status_sender(&self) -> Sender<PhaseStatus> {
-        self.status_sender.clone()
     }
     fn get_timeout_watcher(&self) -> &TimeoutWatcher {
         &self.timeout_watcher

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -20,15 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{
-    collections::HashMap,
-    time::{self, Duration},
-};
+use std::{collections::HashMap, time::Duration};
 
 use crate::{
     binaries::{Binaries, BinaryResolver},
     configs::{config_core::ConfigCore, trait_config::ConfigImpl},
-    events::CriticalProblemPayload,
     events_emitter::EventsEmitter,
     events_manager::EventsManager,
     node::node_manager::{NodeManagerError, STOP_ON_ERROR_CODES},
@@ -44,21 +40,21 @@ use crate::{
 };
 use anyhow::Error;
 use log::{error, info, warn};
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
-use tauri_plugin_sentry::sentry;
 use tokio::{
-    select,
     sync::{
         watch::{self, Sender},
         Mutex,
     },
     time::{interval, Interval},
 };
+use tokio_util::task::TaskTracker;
 
 use super::{
     setup_manager::{PhaseStatus, SetupFeaturesList},
     trait_setup_phase::{SetupConfiguration, SetupPhaseImpl},
-    utils::timeout_watcher::TimeoutWatcher,
+    utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
 static LOG_TARGET: &str = "tari::universe::phase_hardware";
@@ -111,6 +107,27 @@ impl SetupPhaseImpl for NodeSetupPhase {
         &self.app_handle
     }
 
+    async fn get_shutdown_signal(&self) -> ShutdownSignal {
+        TasksTrackers::current().core_phase.get_signal().await
+    }
+    async fn get_task_tracker(&self) -> TaskTracker {
+        TasksTrackers::current().core_phase.get_task_tracker().await
+    }
+    fn get_phase_dependencies(&self) -> Vec<tokio::sync::watch::Receiver<PhaseStatus>> {
+        self.setup_configuration
+            .listeners_for_required_phases_statuses
+            .clone()
+    }
+    fn get_phase_id(&self) -> SetupPhase {
+        SetupPhase::Node
+    }
+    fn get_status_sender(&self) -> Sender<PhaseStatus> {
+        self.status_sender.clone()
+    }
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher {
+        &self.timeout_watcher
+    }
+
     fn create_progress_stepper(
         app_handle: AppHandle,
         timeout_watcher_sender: Sender<u64>,
@@ -146,56 +163,8 @@ impl SetupPhaseImpl for NodeSetupPhase {
         })
     }
 
-    async fn setup(mut self) {
-        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Node);
-
-        TasksTrackers::current().node_phase.get_task_tracker().await.spawn(async move {
-            let mut shutdown_signal = TasksTrackers::current().node_phase.get_signal().await;
-            for subscriber in &mut self.setup_configuration.listeners_for_required_phases_statuses.iter_mut() {
-                select! {
-                    _ = subscriber.wait_for(|value| value.is_success()) => {}
-                    _ = shutdown_signal.wait() => {
-                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Node);
-                        return;
-                    }
-                }
-            };
-            tokio::select! {
-                result = self.timeout_watcher.resolve_timeout() => {
-                   if result.is_some() {
-                        error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Node);
-                        let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Node);
-                        sentry::capture_message(&error_message, sentry::Level::Error);
-                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some(SetupPhase::Node.get_critical_problem_title()),
-                            description: Some(SetupPhase::Node.get_critical_problem_description()),
-                            error_message: Some(error_message),
-                        }).await;
-                    }
-                }
-                result = self.setup_inner() => {
-                    match result {
-                        Ok(_) => {
-                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", SetupPhase::Node);
-                            let __unused = self.finalize_setup().await;
-                        }
-                        Err(error) => {
-                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Node,error);
-                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Node,error);
-                            sentry::capture_message(&error_message, sentry::Level::Error);
-                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some(SetupPhase::Node.get_critical_problem_title()),
-                                description: Some(SetupPhase::Node.get_critical_problem_description()),
-                                error_message: Some(error_message),
-                            }).await;
-                        }
-                    }
-                }
-                _ = shutdown_signal.wait() => {
-                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Node);
-                }
-            };
-        });
+    async fn setup(self) {
+        let _unused = SetupDefaultAdapter::setup(self).await;
     }
 
     #[allow(clippy::too_many_lines)]

--- a/src-tauri/src/setup/phase_unknown.rs
+++ b/src-tauri/src/setup/phase_unknown.rs
@@ -86,7 +86,7 @@ impl SetupPhaseImpl for UnknownSetupPhase {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self {
-        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration.clone());
+        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration);
         Self {
             app_handle: app_handle.clone(),
             progress_stepper: Mutex::new(Self::create_progress_stepper(
@@ -118,9 +118,6 @@ impl SetupPhaseImpl for UnknownSetupPhase {
     }
     fn get_phase_id(&self) -> SetupPhase {
         SetupPhase::Unknown
-    }
-    fn get_status_sender(&self) -> Sender<PhaseStatus> {
-        self.status_sender.clone()
     }
     fn get_timeout_watcher(&self) -> &TimeoutWatcher {
         &self.timeout_watcher

--- a/src-tauri/src/setup/phase_unknown.rs
+++ b/src-tauri/src/setup/phase_unknown.rs
@@ -23,7 +23,6 @@
 use crate::{
     binaries::{Binaries, BinaryResolver},
     configs::{config_core::ConfigCore, config_mining::ConfigMining, trait_config::ConfigImpl},
-    events::CriticalProblemPayload,
     events_emitter::EventsEmitter,
     p2pool_manager::P2poolConfig,
     progress_tracker_old::ProgressTracker,
@@ -37,21 +36,19 @@ use crate::{
     StartConfig, UniverseAppState,
 };
 use anyhow::Error;
-use log::{error, info, warn};
+use log::info;
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
-use tauri_plugin_sentry::sentry;
-use tokio::{
-    select,
-    sync::{
-        watch::{self, Sender},
-        Mutex,
-    },
+use tokio::sync::{
+    watch::{self, Receiver, Sender},
+    Mutex,
 };
+use tokio_util::task::TaskTracker;
 
 use super::{
     setup_manager::{PhaseStatus, SetupFeaturesList},
     trait_setup_phase::{SetupConfiguration, SetupPhaseImpl},
-    utils::timeout_watcher::TimeoutWatcher,
+    utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
 static LOG_TARGET: &str = "tari::universe::phase_hardware";
@@ -108,6 +105,27 @@ impl SetupPhaseImpl for UnknownSetupPhase {
         &self.app_handle
     }
 
+    async fn get_shutdown_signal(&self) -> ShutdownSignal {
+        TasksTrackers::current().core_phase.get_signal().await
+    }
+    async fn get_task_tracker(&self) -> TaskTracker {
+        TasksTrackers::current().core_phase.get_task_tracker().await
+    }
+    fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>> {
+        self.setup_configuration
+            .listeners_for_required_phases_statuses
+            .clone()
+    }
+    fn get_phase_id(&self) -> SetupPhase {
+        SetupPhase::Unknown
+    }
+    fn get_status_sender(&self) -> Sender<PhaseStatus> {
+        self.status_sender.clone()
+    }
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher {
+        &self.timeout_watcher
+    }
+
     fn create_progress_stepper(
         app_handle: AppHandle,
         timeout_watcher_sender: Sender<u64>,
@@ -141,56 +159,8 @@ impl SetupPhaseImpl for UnknownSetupPhase {
         })
     }
 
-    async fn setup(mut self) {
-        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Unknown);
-
-        TasksTrackers::current().unknown_phase.get_task_tracker().await.spawn(async move {
-            let mut shutdown_signal = TasksTrackers::current().unknown_phase.get_signal().await;
-            for subscriber in &mut self.setup_configuration.listeners_for_required_phases_statuses.iter_mut() {
-                select! {
-                    _ = subscriber.wait_for(|value| value.is_success()) => {}
-                    _ = shutdown_signal.wait() => {
-                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Unknown);
-                        return;
-                    }
-                }
-            };
-            tokio::select! {
-                result = self.timeout_watcher.resolve_timeout() => {
-                    if result.is_some() {
-                        error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Unknown);
-                        let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Unknown);
-                        sentry::capture_message(&error_message, sentry::Level::Error);
-                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some(SetupPhase::Unknown.get_critical_problem_title()),
-                            description: Some(SetupPhase::Unknown.get_critical_problem_description()),
-                            error_message: Some(error_message),
-                        }).await;
-                    }
-                }
-                result = self.setup_inner() => {
-                    match result {
-                        Ok(_) => {
-                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", SetupPhase::Unknown);
-                            let _unused = self.finalize_setup().await;
-                        }
-                        Err(error) => {
-                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Unknown,error);
-                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Unknown,error);
-                            sentry::capture_message(&error_message, sentry::Level::Error);
-                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some(SetupPhase::Unknown.get_critical_problem_title()),
-                                description: Some(SetupPhase::Unknown.get_critical_problem_description()),
-                                error_message: Some(error_message),
-                            }).await;
-                        }
-                    }
-                }
-                _ = shutdown_signal.wait() => {
-                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Core);
-                }
-            };
-        });
+    async fn setup(self) {
+        let _unused = SetupDefaultAdapter::setup(self).await;
     }
 
     #[allow(clippy::too_many_lines)]

--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -26,7 +26,6 @@ use crate::{
         config_ui::{ConfigUI, ConfigUIContent},
         trait_config::ConfigImpl,
     },
-    events::CriticalProblemPayload,
     events_emitter::EventsEmitter,
     progress_tracker_old::ProgressTracker,
     progress_trackers::{
@@ -40,22 +39,19 @@ use crate::{
     UniverseAppState,
 };
 use anyhow::Error;
-use log::{error, info, warn};
 use tari_core::transactions::tari_amount::MicroMinotari;
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
-use tauri_plugin_sentry::sentry;
-use tokio::{
-    select,
-    sync::{
-        watch::{self, Sender},
-        Mutex,
-    },
+use tokio::sync::{
+    watch::{self, Receiver, Sender},
+    Mutex,
 };
+use tokio_util::task::TaskTracker;
 
 use super::{
     setup_manager::{PhaseStatus, SetupFeaturesList},
     trait_setup_phase::{SetupConfiguration, SetupPhaseImpl},
-    utils::timeout_watcher::TimeoutWatcher,
+    utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
 static LOG_TARGET: &str = "tari::universe::phase_hardware";
@@ -109,6 +105,27 @@ impl SetupPhaseImpl for WalletSetupPhase {
         &self.app_handle
     }
 
+    async fn get_shutdown_signal(&self) -> ShutdownSignal {
+        TasksTrackers::current().core_phase.get_signal().await
+    }
+    async fn get_task_tracker(&self) -> TaskTracker {
+        TasksTrackers::current().core_phase.get_task_tracker().await
+    }
+    fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>> {
+        self.setup_configuration
+            .listeners_for_required_phases_statuses
+            .clone()
+    }
+    fn get_phase_id(&self) -> SetupPhase {
+        SetupPhase::Wallet
+    }
+    fn get_status_sender(&self) -> Sender<PhaseStatus> {
+        self.status_sender.clone()
+    }
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher {
+        &self.timeout_watcher
+    }
+
     fn create_progress_stepper(
         app_handle: AppHandle,
         timeout_watcher_sender: Sender<u64>,
@@ -136,57 +153,8 @@ impl SetupPhaseImpl for WalletSetupPhase {
         })
     }
 
-    async fn setup(mut self) {
-        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", SetupPhase::Wallet);
-
-        TasksTrackers::current().wallet_phase.get_task_tracker().await.spawn(async move {
-            let mut shutdown_signal = TasksTrackers::current().wallet_phase.get_signal().await;
-            for subscriber in &mut self.setup_configuration.listeners_for_required_phases_statuses.iter_mut() {
-                select! {
-                    _ = subscriber.wait_for(|value| value.is_success()) => {}
-                    _ = shutdown_signal.wait() => {
-                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Wallet);
-                        return;
-                    }
-                }
-            };
-
-            tokio::select! {
-                result = self.timeout_watcher.resolve_timeout() => {
-                    if result.is_some() {
-                        error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", SetupPhase::Wallet);
-                        let error_message = format!("[ {} Phase ] Setup timed out", SetupPhase::Wallet);
-                        sentry::capture_message(&error_message, sentry::Level::Error);
-                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some(SetupPhase::Wallet.get_critical_problem_title()),
-                            description: Some(SetupPhase::Wallet.get_critical_problem_description()),
-                            error_message: Some(error_message),
-                        }).await;
-                    }
-                }
-                result = self.setup_inner() => {
-                    match result {
-                        Ok(_) => {
-                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", SetupPhase::Wallet);
-                            let _unused = self.finalize_setup().await;
-                        }
-                        Err(error) => {
-                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Wallet,error);
-                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", SetupPhase::Wallet,error);
-                            sentry::capture_message(&error_message, sentry::Level::Error);
-                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some(SetupPhase::Wallet.get_critical_problem_title()),
-                                description: Some(SetupPhase::Wallet.get_critical_problem_description()),
-                                error_message: Some(error_message),
-                            }).await;
-                        }
-                    }
-                }
-                _ = shutdown_signal.wait() => {
-                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", SetupPhase::Wallet);
-                }
-            };
-        });
+    async fn setup(self) {
+        let _unused = SetupDefaultAdapter::setup(self).await;
     }
 
     async fn setup_inner(&self) -> Result<(), Error> {

--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -54,7 +54,7 @@ use super::{
     utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 
-static LOG_TARGET: &str = "tari::universe::phase_hardware";
+// static LOG_TARGET: &str = "tari::universe::phase_hardware";
 
 #[derive(Clone, Default)]
 pub struct WalletSetupPhaseOutput {}
@@ -86,7 +86,7 @@ impl SetupPhaseImpl for WalletSetupPhase {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self {
-        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration.clone());
+        let timeout_watcher = TimeoutWatcher::new(configuration.setup_timeout_duration);
         Self {
             app_handle: app_handle.clone(),
             progress_stepper: Mutex::new(Self::create_progress_stepper(
@@ -118,9 +118,6 @@ impl SetupPhaseImpl for WalletSetupPhase {
     }
     fn get_phase_id(&self) -> SetupPhase {
         SetupPhase::Wallet
-    }
-    fn get_status_sender(&self) -> Sender<PhaseStatus> {
-        self.status_sender.clone()
     }
     fn get_timeout_watcher(&self) -> &TimeoutWatcher {
         &self.timeout_watcher

--- a/src-tauri/src/setup/trait_setup_phase.rs
+++ b/src-tauri/src/setup/trait_setup_phase.rs
@@ -85,7 +85,6 @@ pub trait SetupPhaseImpl {
     async fn get_task_tracker(&self) -> TaskTracker;
     fn get_app_handle(&self) -> &AppHandle;
     fn get_phase_id(&self) -> SetupPhase;
-    fn get_status_sender(&self) -> Sender<PhaseStatus>;
     fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>>;
     fn get_timeout_watcher(&self) -> &TimeoutWatcher;
 }

--- a/src-tauri/src/setup/trait_setup_phase.rs
+++ b/src-tauri/src/setup/trait_setup_phase.rs
@@ -23,12 +23,17 @@
 use std::{path::PathBuf, time::Duration};
 
 use anyhow::Error;
+use tari_shutdown::ShutdownSignal;
 use tauri::{AppHandle, Manager};
 use tokio::sync::watch::{Receiver, Sender};
+use tokio_util::task::TaskTracker;
 
 use crate::progress_trackers::ProgressStepper;
 
-use super::setup_manager::{PhaseStatus, SetupFeaturesList};
+use super::{
+    setup_manager::{PhaseStatus, SetupFeaturesList, SetupPhase},
+    utils::timeout_watcher::TimeoutWatcher,
+};
 
 #[derive(Clone, Default)]
 pub struct SetupConfiguration {
@@ -51,9 +56,12 @@ pub trait SetupPhaseImpl {
     ) -> ProgressStepper;
     async fn load_app_configuration() -> Result<Self::AppConfiguration, Error>;
     async fn setup(self);
-    async fn setup_inner(&self) -> Result<(), Error>;
-    async fn finalize_setup(&self) -> Result<(), Error>;
-    fn get_app_handle(&self) -> &AppHandle;
+    fn setup_inner(
+        &self,
+    ) -> impl std::future::Future<Output = Result<(), Error>> + std::marker::Send;
+    fn finalize_setup(
+        &self,
+    ) -> impl std::future::Future<Output = Result<(), Error>> + std::marker::Send;
     fn get_app_dirs(&self) -> Result<(PathBuf, PathBuf, PathBuf), Error> {
         let data_dir = self
             .get_app_handle()
@@ -73,4 +81,11 @@ pub trait SetupPhaseImpl {
 
         Ok((data_dir, config_dir, log_dir))
     }
+    async fn get_shutdown_signal(&self) -> ShutdownSignal;
+    async fn get_task_tracker(&self) -> TaskTracker;
+    fn get_app_handle(&self) -> &AppHandle;
+    fn get_phase_id(&self) -> SetupPhase;
+    fn get_status_sender(&self) -> Sender<PhaseStatus>;
+    fn get_phase_dependencies(&self) -> Vec<Receiver<PhaseStatus>>;
+    fn get_timeout_watcher(&self) -> &TimeoutWatcher;
 }

--- a/src-tauri/src/setup/trait_setup_phase.rs
+++ b/src-tauri/src/setup/trait_setup_phase.rs
@@ -45,7 +45,10 @@ pub trait SetupPhaseImpl {
         configuration: SetupConfiguration,
         setup_features: SetupFeaturesList,
     ) -> Self;
-    fn create_progress_stepper(app_handle: AppHandle) -> ProgressStepper;
+    fn create_progress_stepper(
+        app_handle: AppHandle,
+        timeout_watcher_sender: Sender<u64>,
+    ) -> ProgressStepper;
     async fn load_app_configuration() -> Result<Self::AppConfiguration, Error>;
     async fn setup(self);
     async fn setup_inner(&self) -> Result<(), Error>;

--- a/src-tauri/src/setup/utils/mod.rs
+++ b/src-tauri/src/setup/utils/mod.rs
@@ -23,17 +23,5 @@
 use std::{future::pending, time::Duration};
 
 pub mod phase_builder;
+pub mod setup_default_adapter;
 pub mod timeout_watcher;
-
-pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
-    match duration {
-        Some(duration) => {
-            tokio::time::sleep(duration).await;
-            Some(())
-        }
-        None => {
-            pending::<()>().await;
-            None
-        }
-    }
-}

--- a/src-tauri/src/setup/utils/mod.rs
+++ b/src-tauri/src/setup/utils/mod.rs
@@ -20,8 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::{future::pending, time::Duration};
-
 pub mod phase_builder;
 pub mod setup_default_adapter;
 pub mod timeout_watcher;

--- a/src-tauri/src/setup/utils/mod.rs
+++ b/src-tauri/src/setup/utils/mod.rs
@@ -23,6 +23,7 @@
 use std::{future::pending, time::Duration};
 
 pub mod phase_builder;
+pub mod timeout_watcher;
 
 pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
     match duration {

--- a/src-tauri/src/setup/utils/setup_default_adapter.rs
+++ b/src-tauri/src/setup/utils/setup_default_adapter.rs
@@ -1,0 +1,67 @@
+use crate::{events::CriticalProblemPayload, setup::trait_setup_phase::SetupPhaseImpl, EventsEmitter};
+use log::{error, info, warn};
+use tauri_plugin_sentry::sentry;
+use tokio::select;
+
+static LOG_TARGET: &str = "tari::universe::setup_default_adapter";
+
+pub struct SetupDefaultAdapter {}
+
+impl SetupDefaultAdapter {
+    pub async fn setup<T: SetupPhaseImpl + Send + Sync + 'static>(
+        phase: T,
+    ) -> Result<(), anyhow::Error> {
+        info!(target: LOG_TARGET, "[ {} Phase ] Starting setup", phase.get_phase_id());
+        let mut shutdown_signal = phase.get_shutdown_signal().await;
+        phase.get_task_tracker().await.spawn(async move {
+            for subscriber in &mut phase.get_phase_dependencies().iter_mut() {
+                select! {
+                    _ = subscriber.wait_for(|value| value.is_success()) => {}
+                    _ = shutdown_signal.wait() => {
+                        warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", phase.get_phase_id());
+                        return;
+                    }
+                }
+            };
+
+            tokio::select! {
+                _ = phase.get_timeout_watcher().resolve_timeout() => {
+                    error!(target: LOG_TARGET, "[ {} Phase ] Setup timed out", phase.get_phase_id());
+                    let error_message = format!("[ {} Phase ] Setup timed out", phase.get_phase_id());
+                    sentry::capture_message(&error_message, sentry::Level::Error);
+                    EventsEmitter::emit_critical_problem(CriticalProblemPayload {
+                        title: Some(phase.get_phase_id().get_critical_problem_title()),
+                        description: Some(phase.get_phase_id().get_critical_problem_description()),
+                        error_message: Some(error_message),
+                    }).await;
+
+                }
+                result = phase.setup_inner() => {
+                    match result {
+                        Ok(_) => {
+                            info!(target: LOG_TARGET, "[ {} Phase ] Setup completed successfully", phase.get_phase_id());
+                            let _unused = phase.finalize_setup().await;
+    
+                        }
+                        Err(error) => {
+                            error!(target: LOG_TARGET, "[ {} Phase ] Setup failed with error: {:?}", phase.get_phase_id(),error);
+                            let error_message = format!("[ {} Phase ] Setup failed with error: {:?}", phase.get_phase_id(),error);
+                            sentry::capture_message(&error_message, sentry::Level::Error);
+                            EventsEmitter::emit_critical_problem(CriticalProblemPayload {
+                                title: Some(phase.get_phase_id().get_critical_problem_title()),
+                                description: Some(phase.get_phase_id().get_critical_problem_description()),
+                                error_message: Some(error_message),
+                            }).await;
+                        }
+                    }
+                }
+                _ = shutdown_signal.wait() => {
+                    warn!(target: LOG_TARGET, "[ {} Phase ] Setup cancelled", phase.get_phase_id());
+                }
+            };
+
+        });
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/setup/utils/timeout_watcher.rs
+++ b/src-tauri/src/setup/utils/timeout_watcher.rs
@@ -1,0 +1,96 @@
+use std::{
+    future::pending,
+    hash::{DefaultHasher, Hash, Hasher},
+    time::Duration,
+};
+
+use log::info;
+use tokio::{
+    select,
+    sync::{
+        watch::{Receiver, Sender},
+        Mutex,
+    },
+};
+
+static LOG_TARGET: &str = "tari::universe::timeout_watcher";
+
+pub fn hash_value<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+// #[derive(Clone)]
+pub struct TimeoutWatcher {
+    sender: Sender<u64>,
+    timeout_duration: Option<Duration>,
+    last_hash_value: Mutex<Option<u64>>,
+}
+
+pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
+    match duration {
+        Some(duration) => {
+            tokio::time::sleep(duration).await;
+            Some(())
+        }
+        None => {
+            pending::<()>().await;
+            None
+        }
+    }
+}
+
+impl TimeoutWatcher {
+    pub fn new(timeout_duration: Option<Duration>) -> Self {
+        Self {
+            sender: Sender::default(),
+            timeout_duration,
+            last_hash_value: Mutex::new(None),
+        }
+    }
+    pub fn get_sender(&self) -> Sender<u64> {
+        self.sender.clone()
+    }
+    pub async fn resolve_timeout(&self) -> Option<()> {
+        let mut receiver: Receiver<u64> = self.sender.subscribe();
+        loop {
+            select! {
+                _ = self.resolve_when_hash_changed(&mut receiver) => {
+                    info!(target: LOG_TARGET, "Timeout watcher received a signal to restart timeout.");
+                }
+                _ = conditional_sleeper(self.timeout_duration) => {
+                    // If the timeout duration has elapsed, we can exit the loop
+                    info!(target: LOG_TARGET, "Timeout watcher has resolved the timeout.");
+                    return Some(());
+                }
+            }
+        }
+    }
+
+    async fn resolve_when_hash_changed(
+        &self,
+        receiver: &mut Receiver<u64>,
+    ) -> Result<(), anyhow::Error> {
+        let mut last_hash_value = *self.last_hash_value.lock().await;
+        loop {
+            match receiver.changed().await {
+                Ok(_) => {
+                    let new_hash_value = *receiver.borrow();
+                    if last_hash_value.ne(&Some(new_hash_value)) {
+                        last_hash_value = Some(new_hash_value);
+                        *self.last_hash_value.lock().await = last_hash_value;
+                        info!(target: LOG_TARGET, "Timeout watcher received a signal to restart timeout.");
+                        return Ok(()); // The timeout has been reset
+                    }
+                    // If the hash value has not changed, we continue waiting
+                    continue;
+                }
+                Err(_) => {
+                    info!(target: LOG_TARGET, "Timeout watcher receiver has been closed.");
+                    return Err(anyhow::anyhow!("Timeout watcher receiver has been closed."));
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/setup/utils/timeout_watcher.rs
+++ b/src-tauri/src/setup/utils/timeout_watcher.rs
@@ -21,13 +21,6 @@ pub fn hash_value<T: Hash>(value: &T) -> u64 {
     hasher.finish()
 }
 
-// #[derive(Clone)]
-pub struct TimeoutWatcher {
-    sender: Sender<u64>,
-    timeout_duration: Option<Duration>,
-    last_hash_value: Mutex<Option<u64>>,
-}
-
 pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
     match duration {
         Some(duration) => {
@@ -39,6 +32,12 @@ pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
             None
         }
     }
+}
+
+pub struct TimeoutWatcher {
+    sender: Sender<u64>,
+    timeout_duration: Option<Duration>,
+    last_hash_value: Mutex<Option<u64>>,
 }
 
 impl TimeoutWatcher {

--- a/src-tauri/src/setup/utils/timeout_watcher.rs
+++ b/src-tauri/src/setup/utils/timeout_watcher.rs
@@ -15,12 +15,38 @@ use tokio::{
 
 static LOG_TARGET: &str = "tari::universe::timeout_watcher";
 
+/// A utility function to compute a hash value for a given value of type T.  
+/// This function uses the `DefaultHasher` to create a hash of the value.
 pub fn hash_value<T: Hash>(value: &T) -> u64 {
     let mut hasher = DefaultHasher::new();
     value.hash(&mut hasher);
     hasher.finish()
 }
 
+/// A utility function that sleeps for a specified duration if provided, or indefinitely if `None`.
+/// If a duration is provided, it will sleep for that duration and return `Some(())`.
+/// If `None` is provided, it will wait indefinitely, allowing the caller to use it in a `select!` block.
+/// This is useful for implementing dynamic timeouts
+/// # Example usage:
+/// ```rust
+/// tokio::select! {
+///    _ = conditional_sleeper(Some(Duration::from_secs(5))) => {
+///        println!("Slept for 5 seconds");
+///   }
+///   _ = some_other_future_that_needs_timeout => {
+///       println!("Some other future completed");
+///  }
+/// }
+///
+/// tokio::select! {
+///    _ = conditional_sleeper(None) => {
+///       println!("Waiting indefinitely");
+///   }
+///   _ = some_other_future_that_dont_need_timeout => {
+///      println!("Some other future completed");
+///   }
+/// }
+/// ```
 pub async fn conditional_sleeper(duration: Option<Duration>) -> Option<()> {
     match duration {
         Some(duration) => {
@@ -48,9 +74,43 @@ impl TimeoutWatcher {
             last_hash_value: Mutex::new(None),
         }
     }
+    /// Returns a clone of the sender used to notify about changes in the hash value.
+    /// # Example usage:
+    /// ```rust
+    /// use std::hash::Hash;
+    ///
+    /// #[derive(Hash)]
+    /// struct MyData {
+    ///     value: String,
+    ///     some_field: String,  
+    /// }
+    ///
+    /// let timeout_watcher = TimeoutWatcher::new(Some(Duration::from_secs(60)));
+    /// let sender = timeout_watcher.get_sender();
+    /// let my_data = MyData {
+    ///     value: "example".to_string(),
+    ///    some_field: "field".to_string(),
+    /// };
+    ///
+    ///let _unused = sender.send(hash_value(&my_data)).expect("Failed to send hash value");
+    ///```
     pub fn get_sender(&self) -> Sender<u64> {
         self.sender.clone()
     }
+    /// Resolves the timeout by waiting for either different hash value on the channel or the timeout duration to elapse.
+    ///
+    /// If the timeout duration is `None`, it will wait indefinitely. Its done on purpose to support usage with tokio's `select!` macro.
+    /// # Example usage:
+    /// ```rust
+    /// tokio::select! {
+    ///     _ = timeout_watcher.resolve_timeout() => {
+    ///         println!("Timeout elapsed");
+    ///    }
+    ///     _ = some_other_future => {
+    ///        println!("Some other future completed");
+    ///    }
+    /// }
+    /// ```
     pub async fn resolve_timeout(&self) -> Option<()> {
         let mut receiver: Receiver<u64> = self.sender.subscribe();
         loop {
@@ -66,7 +126,6 @@ impl TimeoutWatcher {
             }
         }
     }
-
     async fn resolve_when_hash_changed(
         &self,
         receiver: &mut Receiver<u64>,


### PR DESCRIPTION
### [ Summary ]
- Added utility to setup for counting timeout only if progress is not being made
- Connected `ProgressStepper` updates to new timeout utility
- Removed restarts limit to `wait_synced` in `node_manager` and increased sleep to 5 seconds
- Created setup_default_adapter for implementing the same setup logic