### PR TITLE
feat(ui): useQuery for xc data + more ui cleanups

### DIFF
--- a/src/components/exchanges/LinkModal/LinkModal.tsx
+++ b/src/components/exchanges/LinkModal/LinkModal.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next';
 import { open } from '@tauri-apps/plugin-shell';
 import { Dialog, DialogContent } from '@app/components/elements/dialog/Dialog.tsx';
 
-import { useExchangeStore } from '@app/store/useExchangeStore.ts';
 import { ImgWrapper, ListWrapper } from '@app/components/exchanges/commonStyles.ts';
 import {
     CloseButton,
@@ -18,10 +17,11 @@ import {
 import { ExternalLinkSVG } from '@app/assets/icons/external-link.tsx';
 import { IoClose } from 'react-icons/io5';
 import { setDialogToShow, useUIStore } from '@app/store';
+import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
 export default function XCLinkModal() {
     const { t } = useTranslation(['wallet']);
-    const exchangeMiners = useExchangeStore((s) => s.exchangeMiners);
+    const { data: exchangeMiners } = useFetchExchangeList();
     const dialog = useUIStore((s) => s.dialogToShow);
     const isOpen = dialog === 'xc_url' && !!exchangeMiners?.some((x) => x.exchange_url);
 

--- a/src/components/exchanges/connect/Connect.tsx
+++ b/src/components/exchanges/connect/Connect.tsx
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { invoke } from '@tauri-apps/api/core';
-import { setShowExchangeModal, useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { setShowExchangeModal } from '@app/store/useExchangeStore.ts';
 import {
     Wrapper,
     CTA,

--- a/src/components/exchanges/connect/Connect.tsx
+++ b/src/components/exchanges/connect/Connect.tsx
@@ -21,13 +21,14 @@ import { setSeedlessUI } from '@app/store/actions/uiStoreActions.ts';
 import { ToggleSwitch } from '@app/components/elements/ToggleSwitch.tsx';
 import { setAllowTelemetry, useConfigCoreStore } from '@app/store';
 import { Typography } from '@app/components/elements/Typography.tsx';
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface ConnectFormFields {
     address: string;
 }
 
 export const Connect = () => {
-    const data = useExchangeStore((s) => s.currentExchangeMiner);
+    const { data } = useFetchXCContent();
     const [address, setAddress] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [addressIsValid, setAddressIsValid] = useState(false);

--- a/src/components/exchanges/connect/Connect.tsx
+++ b/src/components/exchanges/connect/Connect.tsx
@@ -21,14 +21,14 @@ import { setSeedlessUI } from '@app/store/actions/uiStoreActions.ts';
 import { ToggleSwitch } from '@app/components/elements/ToggleSwitch.tsx';
 import { setAllowTelemetry, useConfigCoreStore } from '@app/store';
 import { Typography } from '@app/components/elements/Typography.tsx';
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface ConnectFormFields {
     address: string;
 }
 
 export const Connect = () => {
-    const { data } = useFetchXCContent();
+    const { data } = useFetchExchangeBranding();
     const [address, setAddress] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [addressIsValid, setAddressIsValid] = useState(false);

--- a/src/components/exchanges/universal/clipboardViewer/styles.ts
+++ b/src/components/exchanges/universal/clipboardViewer/styles.ts
@@ -6,17 +6,17 @@ export const Container = styled.div`
     flex-direction: row;
     gap: 6px;
     padding: 10px;
-    background-color: white;
+    background-color: ${({ theme }) => theme.palette.background.default};
     border-radius: 10px;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-    border: 1px solid #e5e7eb;
+    border: 1px solid ${({ theme }) => theme.palette.divider};
     width: 100%;
 `;
 
 export const ClipboardIcon = styled.img`
     width: 36px;
     height: 36px;
-    color: #3b82f6;
+    cursor: pointer;
 `;
 
 export const ContentContainer = styled.div`
@@ -29,7 +29,6 @@ export const ContentContainer = styled.div`
 export const Title = styled(Typography).attrs({ variant: 'h3' })`
     font-size: 14px;
     font-weight: 500;
-    color: #111827;
 `;
 
 export const TextContainer = styled.div`
@@ -42,6 +41,6 @@ export const ClipboardText = styled(Typography)`
     letter-spacing: 0.05rem;
     white-space: pre-wrap;
     word-break: break-word;
-    color: #374151;
+    color: ${({ theme }) => theme.palette.text.secondary};
     line-height: 1.3;
 `;

--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -35,12 +35,13 @@ import { Divider } from '@app/components/elements/Divider.tsx';
 interface XCOptionProps {
     content: ExchangeBranding;
     isCurrent?: boolean;
+    isActive?: boolean;
+    onActiveClick: (id: string) => void;
 }
 
-export const XCOption = ({ content, isCurrent = false }: XCOptionProps) => {
+export const XCOption = ({ content, isCurrent = false, isActive, onActiveClick }: XCOptionProps) => {
     const { t } = useTranslation(['exchange', 'settings'], { useSuspense: false });
     const [isAddressValid, setIsAddressValid] = useState(false);
-    const [isActive, setIsActive] = useState(false);
     const [miningAddress, setMiningAddress] = useState('');
 
     const handleExchangeMiner = async () => {
@@ -88,7 +89,7 @@ export const XCOption = ({ content, isCurrent = false }: XCOptionProps) => {
                         <OpenButton
                             $isOpen={isActive}
                             onClick={() => {
-                                setIsActive(!isActive);
+                                onActiveClick(content.id);
                             }}
                         >
                             <ImgWrapper $border $isActive={isActive}>

--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -89,7 +89,7 @@ export const XCOption = ({ content, isCurrent = false, isActive, onActiveClick }
                         <OpenButton
                             $isOpen={isActive}
                             onClick={() => {
-                                onActiveClick(content.id);
+                                onActiveClick(!isActive ? content.id : '');
                             }}
                         >
                             <ImgWrapper $border $isActive={isActive}>

--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -68,7 +68,7 @@ export const XCOption = ({ content, isCurrent = false }: XCOptionProps) => {
     const showExpand = isTari ? !isCurrent && content.id : content.id;
 
     return (
-        <Wrapper $isCurrent={isCurrent}>
+        <Wrapper $isCurrent={isCurrent} $isActive={isActive}>
             <ContentHeaderWrapper>
                 <XCContent>
                     {(isTari || logoSrc) && (
@@ -98,39 +98,41 @@ export const XCOption = ({ content, isCurrent = false }: XCOptionProps) => {
                     )}
                 </SelectOptionWrapper>
             </ContentHeaderWrapper>
-            <ContentBodyWrapper $isActive={isActive}>
-                <ExchangeAddress handleIsAddressValid={setIsAddressValid} handleAddressChanged={setMiningAddress} />
-                <SeasonReward>
-                    <LeftContent>
-                        {content.campaign_description ? (
-                            <>
-                                <SeasonRewardIcon src="/assets/img/wrapped_gift.png" alt="gift" />
-                                <SeasonRewardText>
-                                    <b>{t('season-one-reward', { ns: 'exchange' })}:</b>{' '}
-                                    <span>{content.campaign_description}</span>
-                                </SeasonRewardText>
-                            </>
+            {isActive && (
+                <ContentBodyWrapper $isActive={isActive}>
+                    <ExchangeAddress handleIsAddressValid={setIsAddressValid} handleAddressChanged={setMiningAddress} />
+                    <SeasonReward>
+                        <LeftContent>
+                            {content.campaign_description ? (
+                                <>
+                                    <SeasonRewardIcon src="/assets/img/wrapped_gift.png" alt="gift" />
+                                    <SeasonRewardText>
+                                        <b>{t('season-one-reward', { ns: 'exchange' })}:</b>{' '}
+                                        <span>{content.campaign_description}</span>
+                                    </SeasonRewardText>
+                                </>
+                            ) : null}
+                        </LeftContent>
+                        {content.reward_expiry_date ? (
+                            <Countdown>
+                                <CountdownText>{formatCountdown(content.reward_expiry_date)}</CountdownText>
+                            </Countdown>
                         ) : null}
-                    </LeftContent>
-                    {content.reward_expiry_date ? (
-                        <Countdown>
-                            <CountdownText>{formatCountdown(content.reward_expiry_date)}</CountdownText>
-                        </Countdown>
-                    ) : null}
-                </SeasonReward>
-                {isAddressValid ? (
-                    <ConfirmButton onClick={handleExchangeMiner} disabled={!isAddressValid}>
-                        <Typography variant="h4">{t('confirm', { ns: 'settings' })}</Typography>
-                    </ConfirmButton>
-                ) : (
-                    <>
-                        <Divider />
-                        <Typography variant="p">
-                            {t('help-find-address', { exchange: content.name, ns: 'exchange' })}
-                        </Typography>
-                    </>
-                )}
-            </ContentBodyWrapper>
+                    </SeasonReward>
+                    {isAddressValid ? (
+                        <ConfirmButton onClick={handleExchangeMiner} disabled={!isAddressValid}>
+                            <Typography variant="h4">{t('confirm', { ns: 'settings' })}</Typography>
+                        </ConfirmButton>
+                    ) : (
+                        <>
+                            <Divider />
+                            <Typography variant="p">
+                                {t('help-find-address', { exchange: content.name, ns: 'exchange' })}
+                            </Typography>
+                        </>
+                    )}
+                </ContentBodyWrapper>
+            )}
         </Wrapper>
     );
 };

--- a/src/components/exchanges/universal/option/styles.ts
+++ b/src/components/exchanges/universal/option/styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { convertHexToRGBA } from '@app/utils';
 
-export const Wrapper = styled.div<{ $isCurrent?: boolean }>`
+export const Wrapper = styled.div<{ $isCurrent?: boolean; $isActive?: boolean }>`
     display: flex;
     border-radius: 10px;
     width: 100%;
@@ -13,7 +13,7 @@ export const Wrapper = styled.div<{ $isCurrent?: boolean }>`
     background-color: ${({ theme, $isCurrent: isCurrent }) =>
         isCurrent ? convertHexToRGBA(theme.colors.green[400], 0.1) : theme.palette.background.paper};
     padding: 15px;
-    min-height: 70px;
+    height: ${({ $isActive }) => ($isActive ? 'auto' : '70px')};
 `;
 
 export const Heading = styled(Typography).attrs({ variant: 'h5' })`
@@ -33,10 +33,10 @@ export const ContentBodyWrapper = styled.div<{ $isActive?: boolean }>`
     justify-content: space-evenly;
     align-items: center;
     flex-direction: column;
+    flex-shrink: 0;
     width: 100%;
     gap: 8px;
     padding: ${({ $isActive }) => ($isActive ? `14px 0 4px ` : 0)};
-    overflow: hidden;
     height: ${({ $isActive: $isActive }) => ($isActive ? 'auto' : '0')};
     opacity: ${({ $isActive: $isActive }) => ($isActive ? '1' : '0')};
     transition:

--- a/src/components/exchanges/universal/option/styles.ts
+++ b/src/components/exchanges/universal/option/styles.ts
@@ -1,6 +1,5 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Typography } from '@app/components/elements/Typography.tsx';
-import { convertHexToRGBA } from '@app/utils';
 
 export const Wrapper = styled.div<{ $isCurrent?: boolean; $isActive?: boolean }>`
     display: flex;
@@ -10,10 +9,19 @@ export const Wrapper = styled.div<{ $isCurrent?: boolean; $isActive?: boolean }>
     align-items: center;
     border: 1px solid
         ${({ theme, $isCurrent: isCurrent }) => (isCurrent ? theme.colors.green[400] : theme.palette.divider)};
-    background-color: ${({ theme, $isCurrent: isCurrent }) =>
-        isCurrent ? convertHexToRGBA(theme.colors.green[400], 0.1) : theme.palette.background.paper};
     padding: 15px;
     height: ${({ $isActive }) => ($isActive ? 'auto' : '70px')};
+
+    ${({ theme, $isCurrent }) =>
+        $isCurrent
+            ? css`
+                  background: ${theme.mode === 'dark'
+                      ? `linear-gradient(-99deg, #1a2d28 8.49%, #233c34 100.54%), #1a2d28`
+                      : `linear-gradient(99deg, #10C6712F 2.49%, #10C6712D 45%), #fff`};
+              `
+            : css`
+                  background: ${theme.palette.background.paper};
+              `}
 `;
 
 export const Heading = styled(Typography).attrs({ variant: 'h5' })`

--- a/src/components/exchanges/universal/option/styles.ts
+++ b/src/components/exchanges/universal/option/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { convertHexToRGBA } from '@app/utils';
 

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -1,4 +1,3 @@
-import { universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
 import { XCOption } from '@app/components/exchanges/universal/option/XCOption.tsx';
 import { ListWrapper, ScrollWrapper } from '@app/components/exchanges/universal/options/styles.ts';
 import { Divider } from '@app/components/elements/Divider.tsx';
@@ -11,7 +10,7 @@ export const XCOptions = () => {
     const { data: currentExchangeMiner } = useFetchExchangeBranding();
     const [activeId, setActiveId] = useState('');
 
-    function handleClick(id) {
+    function handleClick(id: string) {
         setActiveId(id);
     }
 
@@ -25,12 +24,14 @@ export const XCOptions = () => {
 
     return (
         <ListWrapper>
-            <XCOption
-                isCurrent
-                content={currentExchangeMiner ?? universalExchangeMinerOption}
-                isActive={activeId === (currentExchangeMiner?.id ?? universalExchangeMinerOption.id)}
-                onActiveClick={handleClick}
-            />
+            {currentExchangeMiner && (
+                <XCOption
+                    isCurrent
+                    content={currentExchangeMiner}
+                    isActive={activeId === currentExchangeMiner?.id}
+                    onActiveClick={handleClick}
+                />
+            )}
             {exchangeMiners?.length ? <Divider /> : null}
             <ScrollWrapper>{listItems}</ScrollWrapper>
         </ListWrapper>

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -4,20 +4,33 @@ import { ListWrapper, ScrollWrapper } from '@app/components/exchanges/universal/
 import { Divider } from '@app/components/elements/Divider.tsx';
 import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
+import { useState } from 'react';
 
 export const XCOptions = () => {
     const { data: exchangeMiners } = useFetchExchangeList();
     const { data: currentExchangeMiner } = useFetchExchangeBranding();
+    const [activeId, setActiveId] = useState('');
+
+    function handleClick(id) {
+        setActiveId(id);
+    }
 
     const listItems = exchangeMiners
         ?.filter((em) => em.id !== currentExchangeMiner?.id)
         ?.map((item) => {
-            return <XCOption key={item.id} content={item} />;
+            return (
+                <XCOption key={item.id} content={item} isActive={activeId === item.id} onActiveClick={handleClick} />
+            );
         });
 
     return (
         <ListWrapper>
-            <XCOption isCurrent content={currentExchangeMiner ?? universalExchangeMinerOption} />
+            <XCOption
+                isCurrent
+                content={currentExchangeMiner ?? universalExchangeMinerOption}
+                isActive={activeId === (currentExchangeMiner?.id ?? universalExchangeMinerOption.id)}
+                onActiveClick={handleClick}
+            />
             {exchangeMiners?.length ? <Divider /> : null}
             <ScrollWrapper>{listItems}</ScrollWrapper>
         </ListWrapper>

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -2,11 +2,11 @@ import { universalExchangeMinerOption, useExchangeStore } from '@app/store/useEx
 import { XCOption } from '@app/components/exchanges/universal/option/XCOption.tsx';
 import { ListWrapper } from '@app/components/exchanges/universal/options/styles.ts';
 import { Divider } from '@app/components/elements/Divider.tsx';
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export const XCOptions = () => {
     const exchangeMiners = useExchangeStore((s) => s.exchangeMiners);
-    const { data: currentExchangeMiner } = useFetchXCContent();
+    const { data: currentExchangeMiner } = useFetchExchangeBranding();
 
     const listItems = exchangeMiners
         ?.filter((em) => em.id !== currentExchangeMiner?.id)

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -1,20 +1,22 @@
-import { useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { universalExchangeMinerOption, useExchangeStore } from '@app/store/useExchangeStore.ts';
 import { XCOption } from '@app/components/exchanges/universal/option/XCOption.tsx';
 import { ListWrapper } from '@app/components/exchanges/universal/options/styles.ts';
 import { Divider } from '@app/components/elements/Divider.tsx';
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export const XCOptions = () => {
     const exchangeMiners = useExchangeStore((s) => s.exchangeMiners);
-    const currentExchangeMiner = useExchangeStore((s) => s.currentExchangeMiner);
+    const { data: currentExchangeMiner } = useFetchXCContent();
+
     const listItems = exchangeMiners
-        ?.filter((em) => em.id !== currentExchangeMiner.id)
+        ?.filter((em) => em.id !== currentExchangeMiner?.id)
         ?.map((item) => {
             return <XCOption key={item.id} content={item} />;
         });
 
     return (
         <ListWrapper>
-            <XCOption isCurrent content={currentExchangeMiner} />
+            <XCOption isCurrent content={currentExchangeMiner ?? universalExchangeMinerOption} />
             {exchangeMiners?.length ? <Divider /> : null}
             {listItems}
         </ListWrapper>

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -1,6 +1,6 @@
 import { universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
 import { XCOption } from '@app/components/exchanges/universal/option/XCOption.tsx';
-import { ListWrapper } from '@app/components/exchanges/universal/options/styles.ts';
+import { ListWrapper, ScrollWrapper } from '@app/components/exchanges/universal/options/styles.ts';
 import { Divider } from '@app/components/elements/Divider.tsx';
 import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
@@ -19,7 +19,7 @@ export const XCOptions = () => {
         <ListWrapper>
             <XCOption isCurrent content={currentExchangeMiner ?? universalExchangeMinerOption} />
             {exchangeMiners?.length ? <Divider /> : null}
-            {listItems}
+            <ScrollWrapper>{listItems}</ScrollWrapper>
         </ListWrapper>
     );
 };

--- a/src/components/exchanges/universal/options/Options.tsx
+++ b/src/components/exchanges/universal/options/Options.tsx
@@ -1,11 +1,12 @@
-import { universalExchangeMinerOption, useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
 import { XCOption } from '@app/components/exchanges/universal/option/XCOption.tsx';
 import { ListWrapper } from '@app/components/exchanges/universal/options/styles.ts';
 import { Divider } from '@app/components/elements/Divider.tsx';
 import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
 export const XCOptions = () => {
-    const exchangeMiners = useExchangeStore((s) => s.exchangeMiners);
+    const { data: exchangeMiners } = useFetchExchangeList();
     const { data: currentExchangeMiner } = useFetchExchangeBranding();
 
     const listItems = exchangeMiners

--- a/src/components/exchanges/universal/options/styles.ts
+++ b/src/components/exchanges/universal/options/styles.ts
@@ -7,5 +7,15 @@ export const ListWrapper = styled.div`
     border-radius: 24px;
     background-color: ${({ theme }) => theme.palette.background.paper};
     width: 100%;
+    max-height: 50vh;
     padding: 20px;
+    overflow: hidden;
+`;
+
+export const ScrollWrapper = styled.div`
+    flex-direction: column;
+    display: flex;
+    gap: 12px;
+    overflow: hidden;
+    overflow-y: auto;
 `;

--- a/src/components/exchanges/universal/options/styles.ts
+++ b/src/components/exchanges/universal/options/styles.ts
@@ -7,9 +7,10 @@ export const ListWrapper = styled.div`
     border-radius: 24px;
     background-color: ${({ theme }) => theme.palette.background.paper};
     width: 100%;
-    max-height: 50vh;
-    padding: 20px;
+    height: auto;
+    max-height: 55vh;
     overflow: hidden;
+    padding: 20px;
 `;
 
 export const ScrollWrapper = styled.div`

--- a/src/components/transactions/wallet/Exchanges/ExchangesUrls.tsx
+++ b/src/components/transactions/wallet/Exchanges/ExchangesUrls.tsx
@@ -1,13 +1,13 @@
-import { useExchangeStore } from '@app/store/useExchangeStore.ts';
 import { ChevronSVG } from '@app/assets/icons/chevron.tsx';
 import { setDialogToShow } from '@app/store';
 import { useTranslation } from 'react-i18next';
 import { Logos } from './logos/Logos.tsx';
 import { ChevronCTA, CopyWrapper, SectionDivider, Subtitle, Title, XCButton, XCWrapper } from './styles.ts';
+import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
 export default function ExchangesUrls() {
     const { t } = useTranslation('wallet');
-    const exchanges = useExchangeStore((s) => s.exchangeMiners);
+    const { data: exchanges } = useFetchExchangeList();
 
     return exchanges?.length && !!exchanges?.some((x) => x.exchange_url) ? (
         <XCWrapper>

--- a/src/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx
+++ b/src/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx
@@ -1,11 +1,12 @@
 import { XCButton } from './styles.ts';
-import { setShowUniversalModal, useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { setShowUniversalModal } from '@app/store/useExchangeStore.ts';
 import { useTranslation } from 'react-i18next';
 import { Logos } from '@app/components/transactions/wallet/Exchanges/logos/Logos.tsx';
+import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
 export default function ExchangeButton() {
     const { t } = useTranslation('wallet');
-    const exchanges = useExchangeStore((s) => s.exchangeMiners);
+    const { data: exchanges } = useFetchExchangeList();
 
     function handleClick() {
         setShowUniversalModal(true);

--- a/src/components/wallet/components/details/WalletDetails.tsx
+++ b/src/components/wallet/components/details/WalletDetails.tsx
@@ -1,10 +1,10 @@
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import { TariOutlineSVG } from '@app/assets/icons/tari-outline.tsx';
 import WalletCardActions from './actions/WalletCardActions.tsx';
 import { Actions, DetailsLeft, LogoWrapper, Name, Wrapper } from './styles.ts';
 
 export default function WalletDetails() {
-    const { data } = useFetchXCContent();
+    const { data } = useFetchExchangeBranding();
     const { name, logo_img_url } = data || {};
     return (
         <Wrapper>

--- a/src/components/wallet/components/details/WalletDetails.tsx
+++ b/src/components/wallet/components/details/WalletDetails.tsx
@@ -5,12 +5,12 @@ import { Actions, DetailsLeft, LogoWrapper, Name, Wrapper } from './styles.ts';
 
 export default function WalletDetails() {
     const { data } = useFetchExchangeBranding();
-    const { name, logo_img_url } = data || {};
+    const { name, logo_img_small_url } = data || {};
     return (
         <Wrapper>
             <DetailsLeft>
                 <LogoWrapper>
-                    {logo_img_url ? <img src={logo_img_url} alt={`${name} logo`} /> : <TariOutlineSVG />}
+                    {logo_img_small_url ? <img src={logo_img_small_url} alt={`${name} logo`} /> : <TariOutlineSVG />}
                 </LogoWrapper>
                 <Name>{name}</Name>
             </DetailsLeft>

--- a/src/components/wallet/components/details/WalletDetails.tsx
+++ b/src/components/wallet/components/details/WalletDetails.tsx
@@ -1,12 +1,11 @@
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import { TariOutlineSVG } from '@app/assets/icons/tari-outline.tsx';
-
-import { Actions, DetailsLeft, LogoWrapper, Name, Wrapper } from './styles.ts';
 import WalletCardActions from './actions/WalletCardActions.tsx';
-import { useExchangeStore } from '@app/store/useExchangeStore.ts';
+import { Actions, DetailsLeft, LogoWrapper, Name, Wrapper } from './styles.ts';
 
 export default function WalletDetails() {
-    const xcData = useExchangeStore((s) => s.currentExchangeMiner);
-    const { name, logo_img_url } = xcData || { name: 'Tari Universe' };
+    const { data } = useFetchXCContent();
+    const { name, logo_img_url } = data || {};
     return (
         <Wrapper>
             <DetailsLeft>

--- a/src/components/wallet/components/details/styles.ts
+++ b/src/components/wallet/components/details/styles.ts
@@ -32,8 +32,8 @@ export const LogoWrapper = styled.div`
     overflow: hidden;
     svg,
     img {
-        height: 11px;
         display: flex;
+        max-width: 100%;
     }
 `;
 export const Actions = styled.div`

--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -23,16 +23,17 @@ import WalletActions from '@app/components/wallet/components/actions/WalletActio
 import ListActions from '@app/components/wallet/components/actions/ListActions.tsx';
 import { TransactionDetails } from '@app/components/transactions/history/details/TransactionDetails.tsx';
 import { setDetailsItem, setIsSwapping } from '@app/store/actions/walletStoreActions.ts';
-import { useExchangeStore } from '@app/store/useExchangeStore.ts';
+
 import ExchangesUrls from '@app/components/transactions/wallet/Exchanges/ExchangesUrls.tsx';
 import ExchangeButton from '@app/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx';
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface SidebarWalletProps {
     section: string;
     setSection: (section: string) => void;
 }
 export default function SidebarWallet({ section, setSection }: SidebarWalletProps) {
-    const xcData = useExchangeStore((s) => s.currentExchangeMiner);
+    const { data: xcData } = useFetchXCContent();
     const detailsItem = useWalletStore((s) => s.detailsItem);
     const targetRef = useRef<HTMLDivElement>(null);
     const { scrollY } = useScroll({ container: targetRef });

--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -26,14 +26,14 @@ import { setDetailsItem, setIsSwapping } from '@app/store/actions/walletStoreAct
 
 import ExchangesUrls from '@app/components/transactions/wallet/Exchanges/ExchangesUrls.tsx';
 import ExchangeButton from '@app/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx';
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface SidebarWalletProps {
     section: string;
     setSection: (section: string) => void;
 }
 export default function SidebarWallet({ section, setSection }: SidebarWalletProps) {
-    const { data: xcData } = useFetchXCContent();
+    const { data: xcData } = useFetchExchangeBranding();
     const detailsItem = useWalletStore((s) => s.detailsItem);
     const targetRef = useRef<HTMLDivElement>(null);
     const { scrollY } = useScroll({ container: targetRef });

--- a/src/containers/floating/EXModal/EXModal.tsx
+++ b/src/containers/floating/EXModal/EXModal.tsx
@@ -5,10 +5,10 @@ import Content from './components/Content.tsx';
 
 import { Wrapper } from './styles.ts';
 import LoadingDots from '@app/components/elements/loaders/LoadingDots.tsx';
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export default function EXModal() {
-    const { data } = useFetchXCContent();
+    const { data } = useFetchExchangeBranding();
     const showModal = useExchangeStore((s) => s.showExchangeAddressModal);
 
     return (

--- a/src/containers/floating/EXModal/EXModal.tsx
+++ b/src/containers/floating/EXModal/EXModal.tsx
@@ -5,9 +5,10 @@ import Content from './components/Content.tsx';
 
 import { Wrapper } from './styles.ts';
 import LoadingDots from '@app/components/elements/loaders/LoadingDots.tsx';
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export default function EXModal() {
-    const data = useExchangeStore((s) => s.currentExchangeMiner);
+    const { data } = useFetchXCContent();
     const showModal = useExchangeStore((s) => s.showExchangeAddressModal);
 
     return (

--- a/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
+++ b/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
@@ -18,12 +18,12 @@ import { formatCountdown } from '@app/utils';
 import { Typography } from '@app/components/elements/Typography';
 import { CloseButton, CloseWrapper } from '@app/components/exchanges/commonStyles.ts';
 import { IoClose } from 'react-icons/io5';
-import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export default function UniversalEXSelectorModal() {
     const { t } = useTranslation(['exchange', 'common'], { useSuspense: false });
     const showModal = useExchangeStore((s) => s.showUniversalModal);
-    const { data: currentExchangeMiner } = useFetchXCContent();
+    const { data: currentExchangeMiner } = useFetchExchangeBranding();
 
     function handleClose() {
         setShowUniversalModal(false);

--- a/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
+++ b/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
@@ -18,11 +18,12 @@ import { formatCountdown } from '@app/utils';
 import { Typography } from '@app/components/elements/Typography';
 import { CloseButton, CloseWrapper } from '@app/components/exchanges/commonStyles.ts';
 import { IoClose } from 'react-icons/io5';
+import { useFetchXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 export default function UniversalEXSelectorModal() {
     const { t } = useTranslation(['exchange', 'common'], { useSuspense: false });
     const showModal = useExchangeStore((s) => s.showUniversalModal);
-    const currentExchangeMiner = useExchangeStore((s) => s.currentExchangeMiner);
+    const { data: currentExchangeMiner } = useFetchXCContent();
 
     function handleClose() {
         setShowUniversalModal(false);
@@ -47,8 +48,8 @@ export default function UniversalEXSelectorModal() {
                         </MainLogoImageWrapper>
                         <MainLogoOverlay>
                             <MainLogoTitle>{t('main-logo-title', { ns: 'exchange' })}</MainLogoTitle>
-                            <MainLogoDescription>{currentExchangeMiner.campaign_description}</MainLogoDescription>
-                            {currentExchangeMiner.reward_expiry_date && (
+                            <MainLogoDescription>{currentExchangeMiner?.campaign_description}</MainLogoDescription>
+                            {currentExchangeMiner?.reward_expiry_date && (
                                 <MainLogoBottomRow>
                                     <Countdown>
                                         <CountdownText>

--- a/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
+++ b/src/containers/floating/UniversalEXSelectorModal/UniversalEXSelectorModal.tsx
@@ -8,7 +8,6 @@ import {
     Wrapper,
     MainLogoDescription,
     MainLogoContainer,
-    MainLogoOverlay,
     MainLogoBottomRow,
     MainLogoImageWrapper,
 } from './styles';
@@ -46,22 +45,20 @@ export default function UniversalEXSelectorModal() {
                         <MainLogoImageWrapper>
                             <img src="/assets/img/exchange_miner_header.png" alt="Exchange Miner Header Logo" />
                         </MainLogoImageWrapper>
-                        <MainLogoOverlay>
-                            <MainLogoTitle>{t('main-logo-title', { ns: 'exchange' })}</MainLogoTitle>
-                            <MainLogoDescription>{currentExchangeMiner?.campaign_description}</MainLogoDescription>
-                            {currentExchangeMiner?.reward_expiry_date && (
-                                <MainLogoBottomRow>
-                                    <Countdown>
-                                        <CountdownText>
-                                            {formatCountdown(currentExchangeMiner.reward_expiry_date)}
-                                        </CountdownText>
-                                    </Countdown>
-                                    <Typography variant="p" style={{ fontWeight: 500 }}>
-                                        {t('time-left', { ns: 'exchange' })}
-                                    </Typography>
-                                </MainLogoBottomRow>
-                            )}
-                        </MainLogoOverlay>
+                        <MainLogoTitle>{t('main-logo-title', { ns: 'exchange' })}</MainLogoTitle>
+                        <MainLogoDescription>{currentExchangeMiner?.campaign_description}</MainLogoDescription>
+                        {currentExchangeMiner?.reward_expiry_date && (
+                            <MainLogoBottomRow>
+                                <Countdown>
+                                    <CountdownText>
+                                        {formatCountdown(currentExchangeMiner.reward_expiry_date)}
+                                    </CountdownText>
+                                </Countdown>
+                                <Typography variant="p" style={{ fontWeight: 500 }}>
+                                    {t('time-left', { ns: 'exchange' })}
+                                </Typography>
+                            </MainLogoBottomRow>
+                        )}
                     </MainLogoContainer>
                     <XCOptions />
                 </Wrapper>

--- a/src/containers/floating/UniversalEXSelectorModal/styles.ts
+++ b/src/containers/floating/UniversalEXSelectorModal/styles.ts
@@ -4,11 +4,11 @@ import { Typography } from '@app/components/elements/Typography.tsx';
 export const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
     width: min(480px, 40vw);
     padding: 20px;
-    gap: 20px;
+    overflow: hidden;
+    height: 100%;
+    gap: 10px;
 `;
 export const HeaderSection = styled.div`
     display: flex;
@@ -27,30 +27,18 @@ export const MainLogoContainer = styled.div`
     position: relative;
     border-radius: 24px;
     height: 144px;
+    display: flex;
+    flex-shrink: 0;
     overflow: hidden;
 `;
 
 export const MainLogoImageWrapper = styled.div`
     width: 100%;
-
+    display: flex;
+    flex-shrink: 0;
     img {
         max-width: 100%;
     }
-`;
-
-export const MainLogoOverlay = styled.div`
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-start;
-    color: white;
-    padding: 20px;
-    gap: 10px;
 `;
 
 export const MainLogoBottomRow = styled.div`

--- a/src/containers/floating/UniversalEXSelectorModal/styles.ts
+++ b/src/containers/floating/UniversalEXSelectorModal/styles.ts
@@ -28,8 +28,11 @@ export const MainLogoContainer = styled.div`
     border-radius: 24px;
     height: 144px;
     display: flex;
-    flex-shrink: 0;
+    flex-shrink: 1;
     overflow: hidden;
+    @media (max-height: 690px) {
+        height: 110px;
+    }
 `;
 
 export const MainLogoImageWrapper = styled.div`

--- a/src/hooks/exchanges/fetchExchangeContent.ts
+++ b/src/hooks/exchanges/fetchExchangeContent.ts
@@ -12,14 +12,18 @@ import { queryClient } from '@app/App/queryClient.ts';
 export const KEY_XC_CONTENT = 'exchange';
 
 export const queryfn = async (exchangeId: string) => {
+    if (exchangeId === 'universal') {
+        return Promise.resolve(universalExchangeMinerOption);
+    }
+
     const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
     const endpoint = `${apiUrl}/miner/exchanges/${exchangeId}`;
-    console.debug(`queryfn exchangeId= `, exchangeId);
+
     try {
         const res = await fetch(endpoint);
         const content = (await res.json()) as ExchangeBranding;
         const shouldShowExchangeSpecificModal = useUIStore.getState().shouldShowExchangeSpecificModal;
-        console.debug(`setCurrentExchangeMinerId in queryfn`, content.id);
+
         setCurrentExchangeMinerId(content.id);
         if (content) {
             setShowExchangeModal(shouldShowExchangeSpecificModal);
@@ -31,12 +35,12 @@ export const queryfn = async (exchangeId: string) => {
     }
 };
 
-export function useFetchXCContent() {
+export function useFetchExchangeBranding() {
     const exchangeId = useExchangeStore((s) => s.currentExchangeMinerId);
-    console.debug(`useFetchXCContent exchangeId= `, exchangeId);
+
     return useQuery({
         queryKey: [KEY_XC_CONTENT, exchangeId],
-        enabled: exchangeId !== 'universal',
+        enabled: !!exchangeId?.length,
         queryFn: () => queryfn(exchangeId),
         refetchOnWindowFocus: true,
         refetchInterval: 60 * 1000 * 60 * 3, // every three hours
@@ -44,7 +48,6 @@ export function useFetchXCContent() {
 }
 
 export async function fetchExchangeContent(exchangeId: string) {
-    console.debug(`fetchExchangeContent ID= `, exchangeId);
     return await queryClient.fetchQuery({ queryKey: [KEY_XC_CONTENT, exchangeId], queryFn: () => queryfn(exchangeId) });
 }
 

--- a/src/hooks/exchanges/fetchExchangeContent.ts
+++ b/src/hooks/exchanges/fetchExchangeContent.ts
@@ -1,0 +1,53 @@
+import { useConfigBEInMemoryStore, useUIStore } from '@app/store';
+import { useQuery } from '@tanstack/react-query';
+import {
+    setCurrentExchangeMinerId,
+    setShowExchangeModal,
+    universalExchangeMinerOption,
+    useExchangeStore,
+} from '@app/store/useExchangeStore.ts';
+import { ExchangeBranding } from '@app/types/exchange.ts';
+import { queryClient } from '@app/App/queryClient.ts';
+
+export const KEY_XC_CONTENT = 'exchange';
+
+export const queryfn = async (exchangeId: string) => {
+    const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
+    const endpoint = `${apiUrl}/miner/exchanges/${exchangeId}`;
+    console.debug(`queryfn exchangeId= `, exchangeId);
+    try {
+        const res = await fetch(endpoint);
+        const content = (await res.json()) as ExchangeBranding;
+        const shouldShowExchangeSpecificModal = useUIStore.getState().shouldShowExchangeSpecificModal;
+        console.debug(`setCurrentExchangeMinerId in queryfn`, content.id);
+        setCurrentExchangeMinerId(content.id);
+        if (content) {
+            setShowExchangeModal(shouldShowExchangeSpecificModal);
+        }
+        return content;
+    } catch (e) {
+        console.error('Could not fetch exchange content', e);
+        return universalExchangeMinerOption;
+    }
+};
+
+export function useFetchXCContent() {
+    const exchangeId = useExchangeStore((s) => s.currentExchangeMinerId);
+    console.debug(`useFetchXCContent exchangeId= `, exchangeId);
+    return useQuery({
+        queryKey: [KEY_XC_CONTENT, exchangeId],
+        enabled: exchangeId !== 'universal',
+        queryFn: () => queryfn(exchangeId),
+        refetchOnWindowFocus: true,
+        refetchInterval: 60 * 1000 * 60 * 3, // every three hours
+    });
+}
+
+export async function fetchExchangeContent(exchangeId: string) {
+    console.debug(`fetchExchangeContent ID= `, exchangeId);
+    return await queryClient.fetchQuery({ queryKey: [KEY_XC_CONTENT, exchangeId], queryFn: () => queryfn(exchangeId) });
+}
+
+export const refreshXCContent = async (exchangeId: string) => {
+    await queryClient.invalidateQueries({ queryKey: [KEY_XC_CONTENT, exchangeId] });
+};

--- a/src/hooks/exchanges/fetchExchangeContent.ts
+++ b/src/hooks/exchanges/fetchExchangeContent.ts
@@ -31,7 +31,6 @@ export const queryfn = async (exchangeId: string) => {
         return content;
     } catch (e) {
         console.error('Could not fetch exchange content', e);
-        return universalExchangeMinerOption;
     }
 };
 

--- a/src/hooks/exchanges/fetchExchanges.ts
+++ b/src/hooks/exchanges/fetchExchanges.ts
@@ -1,0 +1,44 @@
+import { useConfigBEInMemoryStore, useUIStore } from '@app/store';
+import { useQuery } from '@tanstack/react-query';
+import { universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
+import { ExchangeBranding } from '@app/types/exchange.ts';
+import { queryClient } from '@app/App/queryClient.ts';
+
+export const KEY_XC_LIST = 'exchanges';
+
+export const bl2 = async () => {
+    const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
+    const endpoint = `${apiUrl}/miner/exchanges`;
+    try {
+        const res = await fetch(`${endpoint}`);
+
+        if (res.ok) {
+            const list = (await res.json()) as {
+                exchanges: ExchangeBranding[];
+            };
+            const filteredList = list.exchanges.filter((ex) => !ex.is_hidden);
+            filteredList.push(universalExchangeMinerOption);
+            return filteredList;
+        } else {
+            return [];
+        }
+    } catch (e) {
+        console.error('Could not fetch exchange miners', e);
+    }
+};
+
+export function useFetchXCList() {
+    const isAppExchangeSpecific = useUIStore((s) => s.isAppExchangeSpecific);
+
+    return useQuery({
+        queryKey: [KEY_XC_LIST],
+        enabled: !isAppExchangeSpecific,
+        queryFn: () => bl2(),
+        refetchOnWindowFocus: true,
+        refetchInterval: 60 * 1000 * 60 * 3, // every three hours
+    });
+}
+
+export const refreshXCList = async () => {
+    await queryClient.invalidateQueries({ queryKey: [KEY_XC_LIST] });
+};

--- a/src/hooks/exchanges/fetchExchanges.ts
+++ b/src/hooks/exchanges/fetchExchanges.ts
@@ -9,6 +9,8 @@ export const KEY_XC_LIST = 'exchanges';
 export const queryFn = async () => {
     const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
     const endpoint = `${apiUrl}/miner/exchanges`;
+
+    if (!apiUrl.length) return [];
     try {
         const res = await fetch(`${endpoint}`);
         if (res.ok) {

--- a/src/hooks/exchanges/fetchExchanges.ts
+++ b/src/hooks/exchanges/fetchExchanges.ts
@@ -6,12 +6,11 @@ import { queryClient } from '@app/App/queryClient.ts';
 
 export const KEY_XC_LIST = 'exchanges';
 
-export const bl2 = async () => {
+export const queryFn = async () => {
     const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
     const endpoint = `${apiUrl}/miner/exchanges`;
     try {
         const res = await fetch(`${endpoint}`);
-
         if (res.ok) {
             const list = (await res.json()) as {
                 exchanges: ExchangeBranding[];
@@ -27,18 +26,18 @@ export const bl2 = async () => {
     }
 };
 
-export function useFetchXCList() {
+export function useFetchExchangeList() {
     const isAppExchangeSpecific = useUIStore((s) => s.isAppExchangeSpecific);
 
     return useQuery({
         queryKey: [KEY_XC_LIST],
         enabled: !isAppExchangeSpecific,
-        queryFn: () => bl2(),
+        queryFn: () => queryFn(),
         refetchOnWindowFocus: true,
         refetchInterval: 60 * 1000 * 60 * 3, // every three hours
     });
 }
 
-export const refreshXCList = async () => {
-    await queryClient.invalidateQueries({ queryKey: [KEY_XC_LIST] });
-};
+export async function fetchExchangeList() {
+    return await queryClient.fetchQuery({ queryKey: [KEY_XC_LIST], queryFn: () => queryFn() });
+}

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -26,11 +26,12 @@ import { displayMode, modeType } from '../types';
 import { ConfigCore, ConfigMining, ConfigUI, ConfigWallet } from '@app/types/configs.ts';
 import { NodeType, updateNodeType as updateNodeTypeForNodeStore } from '../useNodeStore.ts';
 import {
-    fetchExchangeContent,
     fetchExchangeMiners,
-    setCurrentExchangeMiner,
+    setCurrentExchangeMinerId,
+    universalExchangeMinerOption,
     useExchangeStore,
 } from '../useExchangeStore.ts';
+import { fetchExchangeContent, refreshXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface SetModeProps {
     mode: modeType;
@@ -51,8 +52,8 @@ export const handleConfigCoreLoaded = async (coreConfig: ConfigCore) => {
         await fetchExchangeMiners();
     }
 
-    const currentExchangeContent = useExchangeStore.getState().currentExchangeMiner;
-    if (currentExchangeContent.id !== coreConfig.exchange_id) {
+    const currentExchangeMinerId = useExchangeStore.getState().currentExchangeMinerId;
+    if (currentExchangeMinerId !== coreConfig.exchange_id) {
         await fetchExchangeContent(coreConfig.exchange_id as string);
     }
 };
@@ -349,6 +350,7 @@ export const fetchBackendInMemoryConfig = async () => {
 };
 
 export const handleExchangeIdChanged = async (payload: string) => {
-    const exchangeContent = await fetchExchangeContent(payload);
-    setCurrentExchangeMiner(exchangeContent);
+    console.debug(`setCurrentExchangeMinerId in handleExchangeIdChanged`, payload);
+    setCurrentExchangeMinerId(payload);
+    await refreshXCContent(payload);
 };

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -25,8 +25,9 @@ import { GpuThreads } from '@app/types/app-status.ts';
 import { displayMode, modeType } from '../types';
 import { ConfigCore, ConfigMining, ConfigUI, ConfigWallet } from '@app/types/configs.ts';
 import { NodeType, updateNodeType as updateNodeTypeForNodeStore } from '../useNodeStore.ts';
-import { fetchExchangeMiners, setCurrentExchangeMinerId, useExchangeStore } from '../useExchangeStore.ts';
+import { setCurrentExchangeMinerId, useExchangeStore } from '../useExchangeStore.ts';
 import { fetchExchangeContent, refreshXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
+import { fetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
 interface SetModeProps {
     mode: modeType;
@@ -44,7 +45,7 @@ export const handleConfigCoreLoaded = async (coreConfig: ConfigCore) => {
     if (isAppExchangeSpecific) {
         await fetchExchangeContent(coreConfig.exchange_id as string);
     } else {
-        await fetchExchangeMiners();
+        await fetchExchangeList();
     }
 
     const currentExchangeMinerId = useExchangeStore.getState().currentExchangeMinerId;

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -25,12 +25,7 @@ import { GpuThreads } from '@app/types/app-status.ts';
 import { displayMode, modeType } from '../types';
 import { ConfigCore, ConfigMining, ConfigUI, ConfigWallet } from '@app/types/configs.ts';
 import { NodeType, updateNodeType as updateNodeTypeForNodeStore } from '../useNodeStore.ts';
-import {
-    fetchExchangeMiners,
-    setCurrentExchangeMinerId,
-    universalExchangeMinerOption,
-    useExchangeStore,
-} from '../useExchangeStore.ts';
+import { fetchExchangeMiners, setCurrentExchangeMinerId, useExchangeStore } from '../useExchangeStore.ts';
 import { fetchExchangeContent, refreshXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 
 interface SetModeProps {
@@ -350,7 +345,6 @@ export const fetchBackendInMemoryConfig = async () => {
 };
 
 export const handleExchangeIdChanged = async (payload: string) => {
-    console.debug(`setCurrentExchangeMinerId in handleExchangeIdChanged`, payload);
     setCurrentExchangeMinerId(payload);
     await refreshXCContent(payload);
 };

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { WalletAddress, WalletBalance } from '@app/types/app-status.ts';
 import { BackendBridgeTransaction, useWalletStore } from '../useWalletStore';
 import { setError } from './appStateStoreActions';
-import { setCurrentExchangeMiner, universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
+import { setCurrentExchangeMinerId, universalExchangeMinerOption } from '@app/store/useExchangeStore.ts';
 import { WrapTokenService, OpenAPI } from '@tari-project/wxtm-bridge-backend-api';
 import { useConfigBEInMemoryStore } from '../useAppConfigStore';
 import { TransactionDetailsItem, TransactionDirection, TransactionStatus } from '@app/types/transactions';
@@ -118,7 +118,11 @@ export const handleExternalWalletAddressUpdate = (payload?: WalletAddress) => {
         });
         if (isSeedlessUI) {
             setSeedlessUI(false);
-            setCurrentExchangeMiner(universalExchangeMinerOption);
+            console.debug(
+                `setCurrentExchangeMinerId in handleExternalWalletAddressUpdate`,
+                universalExchangeMinerOption.exchange_id
+            );
+            setCurrentExchangeMinerId(universalExchangeMinerOption.exchange_id);
         }
     }
 };

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -118,10 +118,6 @@ export const handleExternalWalletAddressUpdate = (payload?: WalletAddress) => {
         });
         if (isSeedlessUI) {
             setSeedlessUI(false);
-            console.debug(
-                `setCurrentExchangeMinerId in handleExternalWalletAddressUpdate`,
-                universalExchangeMinerOption.exchange_id
-            );
             setCurrentExchangeMinerId(universalExchangeMinerOption.exchange_id);
         }
     }

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -8,6 +8,7 @@ import { useConfigBEInMemoryStore } from '../useAppConfigStore';
 import { TransactionDetailsItem, TransactionDirection, TransactionStatus } from '@app/types/transactions';
 import { useUIStore } from '../useUIStore';
 import { setSeedlessUI } from './uiStoreActions';
+import { refreshTransactions } from '@app/hooks/wallet/useFetchTxHistory.ts';
 
 export const fetchBridgeTransactionsHistory = async () => {
     const baseUrl = useConfigBEInMemoryStore.getState().bridgeBackendApiUrl;
@@ -119,6 +120,7 @@ export const handleExternalWalletAddressUpdate = (payload?: WalletAddress) => {
         if (isSeedlessUI) {
             setSeedlessUI(false);
             setCurrentExchangeMinerId(universalExchangeMinerOption.exchange_id);
+            refreshTransactions();
         }
     }
 };

--- a/src/store/useExchangeStore.ts
+++ b/src/store/useExchangeStore.ts
@@ -1,12 +1,9 @@
 import { create } from 'zustand';
 
-import { useConfigBEInMemoryStore } from '@app/store/useAppConfigStore.ts';
-
 import { ExchangeBranding } from '@app/types/exchange.ts';
 
 interface ExchangeStoreState {
     showExchangeAddressModal: boolean | null;
-    exchangeMiners?: ExchangeBranding[];
     currentExchangeMinerId: string;
     showUniversalModal: boolean | null;
 }
@@ -34,31 +31,7 @@ export const setShowUniversalModal = (showUniversalModal: boolean) => {
     useExchangeStore.setState({ showUniversalModal: showUniversalModal });
 };
 
-export const setExchangeMiners = (exchangeMiners?: ExchangeBranding[]) => {
-    if (!exchangeMiners) return;
-    useExchangeStore.setState({ exchangeMiners });
-};
-
 export const setCurrentExchangeMinerId = (currentExchangeMinerId?: string) => {
     if (!currentExchangeMinerId) return;
     useExchangeStore.setState({ currentExchangeMinerId });
 };
-
-export async function fetchExchangeMiners() {
-    const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
-    if (!apiUrl) return;
-    const endpoint = `${apiUrl}/miner/exchanges`;
-    try {
-        const res = await fetch(`${endpoint}`);
-        if (res.ok) {
-            const list = (await res.json()) as {
-                exchanges: ExchangeBranding[];
-            };
-            const filteredList = list.exchanges.filter((ex) => !ex.is_hidden);
-            filteredList.push(universalExchangeMinerOption);
-            setExchangeMiners(filteredList);
-        }
-    } catch (e) {
-        console.error('Could not fetch exchange miners', e);
-    }
-}

--- a/src/store/useExchangeStore.ts
+++ b/src/store/useExchangeStore.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 
 import { useConfigBEInMemoryStore } from '@app/store/useAppConfigStore.ts';
-import { useUIStore } from './useUIStore';
+
 import { ExchangeBranding } from '@app/types/exchange.ts';
 
 interface ExchangeStoreState {
     showExchangeAddressModal: boolean | null;
     exchangeMiners?: ExchangeBranding[];
-    currentExchangeMiner: ExchangeBranding;
+    currentExchangeMinerId: string;
     showUniversalModal: boolean | null;
 }
 
@@ -22,7 +22,7 @@ export const universalExchangeMinerOption: ExchangeBranding = {
 const initialState = {
     showExchangeAddressModal: null,
     showUniversalModal: null,
-    currentExchangeMiner: universalExchangeMinerOption,
+    currentExchangeMinerId: universalExchangeMinerOption.exchange_id,
 };
 export const useExchangeStore = create<ExchangeStoreState>()(() => ({ ...initialState }));
 
@@ -39,9 +39,9 @@ export const setExchangeMiners = (exchangeMiners?: ExchangeBranding[]) => {
     useExchangeStore.setState({ exchangeMiners });
 };
 
-export const setCurrentExchangeMiner = (currentExchangeMiner?: ExchangeBranding) => {
-    if (!currentExchangeMiner) return;
-    useExchangeStore.setState({ currentExchangeMiner });
+export const setCurrentExchangeMinerId = (currentExchangeMinerId?: string) => {
+    if (!currentExchangeMinerId) return;
+    useExchangeStore.setState({ currentExchangeMinerId });
 };
 
 export async function fetchExchangeMiners() {
@@ -60,27 +60,5 @@ export async function fetchExchangeMiners() {
         }
     } catch (e) {
         console.error('Could not fetch exchange miners', e);
-    }
-}
-
-export async function fetchExchangeContent(exchangeId: string) {
-    const currentExchangeContent = useExchangeStore.getState().currentExchangeMiner;
-    if (currentExchangeContent?.id === exchangeId) {
-        return currentExchangeContent;
-    }
-
-    const apiUrl = useConfigBEInMemoryStore.getState().airdropApiUrl;
-    const endpoint = `${apiUrl}/miner/exchanges`;
-    try {
-        const content = await fetch(`${endpoint}/${exchangeId}`);
-        const xcContent = (await content.json()) as ExchangeBranding;
-        const shouldShowExchangeSpecificModal = useUIStore.getState().shouldShowExchangeSpecificModal;
-        if (xcContent) {
-            setCurrentExchangeMiner(xcContent);
-            setShowExchangeModal(shouldShowExchangeSpecificModal);
-        }
-        return xcContent;
-    } catch (e) {
-        console.error('Could not fetch exchange content', e);
     }
 }


### PR DESCRIPTION
Description
___

- use `useQuery` for fetching exchange data (so no need to restart if new ones are added/assets change)
- ui cleanups in wallet and modal 
  - mostly theming 