### PR TITLE
feat: more robust binary monitoring (rebased)

### DIFF
--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -111,7 +111,7 @@ impl CpuMiner {
     ) -> Self {
         let (summary_watch_tx, summary_watch_rx) = watch::channel::<Option<Summary>>(None);
         let xmrig_adapter = XmrigAdapter::new(summary_watch_tx);
-        let process_watcher = ProcessWatcher::new(xmrig_adapter, stats_collector.take_cpu_miner());
+        let process_watcher = ProcessWatcher::new(xmrig_adapter, stats_collector.take_cpu_miner(), app_handle);
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),
             cpu_miner_status_watch_tx,

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -41,10 +41,10 @@ use std::time::{Duration, Instant};
 use tari_common_types::tari_address::TariAddress;
 use tari_core::transactions::tari_amount::MicroMinotari;
 use tari_shutdown::ShutdownSignal;
+use tauri::AppHandle;
 use tokio::select;
 use tokio::sync::{watch, RwLock};
 use tokio::time::{interval, sleep, timeout};
-use tauri::AppHandle;
 
 const LOG_TARGET: &str = "tari::universe::cpu_miner";
 const ECO_MODE_CPU_USAGE: u32 = 30;
@@ -113,7 +113,8 @@ impl CpuMiner {
     ) -> Self {
         let (summary_watch_tx, summary_watch_rx) = watch::channel::<Option<Summary>>(None);
         let xmrig_adapter = XmrigAdapter::new(summary_watch_tx);
-        let process_watcher = ProcessWatcher::new(xmrig_adapter, stats_collector.take_cpu_miner(), app_handle);
+        let process_watcher =
+            ProcessWatcher::new(xmrig_adapter, stats_collector.take_cpu_miner(), app_handle);
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),
             cpu_miner_status_watch_tx,

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -44,6 +44,7 @@ use tari_shutdown::ShutdownSignal;
 use tokio::select;
 use tokio::sync::{watch, RwLock};
 use tokio::time::{interval, sleep, timeout};
+use tauri::AppHandle;
 
 const LOG_TARGET: &str = "tari::universe::cpu_miner";
 const ECO_MODE_CPU_USAGE: u32 = 30;
@@ -108,6 +109,7 @@ impl CpuMiner {
         stats_collector: &mut ProcessStatsCollectorBuilder,
         cpu_miner_status_watch_tx: watch::Sender<CpuMinerStatus>,
         node_status_watch_rx: watch::Receiver<BaseNodeStatus>,
+        app_handle: AppHandle, // Add this parameter
     ) -> Self {
         let (summary_watch_tx, summary_watch_rx) = watch::channel::<Option<Summary>>(None);
         let xmrig_adapter = XmrigAdapter::new(summary_watch_tx);

--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -109,7 +109,7 @@ impl CpuMiner {
         stats_collector: &mut ProcessStatsCollectorBuilder,
         cpu_miner_status_watch_tx: watch::Sender<CpuMinerStatus>,
         node_status_watch_rx: watch::Receiver<BaseNodeStatus>,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let (summary_watch_tx, summary_watch_rx) = watch::channel::<Option<Summary>>(None);
         let xmrig_adapter = XmrigAdapter::new(summary_watch_tx);

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -79,6 +79,10 @@ pub enum EventType {
     AppInMemoryConfigChanged,
     DisabledPhasesChanged,
     UniversalMinerInitializedExchangeIdChanged,
+    // New event types for binary retry functionality
+    BinaryStartupAttempt,
+    BinaryRuntimeRestartAttempt,
+    BinaryPermanentFailure,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -89,6 +93,7 @@ pub enum ProgressEvents {
     Node,
     Unknown,
 }
+
 #[derive(Clone, Debug, Serialize)]
 pub struct ProgressTrackerUpdatePayload {
     pub phase_title: String,
@@ -187,4 +192,25 @@ pub struct DisabledPhasesPayload {
 #[derive(Debug, Serialize, Clone)]
 pub struct UniversalMinerInitializedExchangeIdChangedPayload {
     pub universal_miner_initialized_exchange_id: String,
+}
+
+// New payload structures for binary retry functionality
+#[derive(Clone, Debug, Serialize)]
+pub struct BinaryStartupAttemptPayload {
+    pub name: String,
+    pub attempt: u32,
+    pub max_attempts: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BinaryRuntimeRestartAttemptPayload {
+    pub name: String,
+    pub attempt: u32,
+    pub max_attempts: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BinaryPermanentFailurePayload {
+    pub name: String,
+    pub reason: String, // "startup" or "runtime"
 }

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -24,7 +24,8 @@ use crate::app_in_memory_config::AppInMemoryConfig;
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use crate::events::{
-    AppInMemoryConfigChangedPayload, ConnectionStatusPayload, CriticalProblemPayload,
+    AppInMemoryConfigChangedPayload, BinaryPermanentFailurePayload, BinaryRuntimeRestartAttemptPayload,
+    BinaryStartupAttemptPayload, ConnectionStatusPayload, CriticalProblemPayload,
     DisabledPhasesPayload, InitWalletScanningProgressPayload,
     UniversalMinerInitializedExchangeIdChangedPayload,
 };
@@ -787,6 +788,61 @@ impl EventsEmitter {
             .emit(BACKEND_STATE_UPDATE, event)
         {
             error!(target: LOG_TARGET, "Failed to emit UniversalMinerInitializedExchangeIdChanged event: {:?}", e);
+        }
+    }
+
+    pub async fn emit_binary_startup_attempt(
+        app_handle: &AppHandle,
+        name: String,
+        attempt: u32,
+        max_attempts: u32,
+    ) {
+        let _unused = FrontendReadyChannel::current().wait_for_ready().await;
+        let event = Event {
+            event_type: EventType::BinaryStartupAttempt,
+            payload: BinaryStartupAttemptPayload {
+                name,
+                attempt,
+                max_attempts,
+            },
+        };
+        if let Err(e) = app_handle.emit(BACKEND_STATE_UPDATE, event) {
+            error!(target: LOG_TARGET, "Failed to emit BinaryStartupAttempt event: {:?}", e);
+        }
+    }
+
+    pub async fn emit_binary_runtime_restart_attempt(
+        app_handle: &AppHandle,
+        name: String,
+        attempt: u32,
+        max_attempts: u32,
+    ) {
+        let _unused = FrontendReadyChannel::current().wait_for_ready().await;
+        let event = Event {
+            event_type: EventType::BinaryRuntimeRestartAttempt,
+            payload: BinaryRuntimeRestartAttemptPayload {
+                name,
+                attempt,
+                max_attempts,
+            },
+        };
+        if let Err(e) = app_handle.emit(BACKEND_STATE_UPDATE, event) {
+            error!(target: LOG_TARGET, "Failed to emit BinaryRuntimeRestartAttempt event: {:?}", e);
+        }
+    }
+
+    pub async fn emit_binary_permanent_failure(
+        app_handle: &AppHandle,
+        name: String,
+        reason: String,
+    ) {
+        let _unused = FrontendReadyChannel::current().wait_for_ready().await;
+        let event = Event {
+            event_type: EventType::BinaryPermanentFailure,
+            payload: BinaryPermanentFailurePayload { name, reason },
+        };
+        if let Err(e) = app_handle.emit(BACKEND_STATE_UPDATE, event) {
+            error!(target: LOG_TARGET, "Failed to emit BinaryPermanentFailure event: {:?}", e);
         }
     }
 }

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -138,14 +138,10 @@ impl EventsManager {
         EventsEmitter::emit_binary_runtime_restart_attempt(app, name, attempt, max_attempts).await;
     }
 
-    pub async fn emit_binary_permanent_failure(
-        app: &AppHandle,
-        name: String,
-        reason: String,
-    ) {
+    pub async fn emit_binary_permanent_failure(app: &AppHandle, name: String, reason: String) {
         // Clone the name before the first use
         EventsEmitter::emit_binary_permanent_failure(app, name.clone(), reason).await;
-        
+
         // Now we can use name again
         Self::handle_critical_problem(
             app,

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -119,4 +119,41 @@ impl EventsManager {
 
         EventsEmitter::emit_node_type_update(payload).await;
     }
+
+    pub async fn emit_binary_startup_attempt(
+        app: &AppHandle,
+        name: String,
+        attempt: u32,
+        max_attempts: u32,
+    ) {
+        EventsEmitter::emit_binary_startup_attempt(app, name, attempt, max_attempts).await;
+    }
+
+    pub async fn emit_binary_runtime_restart_attempt(
+        app: &AppHandle,
+        name: String,
+        attempt: u32,
+        max_attempts: u32,
+    ) {
+        EventsEmitter::emit_binary_runtime_restart_attempt(app, name, attempt, max_attempts).await;
+    }
+
+    pub async fn emit_binary_permanent_failure(
+        app: &AppHandle,
+        name: String,
+        reason: String,
+    ) {
+        EventsEmitter::emit_binary_permanent_failure(app, name, reason).await;
+        
+        // Also emit a critical problem for serious failures
+        Self::handle_critical_problem(
+            app,
+            Some(format!("{} Failed", name)),
+            Some(format!(
+                "The {} process failed to start or stay running after multiple attempts. Please check the logs or try restarting the application.",
+                name
+            )),
+            None,
+        ).await;
+    }
 }

--- a/src-tauri/src/events_manager.rs
+++ b/src-tauri/src/events_manager.rs
@@ -143,9 +143,10 @@ impl EventsManager {
         name: String,
         reason: String,
     ) {
-        EventsEmitter::emit_binary_permanent_failure(app, name, reason).await;
+        // Clone the name before the first use
+        EventsEmitter::emit_binary_permanent_failure(app, name.clone(), reason).await;
         
-        // Also emit a critical problem for serious failures
+        // Now we can use name again
         Self::handle_critical_problem(
             app,
             Some(format!("{} Failed", name)),

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -97,7 +97,8 @@ impl GpuMiner {
     ) -> Self {
         let (gpu_raw_status_tx, gpu_raw_status_rx) = watch::channel(None);
         let adapter = GpuMinerAdapter::new(Vec::new(), gpu_raw_status_tx);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_gpu_miner(), app_handle);
+        let mut process_watcher =
+            ProcessWatcher::new(adapter, stats_collector.take_gpu_miner(), app_handle);
         process_watcher.health_timeout = Duration::from_secs(9);
         process_watcher.poll_time = Duration::from_secs(10);
 

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -93,7 +93,7 @@ impl GpuMiner {
         status_broadcast: watch::Sender<GpuMinerStatus>,
         node_status_watch_rx: watch::Receiver<BaseNodeStatus>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let (gpu_raw_status_tx, gpu_raw_status_rx) = watch::channel(None);
         let adapter = GpuMinerAdapter::new(Vec::new(), gpu_raw_status_tx);

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -96,7 +96,7 @@ impl GpuMiner {
     ) -> Self {
         let (gpu_raw_status_tx, gpu_raw_status_rx) = watch::channel(None);
         let adapter = GpuMinerAdapter::new(Vec::new(), gpu_raw_status_tx);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_gpu_miner());
+        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_gpu_miner(), app_handle);
         process_watcher.health_timeout = Duration::from_secs(9);
         process_watcher.poll_time = Duration::from_secs(10);
 

--- a/src-tauri/src/gpu_miner.rs
+++ b/src-tauri/src/gpu_miner.rs
@@ -93,6 +93,7 @@ impl GpuMiner {
         status_broadcast: watch::Sender<GpuMinerStatus>,
         node_status_watch_rx: watch::Receiver<BaseNodeStatus>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
+        app_handle: AppHandle, // Add this parameter
     ) -> Self {
         let (gpu_raw_status_tx, gpu_raw_status_rx) = watch::channel(None);
         let adapter = GpuMinerAdapter::new(Vec::new(), gpu_raw_status_tx);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -284,6 +284,7 @@ struct FEPayload {
 }
 
 // Helper function to create managers with AppHandle
+#[allow(clippy::too_many_arguments)]
 async fn create_managers_with_app_handle(
     app_handle: tauri::AppHandle,
     stats_collector: &mut ProcessStatsCollectorBuilder,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -326,7 +326,7 @@ async fn create_managers_with_app_handle(
     let (local_node_watch_tx, local_node_watch_rx) = watch::channel(BaseNodeStatus::default());
     let (remote_node_watch_tx, remote_node_watch_rx) = watch::channel(BaseNodeStatus::default());
     let (base_node_watch_tx, _) = watch::channel(BaseNodeStatus::default());
-    
+
     let node_manager = NodeManager::new(
         stats_collector,
         LocalNodeAdapter::new(local_node_watch_tx.clone()),
@@ -346,32 +346,29 @@ async fn create_managers_with_app_handle(
     );
 
     let spend_wallet_manager = SpendWalletManager::new(node_manager.clone());
-    
+
     let cpu_miner = CpuMiner::new(
         stats_collector,
         cpu_miner_status_watch_tx.clone(), // Clone here
         base_node_watch_rx.clone(),
         app_handle.clone(),
     );
-    
+
     let gpu_miner = GpuMiner::new(
         gpu_status_tx.clone(), // Clone here
         base_node_watch_rx.clone(),
         stats_collector,
         app_handle.clone(),
     );
-    
+
     let tor_manager = TorManager::new(
         tor_watch_tx.clone(), // Clone here
         stats_collector,
         app_handle.clone(),
     );
-    
-    let mm_proxy_manager = MmProxyManager::new(
-        stats_collector,
-        app_handle.clone(),
-    );
-    
+
+    let mm_proxy_manager = MmProxyManager::new(stats_collector, app_handle.clone());
+
     let p2pool_manager = P2poolManager::new(
         p2pool_stats_tx.clone(), // Clone here
         stats_collector,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -297,7 +297,7 @@ async fn create_managers_with_app_handle(
     p2pool_stats_tx: watch::Sender<Option<P2poolStats>>,
     tor_watch_tx: watch::Sender<TorStatus>,
     app_in_memory_config: Arc<RwLock<AppInMemoryConfig>>,
-    cpu_config: Arc<RwLock<CpuMinerConfig>>,
+    _cpu_config: Arc<RwLock<CpuMinerConfig>>, // Prefix with _ to silence warning
 ) -> (
     NodeManager,
     WalletManager,
@@ -315,6 +315,12 @@ async fn create_managers_with_app_handle(
     Feedback,
     MiningStatusManager,
 ) {
+    // Create receivers before passing senders to constructors
+    let gpu_status_rx = gpu_status_tx.subscribe();
+    let cpu_miner_status_watch_rx = cpu_miner_status_watch_tx.subscribe();
+    let p2pool_stats_rx = p2pool_stats_tx.subscribe();
+    let tor_watch_rx = tor_watch_tx.subscribe();
+
     // Create node manager components
     let (local_node_watch_tx, local_node_watch_rx) = watch::channel(BaseNodeStatus::default());
     let (remote_node_watch_tx, remote_node_watch_rx) = watch::channel(BaseNodeStatus::default());
@@ -339,42 +345,40 @@ async fn create_managers_with_app_handle(
     );
 
     let spend_wallet_manager = SpendWalletManager::new(node_manager.clone());
-
+    
     let cpu_miner = CpuMiner::new(
         stats_collector,
-        cpu_miner_status_watch_tx,
+        cpu_miner_status_watch_tx.clone(), // Clone here
         base_node_watch_rx.clone(),
         app_handle.clone(),
     );
-
+    
     let gpu_miner = GpuMiner::new(
-        gpu_status_tx,
+        gpu_status_tx.clone(), // Clone here
         base_node_watch_rx.clone(),
         stats_collector,
         app_handle.clone(),
     );
-
+    
     let tor_manager = TorManager::new(
-        tor_watch_tx,
+        tor_watch_tx.clone(), // Clone here
         stats_collector,
         app_handle.clone(),
     );
-
+    
     let mm_proxy_manager = MmProxyManager::new(
         stats_collector,
         app_handle.clone(),
     );
-
+    
     let p2pool_manager = P2poolManager::new(
-        p2pool_stats_tx.clone(),
+        p2pool_stats_tx.clone(), // Clone here
         stats_collector,
         app_handle.clone(),
     );
 
-    let (tor_watch_rx,) = (tor_watch_tx.subscribe(),);
-    let (gpu_status_rx,) = (gpu_status_tx.subscribe(),);
-    let (cpu_miner_status_watch_rx,) = (cpu_miner_status_watch_tx.subscribe(),);
-    let (p2pool_stats_rx,) = (p2pool_stats_tx.subscribe(),);
+    // Build stats collector before creating telemetry manager
+    let stats_collector_built = ProcessStatsCollectorBuilder::new().build();
 
     let telemetry_manager = TelemetryManager::new(
         cpu_miner_status_watch_rx.clone(),
@@ -384,7 +388,7 @@ async fn create_managers_with_app_handle(
         base_node_watch_rx.clone(),
         p2pool_stats_rx.clone(),
         tor_watch_rx.clone(),
-        stats_collector.build(),
+        stats_collector_built, // Use the built version
         node_manager.clone(),
     );
 
@@ -477,12 +481,12 @@ fn main() {
     ));
     let _guard = minidump::init(&client);
 
-    let mut stats_collector = ProcessStatsCollectorBuilder::new();
+    let _stats_collector = ProcessStatsCollectorBuilder::new();
     
     // Create channels for communication between components
-    let (base_node_watch_tx, base_node_watch_rx) = watch::channel(BaseNodeStatus::default());
+    let (_base_node_watch_tx, base_node_watch_rx) = watch::channel(BaseNodeStatus::default());
     let (wallet_state_watch_tx, wallet_state_watch_rx) = watch::channel::<Option<WalletState>>(None);
-    let (websocket_message_tx, websocket_message_rx) = tokio::sync::mpsc::channel::<WebsocketMessage>(500);
+    let (websocket_message_tx, _websocket_message_rx) = tokio::sync::mpsc::channel::<WebsocketMessage>(500);
     let (websocket_manager_status_tx, websocket_manager_status_rx) = watch::channel::<WebsocketManagerStatusMessage>(WebsocketManagerStatusMessage::Stopped);
     let (gpu_status_tx, gpu_status_rx) = watch::channel(GpuMinerStatus::default());
     let (cpu_miner_status_watch_tx, cpu_miner_status_watch_rx) = watch::channel::<CpuMinerStatus>(CpuMinerStatus::default());
@@ -494,7 +498,7 @@ fn main() {
     let spend_wallet_manager =
         SpendWalletManager::new(node_manager.clone(), base_node_watch_rx.clone());
     let (p2pool_stats_tx, p2pool_stats_rx) = watch::channel(None);
-    let (tor_watch_tx, tor_watch_rx) = watch::channel(TorStatus::default());
+    let (tor_watch_tx, _tor_watch_rx) = watch::channel(TorStatus::default());
 
     let cpu_config = Arc::new(RwLock::new(CpuMinerConfig {
         node_connection: CpuMinerConnection::BuiltInProxy,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -987,10 +987,6 @@ fn main() {
                 tauri::async_runtime::spawn(async move {
                     SetupManager::get_instance().start_setup(handle_clone.clone()).await;
                     SetupManager::spawn_sleep_mode_handler(handle_clone.clone()).await;
-                    // Initialize frontend updates after setup is complete
-                    if let Err(e) = initialize_frontend_updates(&handle_clone).await {
-                        error!(target: LOG_TARGET, "Failed to initialize frontend updates: {:?}", e);
-                    }
                 });
             }
             tauri::RunEvent::ExitRequested { api: _, code, .. } => {

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -29,6 +29,7 @@ use log::info;
 use tari_common_types::tari_address::TariAddress;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
+use tauri::AppHandle;
 
 use crate::mm_proxy_adapter::{MergeMiningProxyAdapter, MergeMiningProxyConfig};
 use crate::port_allocator::PortAllocator;
@@ -84,7 +85,10 @@ impl Clone for MmProxyManager {
 }
 
 impl MmProxyManager {
-    pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder) -> Self {
+    pub fn new(
+        stats_collector: &mut ProcessStatsCollectorBuilder,
+        app_handle: AppHandle, // Add this parameter
+    ) -> Self {
         let sidecar_adapter = MergeMiningProxyAdapter::new();
         let mut process_watcher =
             ProcessWatcher::new(sidecar_adapter, stats_collector.take_mm_proxy(), app_handle);

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -87,7 +87,7 @@ impl MmProxyManager {
     pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder) -> Self {
         let sidecar_adapter = MergeMiningProxyAdapter::new();
         let mut process_watcher =
-            ProcessWatcher::new(sidecar_adapter, stats_collector.take_mm_proxy());
+            ProcessWatcher::new(sidecar_adapter, stats_collector.take_mm_proxy(), app_handle);
         process_watcher.health_timeout = std::time::Duration::from_secs(28);
         process_watcher.poll_time = std::time::Duration::from_secs(30);
         process_watcher.expected_startup_time = std::time::Duration::from_secs(120);

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -27,9 +27,9 @@ use std::time::Instant;
 use anyhow::anyhow;
 use log::info;
 use tari_common_types::tari_address::TariAddress;
+use tauri::AppHandle;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
-use tauri::AppHandle;
 
 use crate::mm_proxy_adapter::{MergeMiningProxyAdapter, MergeMiningProxyConfig};
 use crate::port_allocator::PortAllocator;
@@ -85,10 +85,7 @@ impl Clone for MmProxyManager {
 }
 
 impl MmProxyManager {
-    pub fn new(
-        stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle,
-    ) -> Self {
+    pub fn new(stats_collector: &mut ProcessStatsCollectorBuilder, app_handle: AppHandle) -> Self {
         let sidecar_adapter = MergeMiningProxyAdapter::new();
         let mut process_watcher =
             ProcessWatcher::new(sidecar_adapter, stats_collector.take_mm_proxy(), app_handle);

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -87,7 +87,7 @@ impl Clone for MmProxyManager {
 impl MmProxyManager {
     pub fn new(
         stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let sidecar_adapter = MergeMiningProxyAdapter::new();
         let mut process_watcher =

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -98,6 +98,7 @@ pub struct NodeManager {
 }
 
 impl NodeManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         stats_collector: &mut ProcessStatsCollectorBuilder,
         local_node_adapter: LocalNodeAdapter,

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -106,7 +106,7 @@ impl NodeManager {
         base_node_watch_tx: watch::Sender<BaseNodeStatus>,
         local_node_watch_rx: watch::Receiver<BaseNodeStatus>,
         remote_node_watch_rx: watch::Receiver<BaseNodeStatus>,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let stats_broadcast = stats_collector.take_minotari_node();
         let local_node_watcher: Option<ProcessWatcher<LocalNodeAdapter>> =

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -27,9 +27,9 @@ use std::time::Duration;
 use futures_util::future::FusedFuture;
 use log::{info, warn};
 use tari_common::configuration::Network;
+use tauri::AppHandle;
 use tokio::sync::{watch, RwLock};
 use tokio::time::sleep;
-use tauri::AppHandle;
 
 use crate::p2pool::models::{Connections, P2poolStats};
 use crate::p2pool_adapter::P2poolAdapter;
@@ -145,7 +145,8 @@ impl P2poolManager {
         app_handle: AppHandle,
     ) -> Self {
         let adapter = P2poolAdapter::new(stats_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool(), app_handle);
+        let mut process_watcher =
+            ProcessWatcher::new(adapter, stats_collector.take_p2pool(), app_handle);
         process_watcher.expected_startup_time = Duration::from_secs(300);
 
         Self {

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -29,6 +29,7 @@ use log::{info, warn};
 use tari_common::configuration::Network;
 use tokio::sync::{watch, RwLock};
 use tokio::time::sleep;
+use tauri::AppHandle;
 
 use crate::p2pool::models::{Connections, P2poolStats};
 use crate::p2pool_adapter::P2poolAdapter;
@@ -141,6 +142,7 @@ impl P2poolManager {
     pub fn new(
         stats_broadcast: watch::Sender<Option<P2poolStats>>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
+        app_handle: AppHandle, // Add this parameter
     ) -> Self {
         let adapter = P2poolAdapter::new(stats_broadcast);
         let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool(), app_handle);

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -143,7 +143,7 @@ impl P2poolManager {
         stats_collector: &mut ProcessStatsCollectorBuilder,
     ) -> Self {
         let adapter = P2poolAdapter::new(stats_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool());
+        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool(), app_handle);
         process_watcher.expected_startup_time = Duration::from_secs(300);
 
         Self {

--- a/src-tauri/src/p2pool_manager.rs
+++ b/src-tauri/src/p2pool_manager.rs
@@ -142,7 +142,7 @@ impl P2poolManager {
     pub fn new(
         stats_broadcast: watch::Sender<Option<P2poolStats>>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let adapter = P2poolAdapter::new(stats_broadcast);
         let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_p2pool(), app_handle);

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -156,7 +156,6 @@ pub(crate) trait ProcessInstanceTrait: Sync + Send + 'static {
     fn ping(&self) -> bool;
     async fn start(&mut self, task_tracker: TaskTracker) -> Result<(), anyhow::Error>;
     async fn stop(&mut self) -> Result<i32, anyhow::Error>;
-    fn is_shutdown_triggered(&self) -> bool;
     async fn wait(&mut self) -> Result<i32, anyhow::Error>;
     async fn start_and_wait_for_output(
         &mut self,
@@ -315,10 +314,6 @@ impl ProcessInstanceTrait for ProcessInstance {
         handle
             .ok_or_else(|| anyhow!("Handle is not present"))?
             .await?
-    }
-
-    fn is_shutdown_triggered(&self) -> bool {
-        self.shutdown.is_triggered()
     }
 
     async fn wait(&mut self) -> Result<i32, anyhow::Error> {

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -156,6 +156,7 @@ pub(crate) trait ProcessInstanceTrait: Sync + Send + 'static {
     fn ping(&self) -> bool;
     async fn start(&mut self, task_tracker: TaskTracker) -> Result<(), anyhow::Error>;
     async fn stop(&mut self) -> Result<i32, anyhow::Error>;
+    fn is_shutdown_triggered(&self) -> bool;
     async fn wait(&mut self) -> Result<i32, anyhow::Error>;
     async fn start_and_wait_for_output(
         &mut self,
@@ -314,6 +315,10 @@ impl ProcessInstanceTrait for ProcessInstance {
         handle
             .ok_or_else(|| anyhow!("Handle is not present"))?
             .await?
+    }
+
+    fn is_shutdown_triggered(&self) -> bool {
+        self.shutdown.is_triggered()
     }
 
     async fn wait(&mut self) -> Result<i32, anyhow::Error> {

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -160,11 +160,10 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                     let health_status = status_monitor.check_health(Duration::from_secs(0), self.health_timeout).await;
                     match health_status {
                         HealthStatus::Healthy => {
-                            // Reset failure tracking on success
-                            consecutive_health_failures = 0;
-                            grace_period_active = false;
                             info!(target: LOG_TARGET, "Process '{}' stabilized and is healthy.", name);
                             initial_health_passed = true;
+                            // Reset failure tracking on success - these values won't be used again since we're exiting
+                            let _ = (consecutive_health_failures, grace_period_active);
                             break;
                         }
                         HealthStatus::Warning => {

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -36,7 +36,6 @@ use tokio::task::JoinHandle;
 
 use tokio::select;
 use tokio::sync::watch;
-use tokio::time::sleep;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::task::TaskTracker;
 
@@ -195,7 +194,7 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
         config_path: PathBuf,
         log_path: PathBuf,
         binary: Binaries,
-        global_shutdown_signal: ShutdownSignal,
+        mut global_shutdown_signal: ShutdownSignal,
         task_tracker: TaskTracker,
     ) -> Result<(), anyhow::Error> {
         if global_shutdown_signal.is_terminated() || global_shutdown_signal.is_triggered() {
@@ -411,19 +410,18 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
                 *warning_count += 1;
                 if *warning_count > 10 {
                     error!(target: LOG_TARGET, "'{}' is not healthy. Health check returned warning {} times.", name, *warning_count);
-                    is_healthy = false;
+                    // Don't assign to is_healthy here since it's not used after this
                 } else {
                     is_healthy = true;
                 }
             }
             HealthStatus::Unhealthy => {
                 warn!(target: LOG_TARGET, "'{}' is not healthy. Health check returned Unhealthy status.", name);
-                is_healthy = false;
+                // Don't assign to is_healthy here since it's not used after this
             }
         }
     } else {
         ping_failed = true;
-        is_healthy = false;
         warn!(target: LOG_TARGET, "Process '{}' ping failed, process is not running.", name);
     }
 

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -73,7 +73,11 @@ pub struct ProcessWatcher<TAdapter: ProcessAdapter> {
 }
 
 impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
-    pub fn new(adapter: TAdapter, stats_broadcast: watch::Sender<ProcessWatcherStats>, app_handle: AppHandle) -> Self {
+    pub fn new(
+        adapter: TAdapter,
+        stats_broadcast: watch::Sender<ProcessWatcherStats>,
+        app_handle: AppHandle,
+    ) -> Self {
         Self {
             adapter,
             watcher_task: None,
@@ -122,13 +126,22 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
         loop {
             if global_shutdown_signal.is_triggered() || inner_shutdown_signal.is_triggered() {
                 info!(target: LOG_TARGET, "Shutdown triggered during initial startup of {}", name);
-                return Err(anyhow::anyhow!("Shutdown during initial startup of {}", name));
+                return Err(anyhow::anyhow!(
+                    "Shutdown during initial startup of {}",
+                    name
+                ));
             }
-    
+
             startup_attempts += 1;
             info!(target: LOG_TARGET, "Attempting to start '{}' (Attempt {}/{})", name, startup_attempts, self.max_startup_attempts);
-            EventsManager::emit_binary_startup_attempt(&self.app_handle, name.to_string(), startup_attempts, self.max_startup_attempts).await;
-    
+            EventsManager::emit_binary_startup_attempt(
+                &self.app_handle,
+                name.to_string(),
+                startup_attempts,
+                self.max_startup_attempts,
+            )
+            .await;
+
             if let Err(e) = child.start(task_tracker.clone()).await {
                 warn!(target: LOG_TARGET, "child.start() failed for '{}': {:?}.", name, e);
             } else {
@@ -138,9 +151,10 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                 let mut consecutive_health_failures = 0;
                 let mut grace_period_active = false;
                 let mut grace_deadline = Instant::now(); // Will be set when needed
-    
+
                 while Instant::now() < stabilization_deadline {
-                    if global_shutdown_signal.is_triggered() || inner_shutdown_signal.is_triggered() {
+                    if global_shutdown_signal.is_triggered() || inner_shutdown_signal.is_triggered()
+                    {
                         warn!(target: LOG_TARGET, "Shutdown during stabilization for {}", name);
                         let _ = child.stop().await;
                         return Err(anyhow::anyhow!("Shutdown during stabilization of {}", name));
@@ -149,15 +163,17 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                         warn!(target: LOG_TARGET, "Process '{}' died immediately after start (ping failed).", name);
                         break;
                     }
-    
+
                     // Smart grace period: only skip health checks if grace period is active
                     if grace_period_active && Instant::now() < grace_deadline {
                         info!(target: LOG_TARGET, "Process '{}' in adaptive grace period due to previous failures", name);
                         tokio::time::sleep(Duration::from_secs(2)).await;
                         continue;
                     }
-    
-                    let health_status = status_monitor.check_health(Duration::from_secs(0), self.health_timeout).await;
+
+                    let health_status = status_monitor
+                        .check_health(Duration::from_secs(0), self.health_timeout)
+                        .await;
                     match health_status {
                         HealthStatus::Healthy => {
                             info!(target: LOG_TARGET, "Process '{}' stabilized and is healthy.", name);
@@ -170,7 +186,9 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                             consecutive_health_failures += 1;
                             if consecutive_health_failures >= 3 && !grace_period_active {
                                 // Activate grace period after 3 consecutive warnings
-                                let grace_duration = Duration::from_secs(5 + (consecutive_health_failures as u64 * 2));
+                                let grace_duration = Duration::from_secs(
+                                    5 + (consecutive_health_failures as u64 * 2),
+                                );
                                 grace_deadline = Instant::now() + grace_duration;
                                 grace_period_active = true;
                                 info!(target: LOG_TARGET, "Activating {:.1}s grace period for '{}' after {} warning failures", 
@@ -182,14 +200,16 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                             consecutive_health_failures += 1;
                             if consecutive_health_failures >= 2 && !grace_period_active {
                                 // Activate grace period after 2 unhealthy checks
-                                let grace_duration = Duration::from_secs(8 + (consecutive_health_failures as u64 * 3));
+                                let grace_duration = Duration::from_secs(
+                                    8 + (consecutive_health_failures as u64 * 3),
+                                );
                                 grace_deadline = Instant::now() + grace_duration;
                                 grace_period_active = true;
                                 info!(target: LOG_TARGET, "Activating {:.1}s grace period for '{}' after {} unhealthy failures", 
                                       grace_duration.as_secs_f32(), name, consecutive_health_failures);
                             }
                             warn!(target: LOG_TARGET, "Process '{}' became unhealthy during stabilization ({} consecutive failures).", name, consecutive_health_failures);
-                            
+
                             if consecutive_health_failures >= 6 {
                                 // Give up after too many failures
                                 warn!(target: LOG_TARGET, "Process '{}' failed too many consecutive health checks ({}), giving up on this attempt.", name, consecutive_health_failures);
@@ -199,26 +219,34 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                     }
                     tokio::time::sleep(Duration::from_secs(2)).await;
                 }
-    
+
                 if initial_health_passed {
                     info!(target: LOG_TARGET, "Process '{}' successfully started and stabilized.", name);
                     return Ok(());
                 }
-    
+
                 warn!(target: LOG_TARGET, "Process '{}' did not stabilize or become healthy. Stopping before retry.", name);
                 if let Err(e) = child.stop().await {
                     warn!(target: LOG_TARGET, "Error stopping child process '{}' after failed stabilization: {:?}", name, e);
                 }
             }
-    
+
             stats.num_restarts += 1;
-    
+
             if startup_attempts >= self.max_startup_attempts {
                 error!(target: LOG_TARGET, "Failed to start and stabilize process '{}' after {} attempts.", name, self.max_startup_attempts);
-                EventsManager::emit_binary_permanent_failure(&self.app_handle, name.to_string(), "startup".to_string()).await;
-                return Err(anyhow::anyhow!("Failed to start '{}' after max startup retries", name));
+                EventsManager::emit_binary_permanent_failure(
+                    &self.app_handle,
+                    name.to_string(),
+                    "startup".to_string(),
+                )
+                .await;
+                return Err(anyhow::anyhow!(
+                    "Failed to start '{}' after max startup retries",
+                    name
+                ));
             }
-    
+
             warn!(target: LOG_TARGET, "Retrying startup for '{}' in {:?}.", name, self.startup_retry_delay);
             tokio::time::sleep(self.startup_retry_delay).await;
         }
@@ -280,7 +308,8 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
             &global_shutdown_signal,
             &inner_shutdown_signal_for_startup,
             &mut stats,
-        ).await?;
+        )
+        .await?;
 
         info!(target: LOG_TARGET, "Process '{}' successfully started & stabilized. Entering main monitoring loop.", name);
         let mut uptime = Instant::now();
@@ -428,13 +457,13 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
 
         match select! {
             r = status_monitor.check_health(current_uptime, health_timeout) => r,
-            _ = inner_shutdown2.wait() => { 
-                info!(target: LOG_TARGET, "Inner shutdown during health check for '{}'", name); 
-                return Ok(Some(0)); 
+            _ = inner_shutdown2.wait() => {
+                info!(target: LOG_TARGET, "Inner shutdown during health check for '{}'", name);
+                return Ok(Some(0));
             },
-            _ = app_shutdown2.wait() => { 
-                info!(target: LOG_TARGET, "Global shutdown during health check for '{}'", name); 
-                return Ok(Some(0)); 
+            _ = app_shutdown2.wait() => {
+                info!(target: LOG_TARGET, "Global shutdown during health check for '{}'", name);
+                return Ok(Some(0));
             }
         } {
             HealthStatus::Healthy => {
@@ -480,34 +509,45 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
                         return Ok(Some(exit_code));
                     }
                 }
-                Err(e) => warn!(target: LOG_TARGET, "Error stopping unhealthy process '{}': {:?}. Attempting restart regardless.", name, e),
+                Err(e) => {
+                    warn!(target: LOG_TARGET, "Error stopping unhealthy process '{}': {:?}. Attempting restart regardless.", name, e)
+                }
             }
-    
+
             if let Err(e) = status_monitor.handle_unhealthy().await {
                 error!(target: LOG_TARGET, "Failed to handle unhealthy status for '{}': {}. Proceeding with restart attempt.", name, e);
             }
-            
+
             // Runtime Restart Loop
             let mut runtime_restart_attempts = 0;
             loop {
-                if global_shutdown_signal.is_triggered() 
-                    || inner_shutdown.is_triggered() 
-                    || child.is_shutdown_triggered() {
+                if global_shutdown_signal.is_triggered()
+                    || inner_shutdown.is_triggered()
+                    || child.is_shutdown_triggered()
+                {
                     info!(target: LOG_TARGET, "Shutdown triggered during runtime restart of '{}'.", name);
                     return Ok(Some(0));
                 }
-    
+
                 runtime_restart_attempts += 1;
 
                 info!(target: LOG_TARGET, "Restarting '{}' (Runtime attempt {}/{})", name, runtime_restart_attempts, max_runtime_restart_attempts);
-                EventsManager::emit_binary_runtime_restart_attempt(app_handle, name.to_string(), runtime_restart_attempts, max_runtime_restart_attempts).await;
+                EventsManager::emit_binary_runtime_restart_attempt(
+                    app_handle,
+                    name.to_string(),
+                    runtime_restart_attempts,
+                    max_runtime_restart_attempts,
+                )
+                .await;
                 stats.num_restarts += 1;
 
                 match child.start(task_tracker.clone()).await {
                     Ok(_) => {
                         tokio::time::sleep(Duration::from_secs(2)).await;
                         if child.ping() {
-                            let health_after_restart = status_monitor.check_health(Duration::from_secs(0), health_timeout).await;
+                            let health_after_restart = status_monitor
+                                .check_health(Duration::from_secs(0), health_timeout)
+                                .await;
                             if health_after_restart == HealthStatus::Healthy {
                                 info!(target: LOG_TARGET, "Process '{}' restarted successfully.", name);
                                 *warning_count = 0;
@@ -518,18 +558,26 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
                                 let _ = child.stop().await;
                             }
                         } else {
-                             warn!(target: LOG_TARGET, "Process '{}' restarted but died immediately (ping failed).", name);
+                            warn!(target: LOG_TARGET, "Process '{}' restarted but died immediately (ping failed).", name);
                         }
                     }
                     Err(e) => {
                         warn!(target: LOG_TARGET, "Error during runtime restart of '{}': {:?}", name, e);
                     }
                 }
-                
+
                 if runtime_restart_attempts >= max_runtime_restart_attempts {
                     error!(target: LOG_TARGET, "Failed to restart process '{}' after {} runtime attempts.", name, max_runtime_restart_attempts);
-                    EventsManager::emit_binary_permanent_failure(app_handle, name.to_string(), "runtime".to_string()).await;
-                    return Err(anyhow::anyhow!("Failed to restart '{}' after max runtime retries", name));
+                    EventsManager::emit_binary_permanent_failure(
+                        app_handle,
+                        name.to_string(),
+                        "runtime".to_string(),
+                    )
+                    .await;
+                    return Err(anyhow::anyhow!(
+                        "Failed to restart '{}' after max runtime retries",
+                        name
+                    ));
                 }
 
                 warn!(target: LOG_TARGET, "Retrying runtime restart for '{}' in {:?}.", name, runtime_restart_retry_delay);

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -446,7 +446,7 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
                 }
                 Err(e) => warn!(target: LOG_TARGET, "Error stopping unhealthy process '{}': {:?}. Attempting restart regardless.", name, e),
             }
-
+    
             if let Err(e) = status_monitor.handle_unhealthy().await {
                 error!(target: LOG_TARGET, "Failed to handle unhealthy status for '{}': {}. Proceeding with restart attempt.", name, e);
             }
@@ -454,12 +454,15 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
             // Runtime Restart Loop
             let mut runtime_restart_attempts = 0;
             loop {
-                if global_shutdown_signal.is_triggered() || inner_shutdown.is_triggered() {
+                if global_shutdown_signal.is_triggered() 
+                    || inner_shutdown.is_triggered() 
+                    || child.is_shutdown_triggered() {
                     info!(target: LOG_TARGET, "Shutdown triggered during runtime restart of '{}'.", name);
                     return Ok(Some(0));
                 }
-
+    
                 runtime_restart_attempts += 1;
+
                 info!(target: LOG_TARGET, "Restarting '{}' (Runtime attempt {}/{})", name, runtime_restart_attempts, max_runtime_restart_attempts);
                 EventsManager::emit_binary_runtime_restart_attempt(app_handle, name.to_string(), runtime_restart_attempts, max_runtime_restart_attempts).await;
                 stats.num_restarts += 1;

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -107,6 +107,7 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn attempt_to_start_and_stabilize_child(
         &self,
         child: &mut TAdapter::ProcessInstance,

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -123,18 +123,20 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                 info!(target: LOG_TARGET, "Shutdown triggered during initial startup of {}", name);
                 return Err(anyhow::anyhow!("Shutdown during initial startup of {}", name));
             }
-
+    
             startup_attempts += 1;
             info!(target: LOG_TARGET, "Attempting to start '{}' (Attempt {}/{})", name, startup_attempts, self.max_startup_attempts);
             EventsManager::emit_binary_startup_attempt(&self.app_handle, name.to_string(), startup_attempts, self.max_startup_attempts).await;
-
+    
             if let Err(e) = child.start(task_tracker.clone()).await {
                 warn!(target: LOG_TARGET, "child.start() failed for '{}': {:?}.", name, e);
             } else {
                 info!(target: LOG_TARGET, "Process '{}' launched. Waiting {:?} for stabilization.", name, self.expected_startup_time);
                 let stabilization_deadline = Instant::now() + self.expected_startup_time;
+                let startup_grace_period = Duration::from_secs(15); // ADD THIS: Grace period before health checks
+                let grace_deadline = Instant::now() + startup_grace_period;
                 let mut initial_health_passed = false;
-
+    
                 while Instant::now() < stabilization_deadline {
                     if global_shutdown_signal.is_triggered() || inner_shutdown_signal.is_triggered() {
                         warn!(target: LOG_TARGET, "Shutdown during stabilization for {}", name);
@@ -145,7 +147,14 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                         warn!(target: LOG_TARGET, "Process '{}' died immediately after start (ping failed).", name);
                         break;
                     }
-
+    
+                    // ADD THIS: Skip health checks during grace period
+                    if Instant::now() < grace_deadline {
+                        info!(target: LOG_TARGET, "Process '{}' in startup grace period, skipping health check.", name);
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        continue;
+                    }
+    
                     let health_status = status_monitor.check_health(Duration::from_secs(0), self.health_timeout).await;
                     match health_status {
                         HealthStatus::Healthy => {
@@ -163,26 +172,26 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
                     }
                     tokio::time::sleep(Duration::from_secs(2)).await;
                 }
-
+    
                 if initial_health_passed {
                     info!(target: LOG_TARGET, "Process '{}' successfully started and stabilized.", name);
                     return Ok(());
                 }
-
+    
                 warn!(target: LOG_TARGET, "Process '{}' did not stabilize or become healthy. Stopping before retry.", name);
                 if let Err(e) = child.stop().await {
                     warn!(target: LOG_TARGET, "Error stopping child process '{}' after failed stabilization: {:?}", name, e);
                 }
             }
-
+    
             stats.num_restarts += 1;
-
+    
             if startup_attempts >= self.max_startup_attempts {
                 error!(target: LOG_TARGET, "Failed to start and stabilize process '{}' after {} attempts.", name, self.max_startup_attempts);
                 EventsManager::emit_binary_permanent_failure(&self.app_handle, name.to_string(), "startup".to_string()).await;
                 return Err(anyhow::anyhow!("Failed to start '{}' after max startup retries", name));
             }
-
+    
             warn!(target: LOG_TARGET, "Retrying startup for '{}' in {:?}.", name, self.startup_retry_delay);
             tokio::time::sleep(self.startup_retry_delay).await;
         }

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
 use tauri_plugin_sentry::sentry;
 use tokio::sync::{watch, RwLock};
+use tauri::AppHandle;
 
 const LOG_TARGET: &str = "tari::universe::tor_manager";
 const STARTUP_TIMEOUT: u64 = 180; // 3mins
@@ -52,6 +53,7 @@ impl TorManager {
     pub fn new(
         status_broadcast: watch::Sender<TorStatus>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
+        app_handle: AppHandle, // Add this parameter
     ) -> Self {
         let status_watch_rx = status_broadcast.subscribe();
         let adapter = TorAdapter::new(status_broadcast);

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -28,9 +28,9 @@ use crate::tor_control_client::TorStatus;
 use anyhow::anyhow;
 use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
+use tauri::AppHandle;
 use tauri_plugin_sentry::sentry;
 use tokio::sync::{watch, RwLock};
-use tauri::AppHandle;
 
 const LOG_TARGET: &str = "tari::universe::tor_manager";
 const STARTUP_TIMEOUT: u64 = 180; // 3mins
@@ -57,7 +57,8 @@ impl TorManager {
     ) -> Self {
         let status_watch_rx = status_broadcast.subscribe();
         let adapter = TorAdapter::new(status_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_tor(), app_handle);
+        let mut process_watcher =
+            ProcessWatcher::new(adapter, stats_collector.take_tor(), app_handle);
         process_watcher.expected_startup_time = Duration::from_secs(STARTUP_TIMEOUT);
         process_watcher.health_timeout = Duration::from_secs(9);
         process_watcher.poll_time = Duration::from_secs(10);

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -53,7 +53,7 @@ impl TorManager {
     pub fn new(
         status_broadcast: watch::Sender<TorStatus>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let status_watch_rx = status_broadcast.subscribe();
         let adapter = TorAdapter::new(status_broadcast);

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -55,7 +55,7 @@ impl TorManager {
     ) -> Self {
         let status_watch_rx = status_broadcast.subscribe();
         let adapter = TorAdapter::new(status_broadcast);
-        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_tor());
+        let mut process_watcher = ProcessWatcher::new(adapter, stats_collector.take_tor(), app_handle);
         process_watcher.expected_startup_time = Duration::from_secs(STARTUP_TIMEOUT);
         process_watcher.health_timeout = Duration::from_secs(9);
         process_watcher.poll_time = Duration::from_secs(10);

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -83,7 +83,7 @@ impl WalletManager {
         node_manager: NodeManager,
         wallet_state_watch_tx: watch::Sender<Option<WalletState>>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
-        app_handle: AppHandle, // Add this parameter
+        app_handle: AppHandle,
     ) -> Self {
         let adapter = WalletAdapter::new(wallet_state_watch_tx);
         let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet(), app_handle);

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -85,7 +85,7 @@ impl WalletManager {
         stats_collector: &mut ProcessStatsCollectorBuilder,
     ) -> Self {
         let adapter = WalletAdapter::new(wallet_state_watch_tx);
-        let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet());
+        let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet(), app_handle);
 
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -83,6 +83,7 @@ impl WalletManager {
         node_manager: NodeManager,
         wallet_state_watch_tx: watch::Sender<Option<WalletState>>,
         stats_collector: &mut ProcessStatsCollectorBuilder,
+        app_handle: AppHandle, // Add this parameter
     ) -> Self {
         let adapter = WalletAdapter::new(wallet_state_watch_tx);
         let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet(), app_handle);

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -86,7 +86,8 @@ impl WalletManager {
         app_handle: AppHandle,
     ) -> Self {
         let adapter = WalletAdapter::new(wallet_state_watch_tx);
-        let process_watcher = ProcessWatcher::new(adapter, stats_collector.take_wallet(), app_handle);
+        let process_watcher =
+            ProcessWatcher::new(adapter, stats_collector.take_wallet(), app_handle);
 
         Self {
             watcher: Arc::new(RwLock::new(process_watcher)),

--- a/src/types/backend-state.ts
+++ b/src/types/backend-state.ts
@@ -1,6 +1,9 @@
 import {
     AppInMemoryConfigChangedPayload,
     BackgroundNodeSyncUpdatePayload,
+    BinaryPermanentFailurePayload,
+    BinaryRuntimeRestartAttemptPayload,
+    BinaryStartupAttemptPayload,
     ConnectedPeersUpdatePayload,
     ConnectionStatusPayload,
     CriticalProblemPayload,
@@ -213,4 +216,16 @@ export type BackendStateUpdateEvent =
     | {
           event_type: 'UniversalMinerInitializedExchangeIdChanged';
           payload: UniversalMinerInitializedExchangeIdChangedPayload;
+      }
+    | {
+          event_type: 'BinaryStartupAttempt';
+          payload: BinaryStartupAttemptPayload;
+      }
+    | {
+          event_type: 'BinaryRuntimeRestartAttempt';
+          payload: BinaryRuntimeRestartAttemptPayload;
+      }
+    | {
+          event_type: 'BinaryPermanentFailure';
+          payload: BinaryPermanentFailurePayload;
       };

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -79,3 +79,21 @@ export interface UniversalMinerInitializedExchangeIdChangedPayload {
     universal_miner_initialized_exchange_id: string;
 }
 export type ConnectionStatusPayload = 'InProgress' | 'Succeed' | 'Failed';
+
+// New event payloads for binary retry functionality
+export interface BinaryStartupAttemptPayload {
+    name: string;
+    attempt: number;
+    max_attempts: number;
+}
+
+export interface BinaryRuntimeRestartAttemptPayload {
+    name: string;
+    attempt: number;
+    max_attempts: number;
+}
+
+export interface BinaryPermanentFailurePayload {
+    name: string;
+    reason: string; // 'startup' or 'runtime'
+}


### PR DESCRIPTION
**Description**
---
Implements a comprehensive binary retry mechanism to make Tari Universe significantly more robust against subprocess startup failures. This enhancement automatically retries failed binaries up to 10 times (configurable) before requiring user intervention, eliminating the need for full application restarts due to temporary binary failures.

**Motivation and Context**
---
Previously, when any subprocess (minotari_node, xmrig, gpu_miner, tor, p2pool, etc.) failed to start, Universe would require a complete application restart. This created a poor user experience, especially in environments with temporary network connectivity issues, resource contention during system startup, antivirus interference, or permission delays.

The new retry mechanism distinguishes between:
1. **Initial startup failures** - retries up to 10 times with 5-second delays
2. **Runtime crashes** - retries up to 3 times with 10-second delays for previously healthy processes

**How Has This Been Tested?**
---
- **Startup Failure Simulation**: Modified binary paths to trigger startup failures and verified retry behavior
- **Runtime Crash Testing**: Manually terminated healthy processes to test runtime restart logic
- **UI Event Testing**: Confirmed new events are properly emitted to frontend
- **Shutdown Testing**: Verified graceful shutdown during various stages of retry loops
- **Edge Case Testing**: Tested behavior with corrupted binaries, permission issues, and rapid shutdown scenarios

**What process can a PR reviewer use to test or verify this change?**
---

### **1. Binary Startup Retry Testing:**
```bash
# Temporarily rename a binary to trigger startup failures
mv minotari_node minotari_node.backup
# Start Universe and observe:
# - Console logs showing retry attempts (1/10, 2/10, etc.)
# - Frontend events for BinaryStartupAttempt
# - Final BinaryPermanentFailure after 10 attempts
# - Critical error dialog in UI
```

### **2. Runtime Restart Testing:**
```bash
# Start Universe normally, then kill a process:
kill -9 $(pgrep minotari_node)
# Observe:
# - Automatic detection of unhealthy process
# - Runtime restart attempts (1/3, 2/3, 3/3)
# - Process recovery or permanent failure notification
```

### **3. Configuration Verification:**
```rust
// Verify retry parameters can be customized in process_watcher.rs:
max_startup_attempts: 10,           // Initial startup retries
startup_retry_delay: 5s,            // Delay between startup attempts  
max_runtime_restart_attempts: 3,    // Runtime crash retries
runtime_restart_retry_delay: 10s,   // Delay between runtime attempts
```

**Breaking Changes**
---
- [x] None