### PR TITLE
fix: gpu miner stats response structure parsing error

### DIFF
--- a/src-tauri/src/gpu_miner_sha_websocket.rs
+++ b/src-tauri/src/gpu_miner_sha_websocket.rs
@@ -22,10 +22,7 @@
 
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Display, Formatter},
-    sync::Arc,
-};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tungstenite::{connect, Message};
 
@@ -35,102 +32,36 @@ const LOG_TARGET: &str = "tari::universe::gpu_miner_sha_adapter";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
-pub struct Job {
+pub struct JobInfo {
     pub job_id: String,
     pub block_height: u64,
     pub difficulty: u64,
     pub timestamp: u64,
 }
 
-impl Display for Job {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Job Info:\n\
-            ──────────────────────────────────────\n\
-            Job ID: {}\n\
-            Block Height: {}\n\
-            Difficulty: {}\n\
-            Timestamp: {}\n\
-            ──────────────────────────────────────",
-            self.job_id, self.block_height, self.difficulty, self.timestamp
-        )
-    }
-}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
-pub struct Share {
-    pub thread_id: u32,
+pub struct WebSocketShare {
+    pub thread_id: usize,
     pub difficulty: u64,
     pub target: u64,
     pub timestamp: u64,
     pub luck_factor: f64,
 }
 
-impl Display for Share {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Share Info:\n\
-            ──────────────────────────────────────\n\
-            Thread ID: {}\n\
-            Difficulty: {}\n\
-            Target: {}\n\
-            Timestamp: {}\n\
-            Luck Factor: {}\n\
-            ──────────────────────────────────────",
-            self.thread_id, self.difficulty, self.target, self.timestamp, self.luck_factor
-        )
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
-
 pub struct SystemInfo {
-    pub cpu_usage: f64,
-    pub cpu_cores: u32,
+    pub cpu_usage: f32,
+    pub cpu_cores: usize,
     pub cpu_name: String,
     pub memory_total: u64,
     pub memory_used: u64,
     pub memory_usage: f64,
-    pub os_name: String,
-    pub kernel_version: String,
-    pub hostname: String,
-    pub cpu_temperature: Option<f64>,
-    pub max_temperature: f64,
-}
-
-impl Display for SystemInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "System Info:\n\
-            ──────────────────────────────────────────────────────\n\
-            CPU Usage: {:.2}%\n\
-            Cores: {}\n\
-            CPU Name: {}\n\
-            Memory Total: {}\n\
-            Memory Used: {}\n\
-            Memory Usage: {:.2}%\n\
-            OS: {}\n\
-            Kernel: {}\n\
-            Hostname: {}\n\
-            CPU Temp: {:?}\n\
-            Max Temp: {:.2}\n\
-            ──────────────────────────────────────────────────────",
-            self.cpu_usage,
-            self.cpu_cores,
-            self.cpu_name,
-            self.memory_total,
-            self.memory_used,
-            self.memory_usage,
-            self.os_name,
-            self.kernel_version,
-            self.hostname,
-            self.cpu_temperature,
-            self.max_temperature
-        )
-    }
+    pub os_name: Option<String>,
+    pub kernel_version: Option<String>,
+    pub hostname: Option<String>,
+    pub cpu_temperature: Option<f32>,
+    pub max_temperature: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -138,30 +69,17 @@ impl Display for SystemInfo {
 pub struct PoolInfo {
     pub pool_address: String,
     pub is_connected: bool,
-    pub latency_ms: u64,
+    pub latency_ms: Option<u64>,
     pub connection_attempts: u32,
-    pub uptime_seconds: u64,
+    pub uptime_seconds: Option<u64>,
 }
 
-impl Display for PoolInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Pool Info:\n\
-            ──────────────────────────────────────────────────────\n\
-            Pool Address: {}\n\
-            Connected: {}\n\
-            Latency: {} ms\n\
-            Connection Attempts: {}\n\
-            Uptime: {} seconds\n\
-            ──────────────────────────────────────────────────────",
-            self.pool_address,
-            self.is_connected,
-            self.latency_ms,
-            self.connection_attempts,
-            self.uptime_seconds
-        )
-    }
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq)]
+pub enum GpuVendor {
+    NVIDIA,
+    AMD,
+    Intel,
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,48 +87,15 @@ impl Display for PoolInfo {
 pub struct GpuInfo {
     pub detected: bool,
     pub name: String,
-    pub driver_version: String,
-    pub temperature: f64,
-    pub power_usage: f64,
-    pub memory_used: u64,
-    pub memory_total: u64,
-    pub utilization: f64,
-    pub count: u32,
-    pub vendor: String,
+    pub driver_version: Option<String>,
+    pub temperature: Option<f32>,
+    pub power_usage: Option<f32>,
+    pub memory_used: Option<u64>,
+    pub memory_total: Option<u64>,
+    pub utilization: Option<f32>,
+    pub count: usize,
+    pub vendor: GpuVendor,
     pub error_message: Option<String>,
-}
-
-impl Display for GpuInfo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "GPU Info:\n\
-            ──────────────────────────────────────────────────────\n\
-            Detected: {}\n\
-            Name: {}\n\
-            Driver Version: {}\n\
-            Temperature: {:.2}°C\n\
-            Power Usage: {:.2}W\n\
-            Memory Used: {}\n\
-            Memory Total: {}\n\
-            Utilization: {:.2}%\n\
-            Count: {}\n\
-            Vendor: {}\n\
-            Error Message: {:?}\n\
-            ──────────────────────────────────────────────────────",
-            self.detected,
-            self.name,
-            self.driver_version,
-            self.temperature,
-            self.power_usage,
-            self.memory_used,
-            self.memory_total,
-            self.utilization,
-            self.count,
-            self.vendor,
-            self.error_message
-        )
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -225,91 +110,21 @@ pub struct WebSocketGpuMinerResponse {
     pub uptime: u64,
     pub thread_hashrates: Vec<u64>,
     pub algorithm: String,
-    pub active_threads: u32,
+    pub active_threads: usize,
     pub share_rate: f64,
     pub total_work: u64,
     pub current_difficulty: u64,
-    pub current_job: Option<Job>,
-    pub recent_jobs: Vec<Job>,
+    pub current_job: JobInfo,
+    pub recent_jobs: Vec<JobInfo>,
     pub session_time: u64,
     pub time_since_last_share: u64,
     pub avg_share_time: f64,
     pub acceptance_rate: f64,
-    pub recent_shares: Vec<Share>,
+    pub recent_shares: Vec<WebSocketShare>,
     pub top_shares: Vec<u64>,
     pub system_info: SystemInfo,
     pub pool_info: PoolInfo,
     pub gpu_info: GpuInfo,
-}
-
-impl Display for WebSocketGpuMinerResponse {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "WebSocket GPU Miner Response:\n\
-            ──────────────────────────────────────────────────────────────────────\n\
-            Current Hashrate: {}\n\
-            Session Average: {}\n\
-            Accepted Shares: {}\n\
-            Submitted Shares: {}\n\
-            Rejected Shares: {}\n\
-            Work Efficiency: {:.2}\n\
-            Average Luck: {:.2}\n\
-            Uptime: {}\n\
-            Thread Hashrates: {:?}\n\
-            Algorithm: {}\n\
-            Active Threads: {}\n\
-            Share Rate: {:.2}\n\
-            Total Work: {}\n\
-            Current Difficulty: {}\n\
-            Current Job: {:?}\n\
-            Recent Jobs: {:?}\n\
-            Session Time: {}\n\
-            Time Since Last Share: {}\n\
-            Avg Share Time: {:.2}\n\
-            Acceptance Rate: {:.2}\n\
-            Recent Shares: {:?}\n\
-            Top Shares: {:?}\n\
-            System Info: {}\n\
-            Pool Info: {}\n\
-            GPU Info: {}\n\
-            ──────────────────────────────────────────────────────────────────────",
-            self.current_hashrate,
-            self.session_average,
-            self.accepted_shares,
-            self.submitted_shares,
-            self.rejected_shares,
-            self.work_efficiency,
-            self.average_luck,
-            self.uptime,
-            self.thread_hashrates,
-            self.algorithm,
-            self.active_threads,
-            self.share_rate,
-            self.total_work,
-            self.current_difficulty,
-            self.current_job.as_ref().map(|job| job.to_string()),
-            self.recent_jobs
-                .iter()
-                .map(|job| job.to_string())
-                .collect::<Vec<_>>(),
-            self.session_time,
-            self.time_since_last_share,
-            self.avg_share_time,
-            self.acceptance_rate,
-            self.recent_shares
-                .iter()
-                .map(|share| share.to_string())
-                .collect::<Vec<_>>(),
-            self.top_shares
-                .iter()
-                .map(|share| share.to_string())
-                .collect::<Vec<_>>(),
-            self.system_info,
-            self.pool_info,
-            self.gpu_info
-        )
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -367,6 +182,9 @@ impl GpuMinerShaWebSocket {
 
                                             }
                                             Err(e) => {
+                                            if !self.last_message.lock().await.is_none() {
+                                                info!(target: LOG_TARGET, "Received message: {text}");
+                                            }
                                                 warn!(target: LOG_TARGET, "Failed to parse message: {e}");
                                                 *self.last_message.lock().await = None;
                                             }


### PR DESCRIPTION
### [ Summary ]
- Adjusted structure that we are expecting to parse to the content from gpu stats response
- Remove display formatting as it was obsolete
- Add log of received data that triggers only once each times that we get new parsing fail, eg.:
- Success Success Success Success => won't trigger
- Success Success Fail Success => trigger only once
- Fail Fail Fail Fail => trigger only once
- Success Fail Success Fail => trigger twice

Should fix #2534