### PR TITLE
fix(ui): seedless UI - tower offset & sync CTA

### DIFF
--- a/src/components/wallet/components/details/actions/WalletCardActions.tsx
+++ b/src/components/wallet/components/details/actions/WalletCardActions.tsx
@@ -1,11 +1,13 @@
-import { Wrapper } from './styles.ts';
+import { useUIStore } from '@app/store';
 import ActionCopyAddress from './ActionCopyAddress';
 import ActionPhoneSync from './ActionPhoneSync';
+import { Wrapper } from './styles.ts';
 
 export default function WalletCardActions() {
+    const seedlessUI = useUIStore((s) => s.seedlessUI);
     return (
         <Wrapper>
-            <ActionPhoneSync />
+            {!seedlessUI && <ActionPhoneSync />}
             <ActionCopyAddress />
         </Wrapper>
     );

--- a/src/containers/navigation/Sidebars/BridgeNavigationButton.tsx
+++ b/src/containers/navigation/Sidebars/BridgeNavigationButton.tsx
@@ -1,11 +1,9 @@
-import { memo, ReactNode, useEffect, useState } from 'react';
+import { memo, ReactNode, useState } from 'react';
 import { IoChevronForwardOutline } from 'react-icons/io5';
-import { setAnimationProperties } from '@tari-project/tari-tower';
 
 import { useUIStore } from '@app/store/useUIStore.ts';
 import { setShowTapplet, setSidebarOpen } from '@app/store/actions/uiStoreActions';
 
-import { SB_MINI_WIDTH, SB_SPACING, SB_WIDTH } from '@app/theme/styles.ts';
 import { HoverIconWrapper, NavIconWrapper, NavigationWrapper, StyledIconButton } from './SidebarMini.styles.ts';
 import { AnimatePresence } from 'motion/react';
 
@@ -56,7 +54,6 @@ const NavButton = memo(function NavButton({ children, isActive, onClick }: NavBu
     );
 });
 const BridgeNavigationButton = memo(function BridgeNavigationButton() {
-    const sidebarOpen = useUIStore((s) => s.sidebarOpen);
     const showTapplet = useUIStore((s) => s.showTapplet);
     const setActiveTappById = useTappletsStore((s) => s.setActiveTappById);
 
@@ -70,21 +67,6 @@ const BridgeNavigationButton = memo(function BridgeNavigationButton() {
             setSidebarOpen(true);
         }
     }
-
-    useEffect(() => {
-        const offset = (!sidebarOpen ? SB_MINI_WIDTH : SB_WIDTH) + SB_SPACING * 2;
-        setAnimationProperties([
-            { property: 'offsetX', value: offset },
-            { property: 'cameraOffsetX', value: offset / window.innerWidth },
-        ]);
-
-        return () => {
-            setAnimationProperties([
-                { property: 'offsetX', value: 0 },
-                { property: 'cameraOffsetX', value: 0 },
-            ]);
-        };
-    }, [sidebarOpen]);
 
     return (
         <NavigationWrapper>

--- a/src/containers/navigation/Sidebars/NavigationButton.tsx
+++ b/src/containers/navigation/Sidebars/NavigationButton.tsx
@@ -74,7 +74,6 @@ const NavigationButton = memo(function NavigationButton() {
             setSidebarOpen(!sidebarOpen);
         }
     }
-
     useEffect(() => {
         setAnimationProperties([
             { property: 'offsetX', value: towerSidebarOffset },

--- a/src/hooks/mining/useMiningUiStateMachine.ts
+++ b/src/hooks/mining/useMiningUiStateMachine.ts
@@ -47,16 +47,12 @@ export const useUiMiningStateMachine = () => {
 
             if (retryCount >= maxRetries) {
                 console.info(
-                    getTowerLogPrefix('info'),
+                    getTowerLogPrefix('warn'),
                     `Animation Stop failed after ${maxRetries} retries: status=${animationStatus}`
                 );
                 return;
             }
 
-            console.info(
-                getTowerLogPrefix('info'),
-                `Animation Stop attempt ${retryCount + 1}/${maxRetries}: status=${animationStatus}`
-            );
             setAnimationState('stop');
             retryCount++;
 
@@ -76,7 +72,6 @@ export const useUiMiningStateMachine = () => {
 
     useEffect(() => {
         if (noVisualMode) return;
-
         if (shouldStop) {
             forceAnimationStop();
         } else if (shouldStart) {

--- a/src/store/actions/uiStoreActions.ts
+++ b/src/store/actions/uiStoreActions.ts
@@ -24,9 +24,7 @@ export const setShowExternalDependenciesDialog = (showExternalDependenciesDialog
 export const setUITheme = (theme: Theme | 'system') => {
     const initialPreferred = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     const uiTheme: Theme = theme === 'system' ? initialPreferred : theme;
-
     setAnimationProperties(uiTheme === 'light' ? animationLightBg : animationDarkBg);
-
     useUIStore.setState({ theme: uiTheme });
 };
 export const setDialogToShow = (dialogToShow?: DialogType) => useUIStore.setState({ dialogToShow });
@@ -92,7 +90,7 @@ export const setSidebarOpen = (sidebarOpen: boolean) =>
         towerSidebarOffset: sidebarOpen ? sidebarTowerOffset + SB_WIDTH : sidebarTowerOffset,
     });
 
-export const setSeedlessUI = (seedlessUI: boolean) => useUIStore.setState({ seedlessUI });
+export const setSeedlessUI = (seedlessUI: boolean) => useUIStore.setState((c) => ({ ...c, seedlessUI }));
 export const setIsAppExchangeSpecific = (isAppExchangeSpecific: boolean) =>
     useUIStore.setState({ isAppExchangeSpecific });
 export const setShouldShowExchangeSpecificModal = (shouldShowExchangeSpecificModal: boolean) =>


### PR DESCRIPTION
Description
---
- removed `useEffect` for tower offset in `BridgeNavigationButton` 
- hid sync with phone CTA if in seedless mode
- adjust/remove some tower logs

Motivation and Context
---
- closes #2430 
- closes #2427 

How Has This Been Tested?
---
- locally:

https://github.com/user-attachments/assets/abdd0815-40b7-4b26-888d-332558ab3820

