### PR TITLE
chore: log error to sentry if elevating permissions fails

### DIFF
--- a/src-tauri/src/download_utils.rs
+++ b/src-tauri/src/download_utils.rs
@@ -144,6 +144,15 @@ pub async fn set_permissions(file_path: &Path) -> Result<(), anyhow::Error> {
     let current_mode = perms.mode();
     perms.set_mode(current_mode | 0o111);
     fs::set_permissions(file_path, perms).await?;
+    let after_mode = fs::metadata(file_path).await?.permissions().mode();
+    if after_mode != (current_mode | 0o111) {
+        return Err(anyhow!(
+            "failed to set permissions for file: {}. Mode before: {:o}, after: {:o}",
+            file_path.display(),
+            current_mode,
+            after_mode
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Description
---
Sometimes on macOS users fails to launch `minotari_node` receiving os error 61: refused to connect to TCP port. This most likely is a result of `minotari_node` failing to launch which is caused by lack of execute permissions on the file.
I was not able to recreate it so to get any data regarding underlying issue we need to increase logging of this issue for further analysis.