### PR TITLE
fix: remove mining restarts on disabling cpu

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1148,17 +1148,10 @@ pub async fn set_auto_update(auto_update: bool) -> Result<(), InvokeError> {
 }
 
 #[tauri::command]
-pub async fn set_cpu_mining_enabled(
-    enabled: bool,
-    app_handle: tauri::AppHandle,
-) -> Result<(), String> {
+pub async fn set_cpu_mining_enabled(enabled: bool) -> Result<(), String> {
     let timer = Instant::now();
     let _unused =
         ConfigMining::update_field(ConfigMiningContent::set_cpu_mining_enabled, enabled).await;
-
-    SetupManager::get_instance()
-        .restart_phases(app_handle, vec![SetupPhase::Mining])
-        .await;
 
     if timer.elapsed() > MAX_ACCEPTABLE_COMMAND_TIME {
         warn!(target: LOG_TARGET,


### PR DESCRIPTION
### [ Summary ]
When we disable `cpu_mining`, feature flag for setup **CentralizedPool** is also removed.
We've triggered restart on `phase_mining` in that case because mmproxy is toggled base on CentralizedPool:
- CentralizedPool **enabled** => We disable mmproxy
- CentralizedPool **disabled** => We enabled mmproxy

But as mmproxy is used only for cpu mining when we disabled cpu there is no need to rechecking this behavior so there is no need for triggering restart