### PR TITLE
feat: wallet migration nonce

### DIFF
--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -54,6 +54,8 @@ pub struct ConfigWalletContent {
     monero_address_is_generated: bool,
     #[getset(get = "pub", set = "pub")]
     keyring_accessed: bool,
+    #[getset(get = "pub", set = "pub")]
+    wallet_migration_nonce: u64,
 }
 
 impl Default for ConfigWalletContent {
@@ -64,6 +66,7 @@ impl Default for ConfigWalletContent {
             monero_address: "".to_string(),
             monero_address_is_generated: false,
             keyring_accessed: false,
+            wallet_migration_nonce: 0,
         }
     }
 }


### PR DESCRIPTION
Simply bump `wallet_migration_nonce` in config wallet to remove wallet related data and trigger full scan etc.
```
// Bump to force wallet full scan
const WALLET_MIGRATION_NONCE: u64 = 1;
```


```
13:59:33 INFO  Wallet migration required(Nonce 0 => 1)
```