### PR TITLE
fix(ui): add new copy to the wallet sync loader

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Geskiedenis",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "历史",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Verlauf",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -123,10 +123,11 @@
     "completed": "Any moment now",
     "line1": "Sync in progress. ",
     "line2": " remaining",
-    "line3": "until your wallet balance is displayed",
+    "line3": "Until your balance is  displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "History",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Historique",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "इतिहास",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Riwayat",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "履歴",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "기록",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Historia",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "История",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -126,7 +126,8 @@
     "line3": "until your wallet balance is displayed",
     "tooltip-description": "Your node is still syncing, so your balance isn't visible yet.",
     "tooltip-description-mining": "Your node is still syncing, so your balance isn't visible yet. But don't worry, you're actively mining and earning XTM.",
-    "tooltip-title": "Why the delay?"
+    "tooltip-title": "Why the delay?",
+    "top-line": "You are now mining Tari XTM"
   },
   "tabs": {
     "history": "Geçmiş",

--- a/src/components/wallet/components/loaders/SyncLoading/SyncLoading.tsx
+++ b/src/components/wallet/components/loaders/SyncLoading/SyncLoading.tsx
@@ -1,8 +1,10 @@
 import LoadingDots from '@app/components/elements/loaders/LoadingDots';
 import {
     Line,
+    LoadingGroup,
     LoadingWrapper,
     Text,
+    TextTop,
     TooltipContent,
     TooltipDescription,
     TooltipPosition,
@@ -37,23 +39,24 @@ export default function SyncLoading() {
     return (
         <>
             <Wrapper ref={refs.setReference} {...getReferenceProps()}>
-                <Text>
-                    <Line>
-                        {t('sync-message.line1')}
-                        <strong>
-                            <SyncCountdown
-                                onStarted={() => setIsStarted(true)}
-                                onCompleted={() => setIsComplete(true)}
-                                isCompact
-                            />
-                            {isStarted && !isComplete && t('sync-message.line2')}
-                        </strong>
-                    </Line>
-                    <Line>{t('sync-message.line3')}</Line>
-                </Text>
-                <LoadingWrapper>
-                    <LoadingDots />
-                </LoadingWrapper>
+                <TextTop>{t('sync-message.top-line')}</TextTop>
+                <LoadingGroup>
+                    <Text>
+                        <Line>
+                            <strong>
+                                <SyncCountdown
+                                    onStarted={() => setIsStarted(true)}
+                                    onCompleted={() => setIsComplete(true)}
+                                />
+                                {isStarted && !isComplete && t('sync-message.line2')}
+                            </strong>
+                        </Line>
+                        <Line>{t('sync-message.line3')}</Line>
+                    </Text>
+                    <LoadingWrapper>
+                        <LoadingDots />
+                    </LoadingWrapper>
+                </LoadingGroup>
             </Wrapper>
             <AnimatePresence>
                 {open && (

--- a/src/components/wallet/components/loaders/SyncLoading/SyncLoading.tsx
+++ b/src/components/wallet/components/loaders/SyncLoading/SyncLoading.tsx
@@ -20,9 +20,9 @@ import SyncCountdown from '@app/components/wallet/components/loaders/SyncLoading
 
 export default function SyncLoading() {
     const { t } = useTranslation(['wallet', 'setup-progresses']);
+
     const cpuMining = useMiningMetricsStore((s) => s.cpu_mining_status.is_mining);
     const gpuMining = useMiningMetricsStore((s) => s.gpu_mining_status.is_mining);
-
     const isMining = cpuMining || gpuMining;
 
     const [open, setOpen] = useState(false);
@@ -39,7 +39,7 @@ export default function SyncLoading() {
     return (
         <>
             <Wrapper ref={refs.setReference} {...getReferenceProps()}>
-                <TextTop>{t('sync-message.top-line')}</TextTop>
+                {isMining && <TextTop>{t('sync-message.top-line')}</TextTop>}
                 <LoadingGroup>
                     <Text>
                         <Line>

--- a/src/components/wallet/components/loaders/SyncLoading/styles.ts
+++ b/src/components/wallet/components/loaders/SyncLoading/styles.ts
@@ -11,9 +11,17 @@ export const Wrapper = styled(m.div)`
     padding: 17px;
 
     display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+`;
+
+export const LoadingGroup = styled.div`
+    display: flex;
     gap: 24px;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
 `;
 
 export const Text = styled.div`
@@ -74,10 +82,19 @@ export const TooltipTitle = styled.div`
 `;
 
 export const TooltipDescription = styled.div`
-    color: #797979;
+    color: ${({ theme }) => theme.palette.text.secondary};
     font-family: Poppins, sans-serif;
     font-size: 12px;
     font-style: normal;
     font-weight: 500;
     line-height: 133.333%;
+`;
+
+export const TextTop = styled.div`
+    color: ${({ theme }) => theme.palette.text.secondary};
+    font-family: Poppins, sans-serif;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
 `;


### PR DESCRIPTION
This is a copy update that adds "You are now mining Tari XTM" copy tot he wallet loader. 

I currently have it set up so this text only displays when the user is mining. Based on the wording, that's what makes sense to me.

![CleanShot 2025-07-09 at 11 13 29@2x](https://github.com/user-attachments/assets/ffef6eec-cd7f-48b4-8aab-a2567958a65a)
