### PR TITLE
fix(ui): hide exchange button on scroll and show my balance text

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Geen transaksies gevind nie",
   "history": {
     "available-balance": "Beskikbaar",
+    "my-balance": "My Balance",
     "label-rewards": "My belonings",
     "sync-with-phone": "Sinkroniseer met Foon",
     "transaction-details": "Transaksiebesonderhede",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "未找到交易",
   "history": {
     "available-balance": "可用",
+    "my-balance": "My Balance",
     "label-rewards": "我的奖励",
     "sync-with-phone": "与手机同步",
     "transaction-details": "交易详情",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Keine Transaktionen gefunden",
   "history": {
     "available-balance": "Verfügbar",
+    "my-balance": "My Balance",
     "label-rewards": "Meine Belohnungen",
     "sync-with-phone": "Mit Telefon synchronisieren",
     "transaction-details": "Transaktionsdetails",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "No transactions found",
   "history": {
     "available-balance": "Available",
+    "my-balance": "My Balance",
     "label-rewards": "My rewards",
     "sync-with-phone": "Sync with Phone",
     "transaction-details": "Transaction Details",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Aucune transaction trouvée",
   "history": {
     "available-balance": "Disponible",
+    "my-balance": "My Balance",
     "label-rewards": "Mes récompenses",
     "sync-with-phone": "Synchroniser avec le téléphone",
     "transaction-details": "Détails de la transaction",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "कोई लेन-देन नहीं मिला",
   "history": {
     "available-balance": "उपलब्ध",
+    "my-balance": "My Balance",
     "label-rewards": "मेरे पुरस्कार",
     "sync-with-phone": "फोन के साथ सिंक करें",
     "transaction-details": "लेन-देन विवरण",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Tidak ada transaksi ditemukan",
   "history": {
     "available-balance": "Tersedia",
+    "my-balance": "My Balance",
     "label-rewards": "Hadiah saya",
     "sync-with-phone": "Sinkronkan dengan Ponsel",
     "transaction-details": "Detail Transaksi",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "トランザクションが見つかりません",
   "history": {
     "available-balance": "利用可能",
+    "my-balance": "My Balance",
     "label-rewards": "私の報酬",
     "sync-with-phone": "電話と同期",
     "transaction-details": "トランザクションの詳細",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "거래를 찾을 수 없음",
   "history": {
     "available-balance": "사용 가능",
+    "my-balance": "My Balance",
     "label-rewards": "내 보상",
     "sync-with-phone": "전화와 동기화",
     "transaction-details": "거래 세부 정보",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Nie znaleziono transakcji",
   "history": {
     "available-balance": "Dostępne",
+    "my-balance": "My Balance",
     "label-rewards": "Moje nagrody",
     "sync-with-phone": "Synchronizuj z telefonem",
     "transaction-details": "Szczegóły transakcji",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "Транзакции не найдены",
   "history": {
     "available-balance": "Доступно",
+    "my-balance": "My Balance",
     "label-rewards": "Мои награды",
     "sync-with-phone": "Синхронизировать с телефоном",
     "transaction-details": "Детали транзакции",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -4,6 +4,7 @@
   "empty-tx": "İşlem bulunamadı",
   "history": {
     "available-balance": "Mevcut",
+    "my-balance": "My Balance",
     "label-rewards": "Ödüllerim",
     "sync-with-phone": "Telefonla Senkronize Et",
     "transaction-details": "İşlem Detayları",

--- a/src/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx
+++ b/src/components/transactions/wallet/Exchanges/exchange-button/ExchangeButton.tsx
@@ -1,10 +1,15 @@
-import { XCButton } from './styles.ts';
+import { MotionWrapper, XCButton } from './styles.ts';
 import { setShowUniversalModal } from '@app/store/useExchangeStore.ts';
 import { useTranslation } from 'react-i18next';
 import { Logos } from '@app/components/transactions/wallet/Exchanges/logos/Logos.tsx';
 import { useFetchExchangeList } from '@app/hooks/exchanges/fetchExchanges.ts';
+import { AnimatePresence } from 'motion/react';
 
-export default function ExchangeButton() {
+interface Props {
+    isScrolled: boolean;
+}
+
+export default function ExchangeButton({ isScrolled }: Props) {
     const { t } = useTranslation('wallet');
     const { data: exchanges } = useFetchExchangeList();
 
@@ -12,9 +17,22 @@ export default function ExchangeButton() {
         setShowUniversalModal(true);
     }
 
-    return exchanges?.length ? (
-        <XCButton onClick={handleClick}>
-            {t('xc.mine-directly-to')} <Logos exchanges={exchanges} variant="mini" />
-        </XCButton>
-    ) : null;
+    if (!exchanges?.length) return null;
+
+    return (
+        <AnimatePresence>
+            {!isScrolled && (
+                <MotionWrapper
+                    initial={{ height: 'auto', opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+                >
+                    <XCButton onClick={handleClick}>
+                        {t('xc.mine-directly-to')} <Logos exchanges={exchanges} variant="mini" />
+                    </XCButton>
+                </MotionWrapper>
+            )}
+        </AnimatePresence>
+    );
 }

--- a/src/components/transactions/wallet/Exchanges/exchange-button/styles.ts
+++ b/src/components/transactions/wallet/Exchanges/exchange-button/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { m } from 'motion/react';
 
 export const XCButton = styled.button`
     display: flex;
@@ -7,8 +8,6 @@ export const XCButton = styled.button`
     justify-content: space-between;
     border-radius: 50px;
     background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(42px);
-    -webkit-backdrop-filter: blur(42px);
     font-size: 11px;
     padding: 0 10px 0 14px;
     font-weight: 600;
@@ -21,4 +20,8 @@ export const XCButton = styled.button`
         background: rgba(0, 0, 0, 0.4);
         color: ${({ theme }) => theme.colors.greyscale[150]};
     }
+`;
+
+export const MotionWrapper = styled(m.div)`
+    overflow: hidden;
 `;

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -21,12 +21,13 @@ export const WalletBalance = () => {
     const available_balance = useWalletStore((s) => s.balance?.available_balance);
 
     const balanceValue = removeXTMCryptoDecimals(roundToTwoDecimals(calculated_balance || 0));
+    const availableBalanceValue = removeXTMCryptoDecimals(roundToTwoDecimals(available_balance || 0));
+
     const isWalletScanning = useWalletStore((s) => s.wallet_scanning?.is_scanning);
     const hideWalletBalance = useUIStore((s) => s.hideWalletBalance);
 
-    const formattedAvailableBalance = hideWalletBalance
-        ? '****'
-        : formatNumber(available_balance || 0, FormatPreset.XTM_LONG);
+    const formattedAvailableBalance = formatNumber(available_balance || 0, FormatPreset.XTM_LONG);
+    const finalAvailableBalance = hideWalletBalance ? '*******' : formattedAvailableBalance;
 
     const formatOptions: Format = {
         maximumFractionDigits: 2,
@@ -62,7 +63,11 @@ export const WalletBalance = () => {
                     </BalanceWrapper>
 
                     <AvailableWrapper>
-                        <Typography>{`${t('history.available-balance')}: ${formattedAvailableBalance} XTM`}</Typography>
+                        {availableBalanceValue != balanceValue ? (
+                            <Typography>{`${t('history.available-balance')}: ${finalAvailableBalance} XTM`}</Typography>
+                        ) : (
+                            <Typography>{t('history.my-balance')}</Typography>
+                        )}
                     </AvailableWrapper>
                 </>
             ) : (

--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -99,7 +99,7 @@ export default function SidebarWallet({ section, setSection }: SidebarWalletProp
                                 <ExternalLink2SVG />
                             </ExternalLink>
                         )}
-                        <ExchangeButton />
+                        <ExchangeButton isScrolled={isScrolled} />
                     </DetailsCardBottomContent>
                 </DetailsCardContent>
             </DetailsCard>
@@ -108,9 +108,10 @@ export default function SidebarWallet({ section, setSection }: SidebarWalletProp
                     <AnimatePresence>
                         {!isScrolled && (
                             <WalletActionWrapper
-                                initial={{ height: 'auto' }}
-                                animate={{ height: 'auto' }}
-                                exit={{ height: 0 }}
+                                initial={{ height: 0, opacity: 0 }}
+                                animate={{ height: 'auto', opacity: 1 }}
+                                exit={{ height: 0, opacity: 0 }}
+                                transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
                             >
                                 <WalletActions section={section} setSection={setSection} />
                             </WalletActionWrapper>

--- a/src/components/wallet/sidebarWallet/styles.ts
+++ b/src/components/wallet/sidebarWallet/styles.ts
@@ -80,7 +80,7 @@ export const DetailsCard = styled(m.div)<{ $isScrolled: boolean }>`
     ${({ $isScrolled }) =>
         $isScrolled &&
         css`
-            height: 141px;
+            height: 100px;
         `}
 
     @media (max-height: 690px) {


### PR DESCRIPTION
Just a few small tweaks to the Wallet section. 

If the Available Balance is the same as the main balance, it now shows "My Balance" label. It's weird to show the same value twice if available balance and mined balance is the same. 

![CleanShot 2025-07-02 at 16 13 39@2x](https://github.com/user-attachments/assets/252aa291-2953-40b8-9d71-d0d5db8f15a7)

I also made it so the Exchange button hides itself when the History List is scrolled, this was a request from design. 

![CleanShot 2025-07-02 at 16 15 29@2x](https://github.com/user-attachments/assets/cf1e9131-35f0-4da9-ad8d-d7842df242f7)


