### PR TITLE
feat: expose sign message

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3206,9 +3206,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.2"
+version = "0.26.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "a62d7684f766b0f96344be88c023f9b6650039aea09d526b4974cce302eb61b1"
 dependencies = [
  "async-trait",
  "bytes 1.10.1",
@@ -3235,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
+version = "0.26.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "bbab5e26a7f82341145ba1fbd1f1858d0490624fcc46270db2d3c4a101f763f4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3838,6 +3838,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4568,8 +4577,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "argon2",
  "base64 0.13.1",
@@ -4588,6 +4597,7 @@ dependencies = [
  "tari_features",
  "tari_max_size",
  "tari_script",
+ "tari_sidechain",
  "tari_utilities",
  "thiserror 1.0.69",
  "tokio",
@@ -4598,16 +4608,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "bs58 0.5.1",
 ]
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "minotari_app_grpc",
 ]
@@ -4615,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
@@ -5618,6 +5628,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-clean"
@@ -7464,6 +7480,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_valid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
+dependencies = [
+ "indexmap 2.10.0",
+ "itertools 0.13.0",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_valid_derive",
+ "serde_valid_literal",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "serde_valid_derive"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
+dependencies = [
+ "itertools 0.13.0",
+ "paste",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_valid_literal"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
+dependencies = [
+ "paste",
+ "regex",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8242,9 +8303,9 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eac57729e3b003c18e822c64c8c4977770102b2eaea920a7c40bca5caf12c54"
+checksum = "98e43bc4d522de252647e34e72aef4d5e33f845a6acc23fb7b1f4e877a7f9053"
 dependencies = [
  "blake2",
  "byteorder",
@@ -8263,8 +8324,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -8288,8 +8349,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -8305,8 +8366,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "base64 0.21.7",
  "bitflags 2.9.1",
@@ -8329,12 +8390,13 @@ dependencies = [
  "tari_max_size",
  "tari_utilities",
  "thiserror 1.0.69",
+ "utoipa",
 ]
 
 [[package]]
 name = "tari_comms"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8379,8 +8441,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -8392,6 +8454,7 @@ dependencies = [
  "diesel_migrations",
  "digest",
  "futures 0.3.31",
+ "futures-util",
  "log",
  "pin-project 0.4.30",
  "prost 0.13.5",
@@ -8412,8 +8475,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8422,8 +8485,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8461,6 +8524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "serde_valid",
  "sha2",
  "sha3",
  "strum",
@@ -8482,6 +8546,7 @@ dependencies = [
  "tari_script",
  "tari_service_framework",
  "tari_shutdown",
+ "tari_sidechain",
  "tari_storage",
  "tari_test_utils",
  "tari_utilities",
@@ -8489,14 +8554,15 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "utoipa",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_crypto"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ee9850e74d1b331d9513c79d1cd6e64ac2fe4698140cc30218e5972731f165"
+checksum = "b74b1ee79be37e04fcdb307b2809e658f19e05f31a2b5263c128fc3a5e2dee16"
 dependencies = [
  "blake2",
  "borsh",
@@ -8517,23 +8583,38 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 
 [[package]]
 name = "tari_hashing"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
+ "blake2",
  "borsh",
  "digest",
  "tari_crypto",
 ]
 
 [[package]]
+name = "tari_jellyfish"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
+dependencies = [
+ "borsh",
+ "digest",
+ "indexmap 2.10.0",
+ "serde",
+ "tari_crypto",
+ "tari_hashing",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "tari_key_manager"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "argon2",
  "async-trait",
@@ -8565,8 +8646,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "borsh",
  "serde",
@@ -8576,8 +8657,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "borsh",
  "digest",
@@ -8590,8 +8671,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -8616,8 +8697,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "blake2",
  "borsh",
@@ -8634,8 +8715,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8649,16 +8730,33 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "futures 0.3.31",
 ]
 
 [[package]]
+name = "tari_sidechain"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
+dependencies = [
+ "borsh",
+ "hex",
+ "log",
+ "serde",
+ "tari_common_types",
+ "tari_crypto",
+ "tari_hashing",
+ "tari_jellyfish",
+ "tari_utilities",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "tari_storage"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -8669,8 +8767,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "4.8.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v4.8.0#6d0db728042877308bc8ac02dffac389b7aa32ce"
+version = "4.9.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v4.9.0#d9b1c0df92a26caf805fafe3c495f920df358c8d"
 dependencies = [
  "futures 0.3.31",
  "rand 0.8.5",
@@ -9995,6 +10093,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,8 +40,8 @@ libsqlite3-sys = { version = "0.25.1", features = [
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -60,15 +60,15 @@ sha2 = "0.10.8"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
-tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0", features = [
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
+tari_core = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0", features = [
   "transactions",
 ] }
 tauri-plugin-single-instance = '2'
-tari_crypto = "0.22.0"
-tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v4.8.0" }
+tari_crypto = "0.22.1"
+tari_key_manager = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v4.9.0" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
   "protocol-asset",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -574,6 +574,7 @@ fn main() {
             commands::get_seed_words,
             commands::get_tor_config,
             commands::get_tor_entry_guards,
+            commands::sign_message,
             commands::get_transactions,
             commands::import_seed_words,
             commands::revert_to_internal_wallet,

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -169,19 +169,6 @@ impl WalletManager {
         self.watcher.read().await.adapter.grpc_port
     }
 
-    pub async fn sign_message(
-        &self,
-        message: Vec<u8>,
-        tapplet_id: Option<u64>,
-    ) -> Result<SignMessageResponseData, WalletManagerError> {
-        let process_watcher = self.watcher.read().await;
-        process_watcher.adapter.sign_message(message, tapplet_id).await
-            .map_err(|e| match e.code() {
-                tonic::Code::Unavailable => WalletManagerError::WalletNotStarted,
-                _ => WalletManagerError::SigningMessageError,
-            })
-    }
-
     pub fn is_initial_scan_completed(&self) -> bool {
         self.initial_scan_completed
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -206,6 +193,19 @@ impl WalletManager {
     pub async fn get_balance(&self) -> Result<WalletBalance, anyhow::Error> {
         let process_watcher = self.watcher.read().await;
         process_watcher.adapter.get_balance().await
+    }
+
+    pub async fn sign_message(
+        &self,
+        message: Vec<u8>,
+        tapplet_id: Option<u64>,
+    ) -> Result<SignMessageResponseData, WalletManagerError> {
+        let process_watcher = self.watcher.read().await;
+        process_watcher.adapter.sign_message(message, tapplet_id).await
+            .map_err(|e| match e.code() {
+                tonic::Code::Unavailable => WalletManagerError::WalletNotStarted,
+                _ => WalletManagerError::SigningMessageError,
+            })
     }
 
     pub async fn get_transactions(

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -72,6 +72,7 @@ declare module '@tauri-apps/api/core' {
     function invoke(param: 'exit_application'): Promise<string>;
     function invoke(param: 'restart_application', payload: { shouldStopMiners: boolean }): Promise<string>;
     function invoke(param: 'set_use_tor', payload: { useTor: boolean }): Promise<void>;
+    function invoke(param: 'sign_message', payload: { message: string; tapplet_id: number });
     function invoke(
         param: 'get_transactions',
         payload: { offset?: number; limit?: number; statusBitflag?: number }

--- a/src/types/tapplets/TappletSigner.ts
+++ b/src/types/tapplets/TappletSigner.ts
@@ -6,6 +6,7 @@ import {
     BridgeTxDetails,
     SendOneSidedRequest,
     SignMessageTappletRequest,
+    SignMessageTappletResponse,
     TappletSignerParams,
     WindowSize,
 } from './tapplet.types';
@@ -95,14 +96,15 @@ export class TappletSigner {
         }
     }
 
-    public async signMessage(req: SignMessageTappletRequest): Promise<void> {
+    public async signMessage(req: SignMessageTappletRequest): Promise<SignMessageTappletResponse> {
         try {
-            await invoke('sign_message', {
+            return await invoke('sign_message', {
                 message: req.message,
                 tapplet_id: req.tapplet_id,
             });
         } catch (error) {
             setStoreError(`Error signing message: ${error}`);
+            throw error;
         }
     }
 

--- a/src/types/tapplets/TappletSigner.ts
+++ b/src/types/tapplets/TappletSigner.ts
@@ -1,7 +1,14 @@
 import { BackendBridgeTransaction, setError as setStoreError, useConfigUIStore, useWalletStore } from '@app/store';
 import { invoke } from '@tauri-apps/api/core';
 import { BaseNodeStatus, BridgeEnvs, WalletBalance } from '../app-status';
-import { AccountData, BridgeTxDetails, SendOneSidedRequest, TappletSignerParams, WindowSize } from './tapplet.types';
+import {
+    AccountData,
+    BridgeTxDetails,
+    SendOneSidedRequest,
+    SignMessageTappletRequest,
+    TappletSignerParams,
+    WindowSize,
+} from './tapplet.types';
 import { useTappletsStore } from '@app/store/useTappletsStore';
 
 export class TappletSigner {
@@ -85,6 +92,17 @@ export class TappletSigner {
         } catch (error) {
             setStoreError(`Error sending transaction: ${error}`);
             return false;
+        }
+    }
+
+    public async signMessage(req: SignMessageTappletRequest): Promise<void> {
+        try {
+            await invoke('sign_message', {
+                message: req.message,
+                tapplet_id: req.tapplet_id,
+            });
+        } catch (error) {
+            setStoreError(`Error signing message: ${error}`);
         }
     }
 

--- a/src/types/tapplets/tapplet.types.ts
+++ b/src/types/tapplets/tapplet.types.ts
@@ -24,6 +24,11 @@ export interface ActiveTapplet {
     supportedChain: SupportedChain[];
 }
 
+export interface SignMessageTappletRequest {
+    message: string;
+    tapplet_id: number;
+}
+
 export interface SendOneSidedRequest {
     amount: string;
     address: string;

--- a/src/types/tapplets/tapplet.types.ts
+++ b/src/types/tapplets/tapplet.types.ts
@@ -29,6 +29,11 @@ export interface SignMessageTappletRequest {
     tapplet_id: number;
 }
 
+export interface SignMessageTappletResponse {
+    signature: string;
+    public_nonce: string;
+}
+
 export interface SendOneSidedRequest {
     amount: string;
     address: string;


### PR DESCRIPTION
Description

This PR adds message signing functionality to the Tari Universe tapplet system. It exposes a new sign_message function that allows tapplets to request cryptographic signatures from the user's wallet, returning the signature and public nonce required for message verification.

This function expose is related to [PR#7299](https://github.com/tari-project/tari/pull/7299)

Motivation and Context

Tapplets need the ability to sign messages using the user's wallet keys for authentication and verification purposes. This feature provides a secure way for tapplets to request message signatures without directly accessing the user's private keys, maintaining the security model where the wallet manages all cryptographic operations.

Changes

  - Added sign_message function to wallet adapter with proper error handling
  - Implemented Tauri command with message and tapplet_id parameters
  - Added TypeScript types for request/response structures
  - Function properly returns SignMessageTappletResponse with signature and public_nonce fields
  - Error handling implemented for wallet unavailable and signing failures

What process can a PR reviewer use to test or verify this change?

  1. Build the application with the changes
  2. Load a tapplet that implements message signing
  3. Trigger the signMessage function from the tapplet
  4. Verify the function returns a valid SignMessageTappletResponse object with signature and public_nonce fields

Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
