### PR TITLE
fix: update block height when block mined

### DIFF
--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -104,7 +104,7 @@ const handleWin = async (coinbase_transaction: TransactionInfo, balance: WalletB
             clearTimeout(winTimeout);
         }
         winTimeout = setTimeout(async () => {
-            useBlockchainVisualisationStore.setState({ displayBlockHeight: blockHeight, earnings: undefined });
+            useBlockchainVisualisationStore.setState({ earnings: undefined });
             await refreshTransactions();
             setWalletBalance(balance);
             setMiningControlsEnabled(true);
@@ -113,7 +113,6 @@ const handleWin = async (coinbase_transaction: TransactionInfo, balance: WalletB
         await refreshTransactions();
         useBlockchainVisualisationStore.setState((curr) => ({
             recapIds: [...curr.recapIds, coinbase_transaction.tx_id],
-            displayBlockHeight: blockHeight,
             earnings: undefined,
         }));
     }
@@ -207,10 +206,10 @@ async function processNewBlock(payload: {
             };
 
             useBlockchainVisualisationStore.setState((prev) => ({
+                displayBlockHeight: payload.block_height,
                 pendingWins: [...prev.pendingWins, pendingWin],
             }));
-
-            console.info(`Block #${payload.block_height} win queued - will show in 3 blocks`);
+            console.info(`Block #${payload.block_height} win queued - will show in 3 blocks | Updating block height`);
         } else {
             await handleFail(payload.block_height, payload.balance, canAnimate);
         }


### PR DESCRIPTION
The recent change (wait 3 blocks before the win animation) disrupted the “expected” update flow, causing significant updates to be delayed/messed.

My fix solves the problem when winning a block does not update block_height until 3 confirmations met - then updates to the tx mined block which is 2 blocks behind

It solves following problem:
1. Block n won - block height not updated(= n - 1)
2. Block n + 1 lost - block height updated to n + 1(updated +2)
3. Block n + 2 lost - block height updated to n + 2(updated + 1)
4. Block(n) met 3 confirmations after winning - updated block height to **n** which is 2 blocks behind

My fix updates block height even though it's won(it's not updated later)

----------

This change has several other issues when won a block:
* received funds aren't visible for next 1-3 blocks
* pending transaction is not changed from pending to completed
* payref is not updated(not merged yet)

Even though winning a block prevents from updating the tx history, refresh is done by:
* losing a block
* sending a transaction
* changing tx history filter(not merged yet)
* refreshing tx history
* restarting the app
* changing some configs