### PR TITLE
fix(ui): fix bug disabling cube pointer events when switching to bridge view

### DIFF
--- a/src/containers/main/Dashboard/Dashboard.tsx
+++ b/src/containers/main/Dashboard/Dashboard.tsx
@@ -15,7 +15,7 @@ export default function Dashboard() {
     useMiningStatesSync();
 
     return (
-        <DashboardContentContainer $tapplet={!!activeTapplet}>
+        <DashboardContentContainer $tapplet={showTapplet}>
             {connectionStatus !== 'connected' && !orphanChainUiDisabled ? <DisconnectWrapper /> : null}
             {showTapplet && activeTapplet ? <Tapplet source={activeTapplet.source} /> : <MiningView />}
         </DashboardContentContainer>


### PR DESCRIPTION
This fixes a bug that disabled mouse interaction on the Mining Cube when you switch from Bridge View back to Mining View. 
