### PR TITLE
fix: inform user if he has no permission to download file

### DIFF
--- a/src-tauri/src/utils/error_utils.rs
+++ b/src-tauri/src/utils/error_utils.rs
@@ -1,9 +1,9 @@
 use std::io;
 
-pub fn find_io_error_kind(error: &anyhow::Error) -> Option<io::ErrorKind> {
+pub fn find_io_error(error: &anyhow::Error) -> Option<&io::Error> {
     for cause in error.chain() {
         if let Some(io_error) = cause.downcast_ref::<io::Error>() {
-            return Some(io_error.kind());
+            return Some(io_error.to_owned());
         }
     }
     None

--- a/src-tauri/src/utils/error_utils.rs
+++ b/src-tauri/src/utils/error_utils.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+pub fn find_io_error_kind(error: &anyhow::Error) -> Option<io::ErrorKind> {
+    for cause in error.chain() {
+        if let Some(io_error) = cause.downcast_ref::<io::Error>() {
+            return Some(io_error.kind());
+        }
+    }
+    None
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -22,6 +22,7 @@
 
 pub mod address_utils;
 pub mod app_flow_utils;
+pub mod error_utils;
 pub mod file_utils;
 pub mod formatting_utils;
 pub mod locks_utils;


### PR DESCRIPTION
Description
---
There is a common sentry error that users lack permissions to download binaries. This is most probably caused by not running as administrator on windows machines.

How Has This Been Tested?
---
Add this to `binaries_manager.rs` at line 480 to simulate lack of permissions:
```rust
        return Err(anyhow!(io::Error::new(
            io::ErrorKind::PermissionDenied,
            "Permission denied"
        )));
```
