### PR TITLE
fix: keyring dialog not displayed on deny

### DIFF
--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -39,7 +39,6 @@ use tari_key_manager::SeedWords;
 use tari_utilities::encoding::MBase58;
 use tari_utilities::message_format::MessageFormat;
 use tari_utilities::{Hidden, SafePassword};
-use tauri::async_runtime::block_on;
 use tauri::{AppHandle, Listener, Manager};
 use tokio::fs;
 use tokio::sync::{oneshot, OnceCell, RwLock};

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -730,15 +730,18 @@ impl InternalWallet {
             else {
                 let wallets = ConfigWallet::content().await.tari_wallets().clone();
                 if let Some(wallet_id) = wallets.first() {
-                    CredentialManager::new_default(wallet_id.clone())
+                    let result = CredentialManager::new_default(wallet_id.clone())
                         .get_credentials()
-                        .await
-                        .map(|cred| cred.encrypted_seed)
-                        .map_err(|e| {
+                        .await;
+
+                    match result {
+                        Ok(cred) => cred.encrypted_seed,
+                        Err(e) => {
                             // Only display once
-                            block_on(EventsEmitter::emit_show_keyring_dialog());
-                            anyhow!("Failed to get tari seed from keyring: {e}")
-                        })?
+                            EventsEmitter::emit_show_keyring_dialog().await;
+                            return Err(anyhow!("Failed to get tari seed from keyring: {e}"));
+                        }
+                    }
                 } else {
                     drop(internal_wallet); // Release lock before await
                     handle_critical_problem("Can't access seed", "[get_tari_seed]", None).await;


### PR DESCRIPTION
```rs
.map_err(|e| {
    // Only display once
    block_on(EventsEmitter::emit_show_keyring_dialog());
    anyhow!("Failed to get tari seed from keyring: {e}")
})?
```

```log
thread 'tokio-runtime-worker' panicked at /Users/mpap/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.46.1/src/runtime/scheduler/multi_thread/mod.rs:86:9:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```
<img width="1027" height="645" alt="Screenshot 2025-07-16 at 01 33 42" src="https://github.com/user-attachments/assets/319b42e4-bddb-48b7-b836-2d2aacee5847" />

