### PR TITLE
fix: fetching content between builds

### DIFF
--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -112,7 +112,7 @@ export const XCOption = ({ content, isCurrent = false, isActive, onActiveClick }
                     )}
                 </SelectOptionWrapper>
             </ContentHeaderWrapper>
-            {isActive && (
+            {isActive && base_tari_address && (
                 <ContentBodyWrapper $isActive={isActive}>
                     <ExchangeAddress
                         handleIsAddressValid={setIsAddressValid}

--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -112,12 +112,14 @@ export const XCOption = ({ content, isCurrent = false, isActive, onActiveClick }
                     )}
                 </SelectOptionWrapper>
             </ContentHeaderWrapper>
-            {isActive && base_tari_address && (
+            {isActive && (
                 <ContentBodyWrapper $isActive={isActive}>
                     <ExchangeAddress
                         handleIsAddressValid={setIsAddressValid}
                         handleAddressChanged={setMiningAddress}
-                        value={isCurrent ? truncateMiddle(base_tari_address, 7, ' ...') : undefined}
+                        value={
+                            isCurrent ? base_tari_address && truncateMiddle(base_tari_address, 7, ' ...') : undefined
+                        }
                     />
                     <SeasonReward>
                         <LeftContent>

--- a/src/hooks/exchanges/fetchExchangeContent.ts
+++ b/src/hooks/exchanges/fetchExchangeContent.ts
@@ -1,16 +1,11 @@
 import { useConfigBEInMemoryStore, useUIStore } from '@app/store';
 import { useQuery } from '@tanstack/react-query';
-import {
-    setCurrentExchangeMinerId,
-    setShowExchangeModal,
-    universalExchangeMinerOption,
-    useExchangeStore,
-} from '@app/store/useExchangeStore.ts';
+import { setShowExchangeModal, universalExchangeMinerOption, useExchangeStore } from '@app/store/useExchangeStore.ts';
 import { ExchangeBranding } from '@app/types/exchange.ts';
 import { queryClient } from '@app/App/queryClient.ts';
 import { useTheme } from 'styled-components';
 
-export const KEY_XC_CONTENT = 'exchange';
+export const KEY_XC_CONTENT = 'branding';
 
 export const queryfn = async (exchangeId: string) => {
     if (exchangeId === 'universal') {
@@ -23,10 +18,9 @@ export const queryfn = async (exchangeId: string) => {
     try {
         const res = await fetch(endpoint);
         const content = (await res.json()) as ExchangeBranding;
-        const shouldShowExchangeSpecificModal = useUIStore.getState().shouldShowExchangeSpecificModal;
 
-        setCurrentExchangeMinerId(content.id);
         if (content) {
+            const shouldShowExchangeSpecificModal = useUIStore.getState().shouldShowExchangeSpecificModal;
             setShowExchangeModal(shouldShowExchangeSpecificModal);
         }
         return content;

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -25,7 +25,7 @@ import { GpuThreads } from '@app/types/app-status.ts';
 import { displayMode, modeType } from '../types';
 import { ConfigCore, ConfigMining, ConfigUI, ConfigWallet } from '@app/types/configs.ts';
 import { NodeType, updateNodeType as updateNodeTypeForNodeStore } from '../useNodeStore.ts';
-import { setCurrentExchangeMinerId, useExchangeStore } from '../useExchangeStore.ts';
+import { setCurrentExchangeMinerId } from '../useExchangeStore.ts';
 import { fetchExchangeContent, refreshXCContent } from '@app/hooks/exchanges/fetchExchangeContent.ts';
 import { fetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
 
@@ -37,19 +37,13 @@ interface SetModeProps {
 
 export const handleConfigCoreLoaded = async (coreConfig: ConfigCore) => {
     useConfigCoreStore.setState(coreConfig);
-
     const buildInExchangeId = useConfigBEInMemoryStore.getState().exchangeId;
     const isAppExchangeSpecific = Boolean(buildInExchangeId !== 'universal');
     setIsAppExchangeSpecific(isAppExchangeSpecific);
 
-    if (isAppExchangeSpecific) {
-        await fetchExchangeContent(coreConfig.exchange_id as string);
-    } else {
+    if (!isAppExchangeSpecific) {
         await fetchExchangeList();
-    }
-
-    const currentExchangeMinerId = useExchangeStore.getState().currentExchangeMinerId;
-    if (currentExchangeMinerId !== coreConfig.exchange_id) {
+    } else {
         await fetchExchangeContent(coreConfig.exchange_id as string);
     }
 };


### PR DESCRIPTION
Description
---
- removed `setCurrentExchangeMinerId` from the fetch query - only set in `handleExchangeIdChanged` and when coming back from seedless ui

How Has This Been Tested?
---
- local builds