### PR TITLE
fix(ui): node type select styling

### DIFF
--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
@@ -14,6 +14,8 @@ import { Select, SelectOption } from '@app/components/elements/inputs/Select.tsx
 import { NodeType } from '@app/store/useNodeStore.ts';
 import { useConfigCoreStore } from '@app/store/useAppConfigStore.ts';
 import { setNodeType } from '@app/store/actions/appConfigStoreActions.ts';
+import { Stack } from '@app/components/elements/Stack.tsx';
+import { offset } from '@floating-ui/react';
 
 export default function NodeTypeConfiguration() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
@@ -42,7 +44,18 @@ export default function NodeTypeConfiguration() {
                     <Typography>{t('node-configuration-description')}</Typography>
                 </SettingsGroupContent>
                 <SettingsGroupAction>
-                    <Select onChange={handleChange} selectedValue={node_type} options={tabOptions} variant="minimal" />
+                    <Stack style={{ width: '100%', minWidth: 160 }}>
+                        <Select
+                            onChange={handleChange}
+                            forceHeight={36}
+                            selectedValue={node_type}
+                            options={tabOptions}
+                            floatingProps={{
+                                middleware: [offset({ crossAxis: -40, mainAxis: 10 })],
+                            }}
+                            variant="bordered"
+                        />
+                    </Stack>
                 </SettingsGroupAction>
             </SettingsGroup>
         </SettingsGroupWrapper>


### PR DESCRIPTION
Description
---

- adjusted select wrapper styling and middleware props

Motivation and Context
---

overflow was borked:

<img width="884" height="592" alt="optimised_14-07_13-03_821" src="https://github.com/user-attachments/assets/db772fde-1ae0-40b3-b451-4d962d7affac" />


How Has This Been Tested?
---

- locally:

https://github.com/user-attachments/assets/840def2d-93e5-4421-a6f9-eaa8eb6ba2c7

