### PR TITLE
fix(ui): start mining on toggle

### DIFF
--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -135,15 +135,15 @@ export const setAutoUpdate = async (autoUpdate: boolean) => {
 };
 export const setCpuMiningEnabled = async (enabled: boolean) => {
     useConfigMiningStore.setState({ cpu_mining_enabled: enabled });
-    const miningInitiated = useMiningStore.getState().isCpuMiningInitiated;
+    const anyMiningInitiated =
+        useMiningStore.getState().isCpuMiningInitiated || useMiningStore.getState().isGpuMiningInitiated;
     const cpuMining = useMiningMetricsStore.getState().cpu_mining_status.is_mining;
-
     if (cpuMining) {
         await stopCpuMining();
     }
     invoke('set_cpu_mining_enabled', { enabled })
         .then(async () => {
-            if (miningInitiated && enabled) {
+            if (anyMiningInitiated && enabled) {
                 await startCpuMining();
             } else {
                 await stopCpuMining();
@@ -153,7 +153,7 @@ export const setCpuMiningEnabled = async (enabled: boolean) => {
             console.error('Could not set CPU mining enabled', e);
             setError('Could not change CPU mining enabled');
             useConfigMiningStore.setState({ cpu_mining_enabled: !enabled });
-            if (miningInitiated && !cpuMining) {
+            if (useMiningStore.getState().isCpuMiningInitiated && !cpuMining) {
                 void stopCpuMining();
             }
         });
@@ -168,7 +168,8 @@ export const setCustomStatsServerPort = async (port?: number) => {
 };
 export const setGpuMiningEnabled = async (enabled: boolean) => {
     useConfigMiningStore.setState({ gpu_mining_enabled: enabled });
-    const miningInitiated = useMiningStore.getState().isGpuMiningInitiated;
+    const anyMiningInitiated =
+        useMiningStore.getState().isCpuMiningInitiated || useMiningStore.getState().isGpuMiningInitiated;
     const gpuMining = useMiningMetricsStore.getState().gpu_mining_status.is_mining;
     const gpuDevices = useMiningMetricsStore.getState().gpu_devices;
     if (gpuMining) {
@@ -176,7 +177,7 @@ export const setGpuMiningEnabled = async (enabled: boolean) => {
     }
     try {
         await invoke('set_gpu_mining_enabled', { enabled });
-        if (miningInitiated && enabled) {
+        if (anyMiningInitiated && enabled) {
             await startGpuMining();
         } else {
             void stopGpuMining();
@@ -195,7 +196,7 @@ export const setGpuMiningEnabled = async (enabled: boolean) => {
         console.error('Could not set GPU mining enabled', e);
         setError('Could not change GPU mining enabled');
         useConfigMiningStore.setState({ gpu_mining_enabled: !enabled });
-        if (miningInitiated && !gpuMining) {
+        if (useMiningStore.getState().isGpuMiningInitiated && !gpuMining) {
             void stopGpuMining();
         }
     }

--- a/src/store/actions/miningStoreActions.ts
+++ b/src/store/actions/miningStoreActions.ts
@@ -152,9 +152,11 @@ export const getMiningNetwork = async () => {
 };
 
 export const startCpuMining = async () => {
-    if (!useSetupStore.getState().cpuMiningUnlocked) return;
-    if (!useConfigMiningStore.getState().cpu_mining_enabled) return;
-    if (useMiningStore.getState().isCpuMiningInitiated) return;
+    const unlocked = useSetupStore.getState().cpuMiningUnlocked;
+    const enabled = useConfigMiningStore.getState().cpu_mining_enabled;
+    const initiated = useMiningStore.getState().isCpuMiningInitiated;
+
+    if (!enabled || !unlocked || initiated) return;
 
     useMiningStore.setState({ isCpuMiningInitiated: true });
     console.info('CPU Mining starting....');


### PR DESCRIPTION
Description
---

- just fixed the checks for `miningInitiated` in the CPU/GPU mining enabled toggles so that they'd start up when enabled if (any type of) mining is already initiated

Motivation and Context
---
- closes #2466 

How Has This Been Tested?
---

- locally:


https://github.com/user-attachments/assets/c2580f1d-8966-4033-8d74-384237bd4b09


