### PR TITLE
fix: always use tor-bundled `libevent-2.1.so.7` on linux

### DIFF
--- a/src-tauri/src/tor_adapter.rs
+++ b/src-tauri/src/tor_adapter.rs
@@ -22,8 +22,6 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-#[cfg(target_os = "linux")]
-use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{anyhow, Error};
@@ -373,43 +371,21 @@ impl Default for TorConfig {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn get_libevent_envs(_binary_version_path: &std::path::Path) -> Option<HashMap<String, String>> {
-    #[cfg(target_os = "linux")]
-    {
-        if !check_libevent_exists() {
-            let mut tor_bundle_path = _binary_version_path.to_path_buf();
-            tor_bundle_path.pop();
-            let mut envs = HashMap::new();
-            envs.insert(
-                "LD_PRELOAD".to_string(),
-                format!("{}/libevent-2.1.so.7", tor_bundle_path.display()),
-            );
-            log::warn!(target: LOG_TARGET, "Using LD_PRELOAD, libevent-2.1.so.7 not found.");
-            return Some(envs);
-        }
-    }
-    // For non-Linux, or if libevent exists, return None
-    None
+    let mut tor_bundle_path = _binary_version_path.to_path_buf();
+    tor_bundle_path.pop();
+    let mut envs = HashMap::new();
+    envs.insert(
+        "LD_PRELOAD".to_string(),
+        format!("{}/libevent-2.1.so.7", tor_bundle_path.display()),
+    );
+    log::warn!(target: LOG_TARGET, "Using LD_PRELOAD for libevent-2.1.so.7.");
+    Some(envs)
 }
 
-#[cfg(target_os = "linux")]
-fn check_libevent_exists() -> bool {
-    let output = Command::new("find")
-        .arg("/usr/lib")
-        .arg("/usr/local/lib")
-        .arg("-name")
-        .arg("libevent-2.1.so.7")
-        .output()
-        .expect("Failed to execute find libevent-2.1.so.7 command");
-
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let lines: Vec<&str> = stdout.split('\n').collect();
-        for line in lines {
-            if line.contains("libevent-2.1.so.7") {
-                return true;
-            }
-        }
-    }
-    false
+#[cfg(not(target_os = "linux"))]
+fn get_libevent_envs(_binary_version_path: &std::path::Path) -> Option<HashMap<String, String>> {
+    // For non-Linux, return None
+    None
 }


### PR DESCRIPTION
Description
---
Regardless of whether or not a user has installed `libevent` from their package manager, the version of `libevent-2.1.so.7` bundled with tor should be used on linux systems.  Even though both the bundled and system copy are listed as the same version, they do not provide the same symbols.  This ABI mismatch is the cause of tor failing to start, not the lack of it being installed.

Here, the linker is able to find the system-copy of `libevent-2.1.so.7`, but tor still fails to launch due to the missing symbol:
```
# libevent is installed
$ sudo find / -name libevent-2.1.so.7
/usr/lib64/libevent-2.1.so.7

$ cd ~/.cache/com.tari.universe.alpha/binaries/tor-binaries/esmeralda/14.5.1/tor

# linker using system copy
$ ldd ./tor
...
libevent-2.1.so.7 => /lib64/libevent-2.1.so.7 (0x00007f184eb91000)
...


$ ./tor
./tor: symbol lookup error: ./tor: undefined symbol: evutil_secure_rng_add_bytes
```

If we instead force the usage of the bundled `libevent-2.1.so.7`, tor starts as expected:
```
# linker using bundled copy
$ LD_PRELOAD=~/.cache/com.tari.universe.alpha/binaries/tor-binaries/esmeralda/14.5.1/tor/libevent-2.1.so.7 ldd ./tor
...
/home/user/.cache/com.tari.universe.alpha/binaries/tor-binaries/esmeralda/14.5.1/tor/libevent-2.1.so.7 (0x00007f8588200000)
...

$ LD_PRELOAD=~/.cache/com.tari.universe.alpha/binaries/tor-binaries/esmeralda/14.5.1/tor/libevent-2.1.so.7 ./tor
Jul 01 23:58:38.758 [notice] Tor 0.4.8.16 (git-64ccafd8115ecdec) running on Linux with Libevent 2.1.12-stable, OpenSSL 3.2.4, Zlib 1.3.1.zlib-ng, Liblzma N/A, Libzstd N/A and Glibc 2.41 as libc.
...
```

We need to avoid mixing system and tor-bundled copies of the tor binary itself and the libevent shared object file. 

Motivation and Context
---
https://github.com/tari-project/universe/pull/1997#issuecomment-2956292620
https://github.com/tari-project/universe/pull/1997#issuecomment-3025076918

How Has This Been Tested?
---
I've tested briefly in a Fedora VM. I've been unable to test on bare-metal, so if others are able, I'd appreciate the time/help.
```
23:32:50 WARN  Using LD_PRELOAD for libevent-2.1.so.7.
...
23:33:05 INFO  Waiting for Tor bootstrap: 100%
```
What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
