### PR TITLE
fix(ui): pool stats days | old feature flags | cleanups

### DIFF
--- a/src/components/mining/timer/MiningTime.tsx
+++ b/src/components/mining/timer/MiningTime.tsx
@@ -25,8 +25,10 @@ export const MiningTime = memo(function MiningTime({ variant = 'primary', timing
     const _minutes = isMini && minutes === '0' ? '00' : minutes;
     const _seconds = isMini && seconds === '0' ? '00' : seconds;
 
+    const renderDays = daysString && parseInt(daysString) > 0;
     const renderHours = hoursString && parseInt(hoursString) > 0;
-    const daysMarkup = daysString ? (
+
+    const daysMarkup = renderDays ? (
         <>
             {daysString}
             <TimerUnitWrapper />

--- a/src/components/tapplets/Tapplet.tsx
+++ b/src/components/tapplets/Tapplet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useTappletSignerStore } from '@app/store/useTappletSignerStore';
-import { MiningViewContainer } from '@app/containers/main/Dashboard/MiningView/MiningView.styles';
+import { TappletContainer } from '@app/containers/main/Dashboard/MiningView/MiningView.styles';
 import { open } from '@tauri-apps/plugin-shell';
 import { useConfigUIStore, useUIStore, setError as setStoreError } from '@app/store';
 
@@ -102,7 +102,7 @@ export const Tapplet: React.FC<TappletProps> = ({ source }) => {
     }, [sendWindowSize, handleMessage]);
 
     return (
-        <MiningViewContainer>
+        <TappletContainer>
             <iframe
                 src={source}
                 width="100%"
@@ -111,6 +111,6 @@ export const Tapplet: React.FC<TappletProps> = ({ source }) => {
                 onLoad={sendWindowSize}
                 style={{ border: 'none', pointerEvents: 'all' }}
             />
-        </MiningViewContainer>
+        </TappletContainer>
     );
 };

--- a/src/containers/main/Dashboard/Dashboard.tsx
+++ b/src/containers/main/Dashboard/Dashboard.tsx
@@ -7,7 +7,6 @@ import { Tapplet } from '@app/components/tapplets/Tapplet.tsx';
 import MiningView from './MiningView/MiningView.tsx';
 
 export default function Dashboard() {
-    const { uiBridgeSwapsEnabled } = useTappletsStore();
     const activeTapplet = useTappletsStore((s) => s.activeTapplet);
     const showTapplet = useUIStore((s) => s.showTapplet);
     const connectionStatus = useUIStore((s) => s.connectionStatus);
@@ -18,11 +17,7 @@ export default function Dashboard() {
     return (
         <DashboardContentContainer $tapplet={!!activeTapplet}>
             {connectionStatus !== 'connected' && !orphanChainUiDisabled ? <DisconnectWrapper /> : null}
-            {uiBridgeSwapsEnabled && showTapplet && activeTapplet ? (
-                <Tapplet source={activeTapplet.source} />
-            ) : (
-                <MiningView />
-            )}
+            {showTapplet && activeTapplet ? <Tapplet source={activeTapplet.source} /> : <MiningView />}
         </DashboardContentContainer>
     );
 }

--- a/src/containers/main/Dashboard/MiningView/MiningView.styles.ts
+++ b/src/containers/main/Dashboard/MiningView/MiningView.styles.ts
@@ -9,3 +9,17 @@ export const MiningViewContainer = styled.div`
     position: relative;
     overflow: hidden;
 `;
+
+export const TappletContainer = styled.div`
+    pointer-events: all;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 2;
+`;

--- a/src/containers/navigation/Sidebars/BridgeNavigationButton.tsx
+++ b/src/containers/navigation/Sidebars/BridgeNavigationButton.tsx
@@ -12,7 +12,8 @@ import { AnimatePresence } from 'motion/react';
 import { BridgeOutlineSVG } from '@app/assets/icons/bridge-outline.tsx';
 import { useTappletsStore } from '@app/store/useTappletsStore.ts';
 import { BRIDGE_TAPPLET_ID } from '@app/store/consts.ts';
-import { useTariBalance } from '@app/hooks/wallet/useTariBalance.ts';
+
+import { useWalletStore } from '@app/store';
 
 interface NavButtonProps {
     children: ReactNode;
@@ -23,7 +24,7 @@ interface NavButtonProps {
 const NavButton = memo(function NavButton({ children, isActive, onClick }: NavButtonProps) {
     const sidebarOpen = useUIStore((s) => s.sidebarOpen);
     const [showArrow, setShowArrow] = useState(false);
-    const { isWalletScanning } = useTariBalance();
+    const isWalletScanning = useWalletStore((s) => s.wallet_scanning?.is_scanning);
 
     const scaleX = sidebarOpen ? -1 : 1;
 

--- a/src/containers/navigation/Sidebars/SidebarMini.tsx
+++ b/src/containers/navigation/Sidebars/SidebarMini.tsx
@@ -5,11 +5,9 @@ import { AirdropSidebarItems } from '@app/containers/main/Airdrop/sidebar/Airdro
 import NavigationButton from './NavigationButton';
 import { GridBottom, GridCenter, GridTop, LogoWrapper, MiniWrapper } from './SidebarMini.styles.ts';
 import BridgeNavigationButton from './BridgeNavigationButton.tsx';
-import { useTappletsStore } from '@app/store/useTappletsStore.ts';
 import { useUIStore } from '@app/store';
 
 const SidebarMini = memo(function SidebarMini() {
-    const uiBridgeSwapsEnabled = useTappletsStore((s) => s.uiBridgeSwapsEnabled);
     const seedlessUI = useUIStore((s) => s.seedlessUI);
 
     return (
@@ -21,7 +19,7 @@ const SidebarMini = memo(function SidebarMini() {
             </GridTop>
             <GridCenter>
                 <NavigationButton />
-                {uiBridgeSwapsEnabled && !seedlessUI && <BridgeNavigationButton />}
+                {!seedlessUI && <BridgeNavigationButton />}
             </GridCenter>
             <GridBottom>
                 <AirdropSidebarItems />

--- a/src/hooks/airdrop/stateHelpers/useAirdropPolling.ts
+++ b/src/hooks/airdrop/stateHelpers/useAirdropPolling.ts
@@ -5,8 +5,6 @@ import {
     fetchLatestXSpaceEvent,
     fetchOrphanChainUiFeatureFlag,
     fetchPollingFeatureFlag,
-    fetchWarmupFeatureFlag,
-    fetchUiSendRecvFeatureFlag,
     fetchBlockBubblesFeatureFlag,
 } from '@app/store/actions/airdropStoreActions';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
@@ -30,12 +28,10 @@ export const useAirdropPolling = () => {
         }, DEBOUNCE_DELAY);
     }, []);
 
-    const fetchFeatureFlags = useCallback(() => {
-        fetchOrphanChainUiFeatureFlag();
-        fetchPollingFeatureFlag();
-        fetchUiSendRecvFeatureFlag();
-        fetchWarmupFeatureFlag();
-        fetchBlockBubblesFeatureFlag();
+    const fetchFeatureFlags = useCallback(async () => {
+        await fetchOrphanChainUiFeatureFlag();
+        await fetchPollingFeatureFlag();
+        await fetchBlockBubblesFeatureFlag();
     }, []);
 
     const fetchFeatureFlagDebounced = useCallback(() => {
@@ -43,7 +39,7 @@ export const useAirdropPolling = () => {
             return;
         }
         featureFlagTimeoutRef.current = setTimeout(async () => {
-            fetchFeatureFlags();
+            await fetchFeatureFlags();
             if (featureFlagTimeoutRef.current) {
                 clearTimeout(featureFlagTimeoutRef.current);
             }

--- a/src/store/actions/airdropStoreActions.ts
+++ b/src/store/actions/airdropStoreActions.ts
@@ -252,20 +252,6 @@ export async function fetchOrphanChainUiFeatureFlag() {
     return response;
 }
 
-export async function fetchWarmupFeatureFlag() {
-    const response = await fetchFeatureFlag(FEATURES.FF_UI_WARMUP);
-    if (response) {
-        useUIStore.setState({ showWarmup: response.access });
-    }
-    return response;
-}
-
-export async function fetchUiSendRecvFeatureFlag() {
-    const response = await fetchFeatureFlag(FEATURES.FF_UI_TX);
-    useAirdropStore.setState({ uiSendRecvEnabled: response?.access || true });
-    return response;
-}
-
 export async function fetchBlockBubblesFeatureFlag() {
     const response = await fetchFeatureFlag(FEATURES.FF_UI_BLOCK_BUBBLES);
     if (response) {

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -14,7 +14,6 @@ import { ProgressTrackerUpdatePayload } from '@app/hooks/app/useProgressEventsLi
 
 import { fetchBridgeTransactionsHistory } from './walletStoreActions';
 import { SetupPhase } from '@app/types/backend-state';
-import { useTappletsStore } from '../useTappletsStore';
 
 export interface DisabledPhasesPayload {
     disabled_phases: SetupPhase[];
@@ -133,9 +132,4 @@ export const updateDisabledPhases = (payload: DisabledPhasesPayload) => {
 
 export const handleUpdateDisabledPhases = (payload: DisabledPhasesPayload) => {
     updateDisabledPhases(payload);
-    if (payload.disabled_phases.includes(SetupPhase.Wallet)) {
-        useTappletsStore.setState({ uiBridgeSwapsEnabled: false });
-    } else if (!useTappletsStore.getState().uiBridgeSwapsEnabled) {
-        useTappletsStore.getState().fetchUiBridgeFeatureFlag();
-    }
 };

--- a/src/store/consts.ts
+++ b/src/store/consts.ts
@@ -1,19 +1,10 @@
 const FF_UI_ORPHAN_CHAIN_DISABLED = 'orphan-chain-ui-disabled';
-const FF_UI_TX = 'ui-send-recv';
-const FF_UI_WARMUP = 'ui-warmup';
-const FF_SWAPS_ENABLED = 'swaps-enabled';
-const FF_UI_BRIDGE = 'ui-bridge-swaps';
 const FF_UI_BLOCK_BUBBLES = 'ui-block-bubbles';
-
 const FF_POLLING = 'polling';
 
 export const FEATURES = {
     FF_POLLING,
     FF_UI_ORPHAN_CHAIN_DISABLED,
-    FF_UI_TX,
-    FF_UI_WARMUP,
-    FF_UI_BRIDGE,
-    FF_SWAPS_ENABLED,
     FF_UI_BLOCK_BUBBLES,
 };
 

--- a/src/store/useTappletsStore.ts
+++ b/src/store/useTappletsStore.ts
@@ -2,14 +2,11 @@ import { create } from './create.ts';
 import { ActiveTapplet, BridgeTxDetails } from '@app/types/tapplets/tapplet.types.ts';
 import { useTappletSignerStore } from './useTappletSignerStore.ts';
 import { invoke } from '@tauri-apps/api/core';
-import { FEATURES } from './consts.ts';
-import { fetchFeatureFlag } from './actions/airdropStoreActions.ts';
 
 interface State {
     isInitialized: boolean;
     isFetching: boolean;
     activeTapplet: ActiveTapplet | undefined;
-    uiBridgeSwapsEnabled: boolean;
     ongoingBridgeTx: BridgeTxDetails | undefined;
     isPendingTappletTx: boolean;
 }
@@ -18,8 +15,6 @@ interface Actions {
     setActiveTapp: (tapplet?: ActiveTapplet) => Promise<void>;
     setActiveTappById: (tappletId: number, isBuiltIn?: boolean) => Promise<void>;
     deactivateTapplet: () => Promise<void>;
-    setUiBridgeSwaps: (enabled: boolean) => Promise<void>;
-    fetchUiBridgeFeatureFlag: () => Promise<boolean>;
     setOngoingBridgeTx: (tx: BridgeTxDetails) => void;
     removeOngoingBridgeTx: () => void;
 }
@@ -30,22 +25,13 @@ const initialState: State = {
     isFetching: false,
     isInitialized: false,
     activeTapplet: undefined,
-    uiBridgeSwapsEnabled: true,
+
     ongoingBridgeTx: undefined,
     isPendingTappletTx: false,
 };
 
 export const useTappletsStore = create<TappletsStoreState>()((set, get) => ({
     ...initialState,
-    setUiBridgeSwaps: async (enabled: boolean) => {
-        set({ uiBridgeSwapsEnabled: enabled });
-    },
-    fetchUiBridgeFeatureFlag: async () => {
-        const response = await fetchFeatureFlag(FEATURES.FF_UI_BRIDGE);
-        const uiBridgeFlag = response?.access ?? false;
-        set({ uiBridgeSwapsEnabled: uiBridgeFlag });
-        return uiBridgeFlag;
-    },
     setActiveTapp: async (tapplet) => {
         set({ activeTapplet: tapplet });
     },


### PR DESCRIPTION
Description
---

- add check for `days` in `MiningTime` (fixes random lonesome `0` on start up in `PoolStatsTile`)
- add `TappletContainer` with updating styling for bridge section
- remove old feature flags 

How Has This Been Tested?
---

- locally:

| before | after |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/d7cbc3c2-fd2d-4857-881c-6b4490637b89) | <img width="231" alt="image" src="https://github.com/user-attachments/assets/fbb28f7b-ffe5-4b16-97de-8cbbe2fe8a09" /> |
| <img width="1332" alt="image" src="https://github.com/user-attachments/assets/8cd4a7da-f963-403a-b0a3-89b3b258e6cf" /> | <img width="1327" alt="image" src="https://github.com/user-attachments/assets/8bc31510-17e9-4d5b-9428-fe4f4b436a08" /> |
