### PR TITLE
fix: importing seed words

### DIFF
--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -309,15 +309,6 @@ impl InternalWallet {
         let address = TariAddress::from_base58(&self.config.tari_address_base58);
         address.map(|a| a.network())
     }
-
-    pub async fn clear_wallet_local_data(cache_path: PathBuf) -> Result<(), anyhow::Error> {
-        let network = Network::get_current_or_user_setting_or_default()
-            .to_string()
-            .to_lowercase();
-        let wallet_dir = cache_path.join("wallet").join(network);
-        fs::remove_dir_all(wallet_dir).await?;
-        Ok(())
-    }
 }
 
 pub fn generate_password(length: usize) -> String {

--- a/src/components/transactions/history/List.tsx
+++ b/src/components/transactions/history/List.tsx
@@ -34,7 +34,7 @@ export function List() {
         onChange: () => hasNextPage && fetchNextPage(),
     });
 
-    const baseTx = data?.pages.flatMap((p) => p) || [];
+    const baseTx = useMemo(() => data?.pages.flatMap((p) => p) || [], [data?.pages]);
 
     useEffect(() => {
         const isThereANewBridgeTransaction = baseTx.find(
@@ -52,7 +52,7 @@ export function List() {
         if (isThereANewBridgeTransaction || isThereEmptyBridgeTransactionAndFoundInWallet) {
             fetchBridgeTransactionsHistory();
         }
-    }, [baseTx, coldWalletAddress, currentBlockHeight]);
+    }, [baseTx, bridgeTransactions, coldWalletAddress, currentBlockHeight]);
 
     const combinedTransactions = useMemo(() => {
         return ([...baseTx, ...bridgeTransactions] as (TransactionInfo | UserTransactionDTO)[]).sort((a, b) => {

--- a/src/hooks/wallet/useFetchTxHistory.ts
+++ b/src/hooks/wallet/useFetchTxHistory.ts
@@ -8,9 +8,10 @@ import { useWalletStore } from '@app/store';
 export const KEY_TX = `transactions`;
 
 export function useFetchTxHistory() {
+    const [walletAddress, _] = useWalletStore((state) => state.getActiveTariAddress());
     const isWalletScanning = useWalletStore((s) => s.wallet_scanning.is_scanning);
     return useInfiniteQuery<TransactionInfo[]>({
-        queryKey: [KEY_TX],
+        queryKey: [KEY_TX, `address: ${walletAddress}`],
         queryFn: async ({ pageParam }) => {
             const limit = 20;
             const offset = limit * (pageParam as number);

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -62,6 +62,7 @@ export const importSeedWords = async (seedWords: string[]) => {
     });
     try {
         await invoke('import_seed_words', { seedWords });
+        await refreshTransactions();
         useWalletStore.setState({ is_wallet_importing: false });
     } catch (error) {
         setError(`Could not import seed words: ${error}`, true);
@@ -120,19 +121,21 @@ export const setDetailsItem = (detailsItem: TransactionDetailsItem | BackendBrid
 export const handleExternalWalletAddressUpdate = (payload?: WalletAddress) => {
     const isSeedlessUI = useUIStore.getState().seedlessUI;
     if (payload) {
-        useWalletStore.setState({
+        useWalletStore.setState((c) => ({
+            ...c,
             external_tari_address_base58: payload.tari_address_base58,
             external_tari_address_emoji: payload.tari_address_emoji,
-        });
+        }));
 
         if (!isSeedlessUI) {
             setSeedlessUI(true);
         }
     } else {
-        useWalletStore.setState({
+        useWalletStore.setState((c) => ({
+            ...c,
             external_tari_address_base58: undefined,
             external_tari_address_emoji: undefined,
-        });
+        }));
         if (isSeedlessUI) {
             setSeedlessUI(false);
             setCurrentExchangeMinerId(universalExchangeMinerOption.exchange_id);
@@ -142,8 +145,9 @@ export const handleExternalWalletAddressUpdate = (payload?: WalletAddress) => {
 };
 
 export const handleBaseWalletUpate = (payload: WalletAddress) => {
-    useWalletStore.setState({
+    useWalletStore.setState((c) => ({
+        ...c,
         tari_address_base58: payload.tari_address_base58,
         tari_address_emoji: payload.tari_address_emoji,
-    });
+    }));
 };

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -43,7 +43,22 @@ export const fetchBridgeColdWalletAddress = async () => {
 };
 
 export const importSeedWords = async (seedWords: string[]) => {
-    useWalletStore.setState({ is_wallet_importing: true });
+    useWalletStore.setState({
+        is_wallet_importing: true,
+        coinbase_transactions: [],
+        transactions: [],
+        bridge_transactions: [],
+        has_more_coinbase_transactions: true,
+        has_more_transactions: true,
+        is_reward_history_loading: false,
+        is_transactions_history_loading: false,
+        wallet_scanning: {
+            is_scanning: true,
+            scanned_height: 0,
+            total_height: 0,
+            progress: 0,
+        },
+    });
     try {
         await invoke('import_seed_words', { seedWords });
         useWalletStore.setState({ is_wallet_importing: false });

--- a/src/store/useBlockchainVisualisationStore.ts
+++ b/src/store/useBlockchainVisualisationStore.ts
@@ -12,7 +12,6 @@ import { setMiningControlsEnabled } from './actions/miningStoreActions.ts';
 import { updateWalletScanningProgress, useWalletStore } from './useWalletStore.ts';
 import { useConfigUIStore } from '@app/store/useAppConfigStore.ts';
 import { refreshTransactions } from '@app/hooks/wallet/useFetchTxHistory.ts';
-import { fetchBridgeTransactionsHistory } from '@app/store/actions/walletStoreActions.ts';
 
 const appWindow = getCurrentWindow();
 

--- a/src/store/useWalletStore.ts
+++ b/src/store/useWalletStore.ts
@@ -78,6 +78,7 @@ export const useWalletStore = create<WalletStoreState & WalletStoreSelectors>()(
         const externalAddress = get().external_tari_address_base58;
         const externalAddressEmoji = get().external_tari_address_emoji;
         const isSeedlessUI = useUIStore.getState().seedlessUI;
+
         if (isSeedlessUI && externalAddress && externalAddressEmoji) {
             return [externalAddress, externalAddressEmoji];
         }


### PR DESCRIPTION
* use clean_data_folder from wallet manager, to also change init scan flag

main issue was:
```
state
                .wallet_manager
                .set_view_private_key_and_spend_key(wallet.get_view_key(), wallet.get_spend_key())
                .await;
```

Wallet process was starting with old keys