### PR TITLE
fix(ui): format bridge tx details

### DIFF
--- a/src/components/transactions/history/details/getListEntries.tsx
+++ b/src/components/transactions/history/details/getListEntries.tsx
@@ -33,6 +33,14 @@ const BRIDGE_HIDDEN_KEYS = ['paymentId'];
 const keyTranslations: Record<string, string> = {
     tx_id: 'wallet:send.transaction-id',
     payment_id: 'wallet:send.transaction-description',
+    amount: 'wallet:send.label-amount',
+    source_address: 'wallet:receive.label-address',
+    dest_address: 'wallet:send.destination-address',
+    dest_address_emoji: 'wallet:receive.tooltip-emoji-id-title',
+    fee: 'wallet:send.network-fee',
+    dest_address_eth: 'Destination address [ ETH ]',
+    amount_after_fee: 'Amount after fee',
+    created_at: 'Created at',
 };
 function capitalizeKey(key: string): string {
     return key
@@ -96,34 +104,66 @@ function parseBridgeTransactionValues({
     value: ReactNode;
 } {
     const rest: Partial<StatusListEntry> = {};
+    if (key === 'sourceAddress') {
+        return { label: getLabel('source_address'), value: value };
+    }
+    if (key === 'createdAt') {
+        return { label: getLabel('created_at'), value: value };
+    }
     if (key === 'status') {
         const tKey = getTxStatusTitleKey(transaction);
         return { value: i18n.t(`common:${tKey}`), valueRight: value };
     }
     if (key === 'tokenAmount') {
         const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        const valueMarkup = (
+            <>
+                {formatNumber(Number(value), preset)}
+                <span>{` XTM`}</span>
+            </>
+        );
         return {
-            value: formatNumber(Number(value), preset),
-            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+            label: getLabel('amount'),
+            value: valueMarkup,
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µXTM`,
         };
     }
     if (key === 'amountAfterFee') {
         const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        const valueMarkup = (
+            <>
+                {formatNumber(Number(value), preset)}
+                <span>{` XTM`}</span>
+            </>
+        );
         return {
-            value: formatNumber(Number(value), preset),
-            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+            label: getLabel('amount_after_fee'),
+            value: valueMarkup,
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µXTM`,
         };
     }
     if (key === 'feeAmount') {
         const preset = value.toString().length > 5 ? FormatPreset.XTM_LONG : FormatPreset.XTM_DECIMALS;
+        const valueMarkup = (
+            <>
+                {formatNumber(Number(value), preset)}
+                <span>{` XTM`}</span>
+            </>
+        );
         return {
-            value: formatNumber(Number(value), preset),
-            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µT`,
+            label: getLabel('fee'),
+            value: valueMarkup,
+            valueRight: `${formatNumber(Number(value), FormatPreset.DECIMAL_COMPACT)} µXTM`,
         };
     }
 
     if (key === 'destinationAddress') {
-        return { label: 'Destination address [ ETH ]', value: transaction.destinationAddress };
+        return { label: getLabel('dest_address_eth'), value: transaction.destinationAddress };
+    }
+
+    if (key === 'mined_in_block_height' && value) {
+        const explorerURL = getExplorerUrl(network === Network.MainNet);
+        rest['externalLink'] = `${explorerURL}/blocks/${value}`;
     }
 
     return { value, ...rest };


### PR DESCRIPTION
Description
---
Some fields from the bridge and regular transaction info details were different in formatting. This text is to unify them. Additionally, some translations have been added.

Motivation and Context
---
Wallet tx:
![image](https://github.com/user-attachments/assets/c0e27f66-19fb-46a8-be2a-eee0ed20e7ce)

Bridge tx before:
![image](https://github.com/user-attachments/assets/f10fe1a1-50b5-4786-9738-39a7254b757c)


Bridge tx after:
![image](https://github.com/user-attachments/assets/748842a5-55b0-4de3-95c9-4c4a4d3ebdb1)




How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
