### PR TITLE
fix: seed word restoration

### DIFF
--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -186,9 +186,6 @@ impl WalletManager {
 
         if path_to_network_wallet.try_exists()? && path_to_network_wallet.is_dir() {
             fs::remove_dir_all(path_to_network_wallet).await?;
-        } else {
-            //create the directory if it does not exist
-            fs::create_dir_all(path_to_network_wallet).await?;
         }
 
         log::info!(target: LOG_TARGET, "Cleaning wallet data folder");

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -180,12 +180,16 @@ impl WalletManager {
         self.initial_scan_completed
             .store(false, std::sync::atomic::Ordering::Relaxed);
 
-        fs::remove_dir_all(
-            base_path
-                .join("wallet")
-                .join(Network::get_current().to_string().to_lowercase()),
-        )
-        .await?;
+        let path_to_network_wallet = base_path
+            .join("wallet")
+            .join(Network::get_current().to_string().to_lowercase());
+        if path_to_network_wallet.try_exists()? && path_to_network_wallet.is_dir() {
+            fs::remove_dir_all(path_to_network_wallet).await?;
+        } else {
+            //create the directory if it does not exist
+            fs::create_dir_all(path_to_network_wallet).await?;
+        }
+
         log::info!(target: LOG_TARGET, "Cleaning wallet data folder");
         Ok(())
     }

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -183,6 +183,7 @@ impl WalletManager {
         let path_to_network_wallet = base_path
             .join("wallet")
             .join(Network::get_current().to_string().to_lowercase());
+
         if path_to_network_wallet.try_exists()? && path_to_network_wallet.is_dir() {
             fs::remove_dir_all(path_to_network_wallet).await?;
         } else {


### PR DESCRIPTION
Description
---


Solves the issue that under linux we would have deleted a folder in `app_local_data_dir` which is different than the app_config_dir() (.local/share as opposed to .config). The fix does not solve the underlying issue that  we are trying to delete the folder but prevents the app from crashing if the folder is not there (we do nothing in that case)

Motivation and Context
---

Fixes #2487 


How Has This Been Tested?
---

Locally withe esme



What process can a PR reviewer use to test or verify this change?
---


Change the seed words while setting the application up.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
