### PR TITLE
fix(ui): pool stats tooltip regression

### DIFF
--- a/src/containers/navigation/Sidebars/Sidebar.styles.ts
+++ b/src/containers/navigation/Sidebars/Sidebar.styles.ts
@@ -23,7 +23,6 @@ export const SidebarWrapper = styled(m.div).attrs({
     flex-shrink: 0;
     padding: 15px 10px;
     position: relative;
-    overflow: hidden;
     width: ${SB_WIDTH}px;
 
     & * {
@@ -73,4 +72,5 @@ export const BuyOverlay = styled(m.div)`
     z-index: 4;
     top: 0;
     left: 0;
+    border-radius: 20px;
 `;


### PR DESCRIPTION
Description
---
- broke(hid) the tooltip in #2390 with `overflow: hidden` on the sidebar wrapper, fixed by just adding the border radius to the overlay instead

How Has This Been Tested?
---
- locally: 
![optimised_18-06_13-05_722](https://github.com/user-attachments/assets/e6f5d627-25e8-4d85-b742-498b015862fe)


What process can a PR reviewer use to test or verify this change?
---
- hover over tooltip trigger -> still see tooltip