### PR TITLE
fix: adjust restart behaviour for mmproxy during airdrop connect

### DIFF
--- a/src-tauri/src/airdrop.rs
+++ b/src-tauri/src/airdrop.rs
@@ -28,7 +28,6 @@ use tauri::{AppHandle, Manager};
 
 use crate::{
     configs::{config_core::ConfigCore, trait_config::ConfigImpl},
-    mm_proxy_adapter::MergeMiningProxyConfig,
     tasks_tracker::TasksTrackers,
     UniverseAppState,
 };

--- a/src-tauri/src/airdrop.rs
+++ b/src-tauri/src/airdrop.rs
@@ -105,33 +105,6 @@ pub async fn validate_jwt(airdrop_access_token: Option<String>) -> Option<String
     })
 }
 
-pub async fn restart_mm_proxy_with_new_telemetry_id(
-    state: tauri::State<'_, UniverseAppState>,
-) -> Result<(), String> {
-    info!(target: LOG_TARGET, "Restarting mm_proxy");
-    let telemetry_id = state
-        .telemetry_manager
-        .read()
-        .await
-        .get_unique_string()
-        .await;
-    let mm_proxy_manager_config = state
-        .mm_proxy_manager
-        .config()
-        .await
-        .ok_or("mm proxy config could not be found")?;
-    let _unused = state
-        .mm_proxy_manager
-        .change_config(MergeMiningProxyConfig {
-            coinbase_extra: telemetry_id.clone(),
-            ..mm_proxy_manager_config
-        })
-        .await
-        .map_err(|e| e.to_string());
-    info!(target: LOG_TARGET, "mm_proxy restarted");
-    Ok(())
-}
-
 pub async fn get_wallet_view_key_hashed(app: AppHandle) -> String {
     let wallet_manager = app.state::<UniverseAppState>().wallet_manager.clone();
     let view_private_key = wallet_manager.get_view_private_key().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1436,8 +1436,7 @@ pub async fn set_visual_mode<'r>(enabled: bool) -> Result<(), InvokeError> {
 #[tauri::command]
 pub async fn set_airdrop_tokens<'r>(
     airdrop_tokens: Option<AirdropTokens>,
-    state: tauri::State<'_, UniverseAppState>,
-    app: tauri::AppHandle,
+    app_handle: tauri::AppHandle,
 ) -> Result<(), InvokeError> {
     let old_id = ConfigCore::content()
         .await
@@ -1458,31 +1457,14 @@ pub async fn set_airdrop_tokens<'r>(
 
     info!(target: LOG_TARGET, "New Airdrop tokens saved, user id changed:{:?}", user_id_changed);
     if user_id_changed {
-        let currently_mining = {
-            let cpu_mining_status = state.cpu_miner_status_watch_rx.borrow().clone();
-            let gpu_mining_status = state.gpu_latest_status.borrow().clone();
-            cpu_mining_status.is_mining || gpu_mining_status.is_mining
-        };
+        // If the user id changed, we need to restart the mining phases to ensure that the new telemetry_id ( unique_string value )is used
+        SetupManager::get_instance()
+            .add_phases_to_restart_queue(vec![SetupPhase::Mining])
+            .await;
 
-        if currently_mining {
-            stop_cpu_mining(state.clone())
-                .await
-                .map_err(|e| e.to_string())?;
-            stop_gpu_mining(state.clone())
-                .await
-                .map_err(|e| e.to_string())?;
-
-            airdrop::restart_mm_proxy_with_new_telemetry_id(state.clone()).await?;
-
-            start_cpu_mining(state.clone(), app.clone())
-                .await
-                .map_err(|e| e.to_string())?;
-            start_gpu_mining(state, app)
-                .await
-                .map_err(|e| e.to_string())?;
-        } else {
-            airdrop::restart_mm_proxy_with_new_telemetry_id(state.clone()).await?;
-        }
+        SetupManager::get_instance()
+            .restart_phases_from_queue(app_handle.clone())
+            .await;
     }
     Ok(())
 }

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -98,35 +98,6 @@ impl MmProxyManager {
         }
     }
 
-    pub async fn config(&self) -> Option<MergeMiningProxyConfig> {
-        let lock = self.watcher.read().await;
-        lock.adapter.config.clone()
-    }
-
-    pub async fn change_config(&self, config: MergeMiningProxyConfig) -> Result<(), anyhow::Error> {
-        if self.watcher.read().await.is_running() {
-            let mut lock = self.watcher.write().await;
-            lock.stop().await?;
-            drop(lock);
-        }
-        let start_config_read = self.start_config.read().await;
-        match start_config_read.as_ref() {
-            Some(start_config) => {
-                let config_with_override = start_config.override_by(config);
-                drop(start_config_read);
-                self.start(config_with_override).await?;
-                self.wait_ready().await?;
-            }
-            None => {
-                return Err(anyhow!(
-                    "Missing start config! MM proxy manager must be started at least once!"
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
     pub async fn start(&self, config: StartConfig) -> Result<(), anyhow::Error> {
         let shutdown_signal = TasksTrackers::current().mining_phase.get_signal().await;
         let task_tracker = TasksTrackers::current()

--- a/src-tauri/src/mm_proxy_manager.rs
+++ b/src-tauri/src/mm_proxy_manager.rs
@@ -54,6 +54,7 @@ pub(crate) struct StartConfig {
 }
 
 impl StartConfig {
+    #[allow(dead_code)]
     fn override_by(&self, override_by: MergeMiningProxyConfig) -> Self {
         let cloned = self.clone();
         Self {


### PR DESCRIPTION
### [ Summary ]
- After connecting to airdrop there is a need to restart `mmproxy` to obtain new `unique_string` based on airdrop values
- If mining then we were stopping it, then changing `mmproxy` config and restarting `mmproxy`, at the end starting mining again
- There was a problem with obtaining `mmproxy` config which resulted in error so mining didn't started again
- Starting / Stopping mining from backend **does not influence UI** states on frontend which resulted in constant load

### [ Fix ]
- Switched to the **restart phase implementation** from `setup_manager`, and just restarted `mining_phase` which then should pass newest `unique_string` to `mmproxy` and handle mining flow properly

Fixes: #2327