### PR TITLE
fix: paper wallet covers pin dialog

### DIFF
--- a/src/components/GreenModal/styles.ts
+++ b/src/components/GreenModal/styles.ts
@@ -7,7 +7,7 @@ export const Wrapper = styled('div')`
     height: 100%;
     top: 0;
     left: 0;
-    z-index: 99999;
+    z-index: 99;
 
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Description
---
* Lower PaperWallet modal z-index from 9999 to 99(pin dialogs are 100)