### PR TITLE
fix(ui): multiple tower init

### DIFF
--- a/src/containers/main/Dashboard/components/VisualMode.tsx
+++ b/src/containers/main/Dashboard/components/VisualMode.tsx
@@ -25,11 +25,7 @@ function VisualMode() {
 
     const handleSwitch = useCallback(() => {
         if (visualModeToggleLoading) return;
-        if (visualMode) {
-            enableTowerAnimation(false);
-        } else {
-            enableTowerAnimation(true);
-        }
+        enableTowerAnimation(!visualMode);
     }, [visualMode, visualModeToggleLoading]);
 
     return (

--- a/src/hooks/app/useTauriEventsListener.ts
+++ b/src/hooks/app/useTauriEventsListener.ts
@@ -98,7 +98,7 @@ const useTauriEventsListener = () => {
                             await handleAppUnlocked();
                             break;
                         case 'UnlockWallet':
-                            handleWalletUnlocked();
+                            await handleWalletUnlocked();
                             break;
                         case 'UnlockCpuMining':
                             await handleCpuMiningUnlocked();

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -51,7 +51,6 @@ async function initializeAnimation() {
 }
 
 export const handleAppUnlocked = async () => {
-    console.debug(`wen app unlock`);
     useSetupStore.setState({ appUnlocked: true });
     await fetchBridgeTransactionsHistory().catch((error) => {
         console.error('Could not fetch bridge transactions history:', error);
@@ -60,12 +59,12 @@ export const handleAppUnlocked = async () => {
     // todo move it to event
     await fetchApplicationsVersionsWithRetry();
 };
-export const handleWalletUnlocked = () => {
+export const handleWalletUnlocked = async () => {
     useSetupStore.setState({ walletUnlocked: true });
     // Initial fetch of transactions
-    const { tx_history_filter } = useWalletStore.getState();
-    fetchTransactionsHistory({ offset: 0, limit: 20, filter: tx_history_filter });
-    fetchCoinbaseTransactions({
+    const tx_history_filter = useWalletStore.getState().tx_history_filter;
+    await fetchTransactionsHistory({ offset: 0, limit: 20, filter: tx_history_filter });
+    await fetchCoinbaseTransactions({
         offset: 0,
         limit: 20,
     });

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -29,25 +29,24 @@ export interface DisabledPhasesPayload {
 }
 
 async function initializeAnimation() {
-    const existingCanvas = document.getElementById(TOWER_CANVAS_ID);
     const visual_mode = useConfigUIStore.getState().visual_mode;
-    if (existingCanvas || !visual_mode) {
-        return;
-    }
+    const towerInitalized = useUIStore.getState().towerInitalized;
+    if (!visual_mode || towerInitalized) return;
+
     const offset = useUIStore.getState().towerSidebarOffset;
-    if (visual_mode) {
+    try {
+        console.info('Loading tower animation');
         try {
-            console.info('Loading tower animation');
             await loadTowerAnimation({ canvasId: TOWER_CANVAS_ID, offset: offset });
-            try {
-                setAnimationState('showVisual');
-            } catch (error) {
-                console.error('Failed to set animation state:', error);
-            }
-        } catch (e) {
-            console.error('Error at loadTowerAnimation:', e);
-            useConfigUIStore.setState({ visual_mode: false });
+            setAnimationState('showVisual');
+            useUIStore.setState({ towerInitalized: true });
+        } catch (error) {
+            console.error('Failed to set animation state:', error);
+            useUIStore.setState({ towerInitalized: false });
         }
+    } catch (e) {
+        console.error('Error at loadTowerAnimation:', e);
+        useConfigUIStore.setState({ visual_mode: false });
     }
 }
 

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -28,13 +28,12 @@ export interface DisabledPhasesPayload {
     disabled_phases: SetupPhase[];
 }
 
-export const handleAppUnlocked = async () => {
-    useSetupStore.setState({ appUnlocked: true });
-    await fetchBridgeTransactionsHistory().catch((error) => {
-        console.error('Could not fetch bridge transactions history:', error);
-    });
-
+async function initializeAnimation() {
+    const existingCanvas = document.getElementById(TOWER_CANVAS_ID);
     const visual_mode = useConfigUIStore.getState().visual_mode;
+    if (existingCanvas || !visual_mode) {
+        return;
+    }
     const offset = useUIStore.getState().towerSidebarOffset;
     if (visual_mode) {
         try {
@@ -50,6 +49,15 @@ export const handleAppUnlocked = async () => {
             useConfigUIStore.setState({ visual_mode: false });
         }
     }
+}
+
+export const handleAppUnlocked = async () => {
+    console.debug(`wen app unlock`);
+    useSetupStore.setState({ appUnlocked: true });
+    await fetchBridgeTransactionsHistory().catch((error) => {
+        console.error('Could not fetch bridge transactions history:', error);
+    });
+    await initializeAnimation();
     // todo move it to event
     await fetchApplicationsVersionsWithRetry();
 };

--- a/src/store/actions/uiStoreActions.ts
+++ b/src/store/actions/uiStoreActions.ts
@@ -36,10 +36,9 @@ export const setIsWebglNotSupported = (isWebglNotSupported: boolean) => {
 export const enableTowerAnimation = (enabled: boolean) => {
     const setupComplete = useSetupStore.getState().appUnlocked;
     const towerSidebarOffset = useUIStore.getState().towerSidebarOffset;
-    const existingCanvas = document.getElementById(TOWER_CANVAS_ID);
     useConfigUIStore.setState({ visualModeToggleLoading: true });
     setVisualMode(enabled);
-    if (enabled && !existingCanvas) {
+    if (enabled) {
         loadTowerAnimation({ canvasId: TOWER_CANVAS_ID, offset: towerSidebarOffset })
             .then(() => {
                 if (setupComplete) {

--- a/src/store/actions/uiStoreActions.ts
+++ b/src/store/actions/uiStoreActions.ts
@@ -36,9 +36,10 @@ export const setIsWebglNotSupported = (isWebglNotSupported: boolean) => {
 export const enableTowerAnimation = (enabled: boolean) => {
     const setupComplete = useSetupStore.getState().appUnlocked;
     const towerSidebarOffset = useUIStore.getState().towerSidebarOffset;
+    const existingCanvas = document.getElementById(TOWER_CANVAS_ID);
     useConfigUIStore.setState({ visualModeToggleLoading: true });
     setVisualMode(enabled);
-    if (enabled) {
+    if (enabled && !existingCanvas) {
         loadTowerAnimation({ canvasId: TOWER_CANVAS_ID, offset: towerSidebarOffset })
             .then(() => {
                 if (setupComplete) {

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -44,6 +44,7 @@ interface UIStoreState {
     hideWalletBalance: boolean;
     showResumeAppModal: boolean;
     towerSidebarOffset: number;
+    towerInitalized: boolean;
     showTapplet: boolean;
     blockBubblesEnabled: boolean;
     resumeModalIsOpen: boolean;
@@ -69,6 +70,7 @@ const initialState: UIStoreState = {
     isAppExchangeSpecific: false,
     shouldShowExchangeSpecificModal: false,
     towerSidebarOffset: sidebarTowerOffset,
+    towerInitalized: false,
     showTapplet: false,
     blockBubblesEnabled: false,
     resumeModalIsOpen: false,


### PR DESCRIPTION
Description
---

`loadTowerAnimation` was being called multiple times from `handleAppUnlocked`, causing multiple layers of the animation


**it should be fine with https://github.com/tari-project/universe/pull/2492 going in, but doesn't hurt to have a fallback in case something else triggers this action twice** 

- add store var if tower has been initialised or not before calling `loadTowerAnimation` during set up
- small cleanups in store actions & visual mode toggle

Motivation and Context
---

- closes #2491 

How Has This Been Tested?
---

- locally:


