### PR TITLE
[Feature] Use Tari icon for systray

### DIFF
--- a/src-tauri/src/systemtray_manager.rs
+++ b/src-tauri/src/systemtray_manager.rs
@@ -28,6 +28,8 @@ use tauri::{
     AppHandle, Manager, Wry,
 };
 
+use tauri::tray::TrayIconBuilder;
+
 use crate::utils::{
     formatting_utils::{format_currency, format_hashrate},
     platform_utils::{CurrentOperatingSystem, PlatformUtils},
@@ -150,7 +152,9 @@ impl SystemTrayManager {
     }
 
     pub fn initialize_tray(&mut self, app: AppHandle) -> Result<(), anyhow::Error> {
-        let tray = app.tray_by_id("universe-tray-id").expect("tray not found");
+        let tray = TrayIconBuilder::new()
+          .icon(app.default_window_icon().unwrap().clone())
+          .build(&app)?;
         let menu = self.initialize_menu(app.clone())?;
         tray.set_menu(Some(menu.clone()))?;
 


### PR DESCRIPTION
Description
---
This PR just uses the main Tari icon for the systray.

Motivation and Context
---
I use a dark theme and the icon is basically invisble.

![image](https://github.com/user-attachments/assets/5257ee98-97fc-47a4-97d7-ecd4175bb62a)

How Has This Been Tested?
---
Locally

What process can a PR reviewer use to test or verify this change?
---
Build with this change and look at the Systray, it should use the nice window icon.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
