### PR TITLE
fix(ui): disable transparent bg for linux

### DIFF
--- a/src/components/elements/dialog/Dialog.styles.ts
+++ b/src/components/elements/dialog/Dialog.styles.ts
@@ -10,8 +10,6 @@ export interface ContentWrapperProps {
     $transparentBg?: boolean;
 }
 export const ContentWrapper = styled.div<ContentWrapperProps>`
-    background-color: ${({ theme }) => theme.palette.background.paper};
-    position: relative;
     border-radius: ${({ theme, $borderRadius }) => $borderRadius || theme.shape.borderRadius.dialog};
     box-shadow: 0 4px 45px 0 rgba(0, 0, 0, 0.08);
     display: flex;
@@ -19,27 +17,34 @@ export const ContentWrapper = styled.div<ContentWrapperProps>`
     gap: 6px;
     max-height: 90%;
     padding: ${({ $unPadded }) => ($unPadded ? '0' : '20px')};
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        -webkit-backdrop-filter: blur(20px);
+        backdrop-filter: blur(20px);
+        z-index: -1;
+    }
+
+    ${({ theme, $transparentBg }) =>
+        $transparentBg
+            ? css`
+                  background-color: ${convertHexToRGBA(
+                      theme.palette.background.paper,
+                      theme.mode == 'dark' ? 0.75 : 0.65
+                  )};
+              `
+            : css`
+                  background-color: ${theme.palette.background.paper};
+              `}
 
     ${({ $disableOverflow }) =>
         !$disableOverflow &&
         css`
             overflow-y: auto;
-        `}
-
-    ${({ theme, $transparentBg }) =>
-        $transparentBg &&
-        css`
-            background-color: ${convertHexToRGBA(theme.palette.background.paper, theme.mode == 'dark' ? 0.75 : 0.65)};
-
-            &::before {
-                content: '';
-                position: absolute;
-                width: 100%;
-                height: 100%;
-                -webkit-backdrop-filter: blur(20px);
-                backdrop-filter: blur(20px);
-                z-index: -1;
-            }
         `}
 `;
 

--- a/src/components/elements/dialog/Dialog.tsx
+++ b/src/components/elements/dialog/Dialog.tsx
@@ -21,6 +21,7 @@ import {
     useMergeRefs,
     useRole,
 } from '@floating-ui/react';
+import { type } from '@tauri-apps/plugin-os';
 import { useAppStateStore } from '@app/store/appStateStore.ts';
 import { ContentWrapper, ContentWrapperProps, Overlay } from './Dialog.styles.ts';
 
@@ -114,8 +115,14 @@ export function Dialog({
 
 export const DialogContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement> & ContentWrapperProps>(
     function DialogContent(props, propRef) {
+        const osType = type();
+
+        const isNotLinux = osType !== 'linux';
         const context = useDialogContext();
         const ref = useMergeRefs([context.refs.setFloating, propRef]);
+
+        const transparentBg = props.$transparentBg && isNotLinux;
+
         return (
             <FloatingNode id={context.nodeId} key={context.nodeId}>
                 {context.open ? (
@@ -124,13 +131,13 @@ export const DialogContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement
                             <FloatingFocusManager context={context.context} modal={false}>
                                 <ContentWrapper
                                     ref={ref}
+                                    {...context.getFloatingProps(props)}
                                     aria-labelledby={context.labelId}
                                     aria-describedby={context.descriptionId}
                                     $unPadded={props.$unPadded}
                                     $disableOverflow={props.$disableOverflow}
                                     $borderRadius={props.$borderRadius}
-                                    $transparentBg={props.$transparentBg}
-                                    {...context.getFloatingProps(props)}
+                                    $transparentBg={transparentBg}
                                 >
                                     {props.children}
                                 </ContentWrapper>


### PR DESCRIPTION
Description
---

- just disable transaparentBg prop if os is linux

Motivation and Context
---

`backdrop-filter` blur isn't working on linux
