### PR TITLE
fix(ui): language dropdown styling

### DIFF
--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -51,6 +51,7 @@ export const TriggerWrapper = styled.div<StyleProps>`
 
 export const OptionsPosition = styled.div`
     position: absolute;
+    width: 100%;
     z-index: 10;
 `;
 
@@ -118,7 +119,8 @@ export const StyledOption = styled.div<StyleProps>`
     transition: all 0.2s ease-in-out;
 
     height: 38px;
-    padding: 0px 12px;
+    padding: 0 12px;
+
     justify-content: space-between;
     align-items: center;
     align-self: stretch;
@@ -127,6 +129,13 @@ export const StyledOption = styled.div<StyleProps>`
     &:hover {
         background: ${({ theme }) => theme.palette.action.hover.default};
     }
+
+    ${({ $isBordered }) =>
+        $isBordered &&
+        css`
+            height: 36px;
+            padding: 13px 7px;
+        `}
 `;
 
 export const IconWrapper = styled.div`

--- a/src/components/elements/inputs/Select.tsx
+++ b/src/components/elements/inputs/Select.tsx
@@ -146,6 +146,7 @@ export function Select({
                                     key={`opt-${value}-${label}`}
                                     $selected={selected}
                                     $loading={loading && !selected}
+                                    $isBordered={isBordered}
                                 >
                                     <OptionLabelWrapper>
                                         {iconSrc ? <img src={iconSrc} alt={`Select option: ${value} icon `} /> : null}


### PR DESCRIPTION
Description
---

dropdown styling was changed in sidebar updates and it affected the existing language dropdown

- just fixed by reverting back to original styling for that variant & setting width in the positioning wrapper

Motivation and Context
---

- closes #2461 

How Has This Been Tested?
---
- locally:

https://github.com/user-attachments/assets/537fc1e8-501f-4074-94c0-a3bee082c1c9


What process can a PR reviewer use to test or verify this change?
---
- check that the lang dropdown styling is restored
- new history list filter dropdown still as is