### PR TITLE
fix: increase timeout to process payrefs

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -416,7 +416,8 @@ fn construct_process_watcher<T: NodeAdapter + ProcessAdapter + Send + Sync + 'st
         process_watcher.poll_time = Duration::from_secs(10);
         process_watcher.health_timeout = Duration::from_secs(9);
     }
-    process_watcher.expected_startup_time = Duration::from_secs(30);
+    // NODE: Temporary solution to process payrefs in TU v1.2.9
+    process_watcher.expected_startup_time = Duration::from_secs(540); // 9mins
 
     process_watcher
 }
@@ -584,7 +585,8 @@ where
                     return Ok(());
                 }
                 Err(err) => {
-                    if retries > 20 {
+                    // NODE: Temporary solution to process payrefs in TU v1.2.9
+                    if retries > 420 {
                         warn!(
                             target: LOG_TARGET,
                             "Max retries exceeded for {} node identity readiness. Stopping watcher. Error: {}",

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -372,7 +372,8 @@ impl SetupManager {
     async fn setup_hardware_phase(&self, app_handle: AppHandle) {
         let setup_features = self.features.read().await.clone();
         let hardware_phase_setup = PhaseBuilder::new()
-            .with_setup_timeout_duration(Duration::from_secs(60 * 10)) // 10 minutes
+            // NODE: Temporary solution to process payrefs in TU v1.2.9
+            .with_setup_timeout_duration(Duration::from_secs(60 * 15)) // 15 minutes
             .with_listeners_for_required_phases_statuses(vec![self.core_phase_status.subscribe()])
             .build::<HardwareSetupPhase>(
                 app_handle.clone(),


### PR DESCRIPTION
Description
---
Node timeouts set to: 
* processing refs and returning indentity - 420sec(7mins)
* expected node startup time(being healthy == returning state) - 540sec(9mins)
* node phase timeout - 15mins(mainly for peer connection)