### PR TITLE
fix(tor): use custom torrc file to avoid system level conflicts

### DIFF
--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -220,6 +220,7 @@ impl ProcessAdapter for TorAdapter {
 
         let working_dir_string = convert_to_string(working_dir)?;
         let log_dir_string = convert_to_string(log_dir.join("tor.log"))?;
+        let torrc_string = convert_to_string(data_dir.join("torrc"))?;
         let mut lyrebird_path = binary_version_path.clone();
         lyrebird_path.pop();
         lyrebird_path.push("pluggable_transports");
@@ -244,6 +245,8 @@ impl ProcessAdapter for TorAdapter {
         }
 
         let mut args: Vec<String> = vec![
+            "-f".to_string(),
+            torrc_string,
             "--allow-missing-torrc".to_string(),
             "--ignore-missing-torrc".to_string(),
             "--clientonly".to_string(),


### PR DESCRIPTION
Description
---
Add flag to use custom torrc file when launching tor. This is not a new flag for Tari, just a new flag being passed to tor when it starts up.

Motivation and Context
---
In Arch Linux, when Tor is installed, it is setup for the tor user. The existing torrc file is not suitable to be used for Tari and leads to tor not launching at all when using the AppImage. This also allows for the  Tari project to customize tor more easily, as now you can adjust the custom torrc file.

For more context see:
https://github.com/tari-project/universe/issues/2214

How Has This Been Tested?
---
Just tested locally, with the new flag tor starts as expected.

What process can a PR reviewer use to test or verify this change?
---
Install a system level tor that has an incompatible torrc, like in Arch Linux. Or just setup a completely invalid /etc/tor/torrc file.

Then try to launch the AppImage (or the binary, I assume both are affected). 

Notice that before the change, tor fails to startup, and the app is not usable. After the change, tor starts up as it can happily use a non-existent config file, just not an incompatible one!

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->

Nothing should break.