### PR TITLE
fix(exchange-miner): change 'mining here' text to fixed color on both themes

### DIFF
--- a/src/components/wallet/components/details/WalletDetails.tsx
+++ b/src/components/wallet/components/details/WalletDetails.tsx
@@ -1,7 +1,6 @@
 import { useFetchExchangeBranding } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import WalletCardActions from './actions/WalletCardActions.tsx';
-import { Actions, DetailsLeft, LogoWrapper, MiningHereWrapper, Name, Wrapper } from './styles.ts';
-import { Typography } from '@app/components/elements/Typography.tsx';
+import { Actions, DetailsLeft, LogoWrapper, MiningHereText, MiningHereWrapper, Name, Wrapper } from './styles.ts';
 import { useTranslation } from 'react-i18next';
 
 export default function WalletDetails() {
@@ -22,9 +21,7 @@ export default function WalletDetails() {
             </DetailsLeft>
             <Actions>
                 <MiningHereWrapper>
-                    <Typography variant="p" style={{ fontSize: '10px' }}>
-                        {t('xc.mining-here')}
-                    </Typography>
+                    <MiningHereText>{t('xc.mining-here')}</MiningHereText>
                 </MiningHereWrapper>
                 <WalletCardActions />
             </Actions>

--- a/src/components/wallet/components/details/styles.ts
+++ b/src/components/wallet/components/details/styles.ts
@@ -50,3 +50,10 @@ export const MiningHereWrapper = styled.div`
     backdrop-filter: blur(154px);
     padding: 9px 10px 9px 10px;
 `;
+
+export const MiningHereText = styled(Typography).attrs({
+    variant: 'p',
+})`
+    color: ${({ theme }) => theme.colors.greyscale[100]};
+    font-size: 10px;
+`;


### PR DESCRIPTION
Description
---
Fix 'Mining here' text to fix color on both themes:

![Screenshot from 2025-06-16 16-28-40](https://github.com/user-attachments/assets/926d32dd-a484-4b01-8b6b-42d4adc3f6e0)
![Screenshot from 2025-06-16 16-28-49](https://github.com/user-attachments/assets/37f41aed-4149-49ad-88ac-1735cb977db7)
