### PR TITLE
fix(ui): only check sync for syncing UI in wallet

### DIFF
--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -67,8 +67,7 @@ export default function SidebarWallet({ section, setSection }: SidebarWalletProp
         return () => el.removeEventListener('scroll', onScroll);
     }, []);
 
-    const walletIsScanning = useWalletStore((s) => s.wallet_scanning.is_scanning);
-    const isSyncing = walletIsScanning || !isConnectedToTariNetwork;
+    const isSyncing = !isConnectedToTariNetwork;
     const isSwapping = useWalletStore((s) => s.is_swapping);
     const seedlessUI = useUIStore((s) => s.seedlessUI);
 


### PR DESCRIPTION
Description
---

there was a misunderstanding on where/when the new sync UI should be displayed in the sidebar wallet section - this PR simply removes the `walletIsScanning` check from the sync UI condition


How Has This Been Tested?
---

- locally:

https://github.com/user-attachments/assets/ed74f367-b210-46c9-9829-69e8a0d83825

https://github.com/user-attachments/assets/e1da1c77-d139-4be2-b156-55ac3d27895d


