### PR TITLE
fix(ui): made start mining button darker when not active

### DIFF
--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/MiningButton.tsx
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/MiningButton.tsx
@@ -1,8 +1,9 @@
-import { DropdownWrapper, HitBox, ButtonWrapper, Text, IconWrapper } from './styles';
+import { DropdownWrapper, HitBox, ButtonWrapper, Text, IconWrapper, Shadow } from './styles';
 import ModeDropdown from './components/ModeDropdown/ModeDropdown';
 import AnimatedBackground from './components/AnimatedBackground/AnimatedBackground';
 import { useTranslation } from 'react-i18next';
 import { useConfigMiningStore } from '@app/store';
+import { AnimatePresence } from 'motion/react';
 
 interface Props {
     onClick: () => void;
@@ -33,7 +34,10 @@ export default function MiningButton({ onClick, buttonText, icon, isMining, disa
             <DropdownWrapper>
                 <ModeDropdown />
             </DropdownWrapper>
-            {isMining && <AnimatedBackground />}
+            <AnimatePresence>
+                {!isMining && <Shadow initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} />}
+            </AnimatePresence>
+            <AnimatePresence>{isMining && <AnimatedBackground />}</AnimatePresence>
         </ButtonWrapper>
     );
 }

--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/AnimatedBackground/AnimatedBackground.tsx
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/AnimatedBackground/AnimatedBackground.tsx
@@ -32,7 +32,7 @@ const CUBES = CUBE_DEFINITIONS.flatMap((def, defIndex) =>
 
 export default function AnimatedBackground() {
     return (
-        <Wrapper>
+        <Wrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
             <Rings>
                 {RINGS.map((ring) => (
                     <Ring key={ring.size} $size={ring.size} />

--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/AnimatedBackground/styles.ts
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/AnimatedBackground/styles.ts
@@ -19,7 +19,7 @@ const cubeRotate = keyframes`
     }
 `;
 
-export const Wrapper = styled.div`
+export const Wrapper = styled(m.div)`
     position: absolute;
     top: 0;
     left: 0;

--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/styles.ts
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/styles.ts
@@ -155,3 +155,14 @@ export const IconWrapper = styled.div<{ $absolute?: boolean }>`
             transform: translateY(-50%);
         `}
 `;
+
+export const Shadow = styled(m.div)`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.4) 100%);
+    border-radius: 500px;
+    z-index: 0;
+`;

--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/styles.ts
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/styles.ts
@@ -162,7 +162,7 @@ export const Shadow = styled(m.div)`
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.4) 100%);
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.4) 100%);
     border-radius: 500px;
     z-index: 0;
 `;


### PR DESCRIPTION
This update adds a slight shadow to the mining button when it's not mining. So the button appears "lighter" while it's mining. This helps differentiate the 2 states so it's clearer when the mining has stopped. 

https://www.loom.com/share/7b486329ec7e41d2a0417f36ffbe910f?sid=d3128f12-66a6-4bdf-af13-2fb5874e0f41

![CleanShot 2025-07-02 at 16 46 02@2x](https://github.com/user-attachments/assets/58203224-a53e-43a4-a679-1edec22d1180)

![CleanShot 2025-07-02 at 16 46 43@2x](https://github.com/user-attachments/assets/4d9f2312-5f20-4ef9-8a98-ac71f8925712)

![CleanShot 2025-07-02 at 16 45 14@2x](https://github.com/user-attachments/assets/e0a1872f-8b08-41cc-b4af-c43701cdb010)

