### PR TITLE
feat(ui): moved the admin button

### DIFF
--- a/src/components/AdminUI/AdminUI.tsx
+++ b/src/components/AdminUI/AdminUI.tsx
@@ -26,7 +26,7 @@ const AdminUI = memo(function AdminUI() {
         nodeId,
         open: isOpen,
         onOpenChange: setIsOpen,
-        middleware: [offset(10), flip(), shift()],
+        middleware: [offset(5), flip(), shift()],
         placement: 'bottom-end',
     });
 

--- a/src/components/AdminUI/styles.ts
+++ b/src/components/AdminUI/styles.ts
@@ -4,21 +4,27 @@ import styled, { css } from 'styled-components';
 export const ToggleButton = styled('button')<{ $isOpen?: boolean }>`
     background: #444;
     color: white;
-    padding: 4px 6px;
-    border-radius: 4px;
+    padding: 8px 0px;
+    border-radius: 50px;
     cursor: pointer;
+    width: 76px;
 
     position: fixed;
-    top: 20px;
-    right: 30px;
+    top: 32px;
+    left: 11px;
     z-index: 99999;
     pointer-events: all;
 
-    font-size: 12px;
+    font-size: 11px;
     opacity: 0;
     transition: opacity 0.2s ease;
+    font-weight: 600;
 
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &:hover {
         background: #555;
@@ -42,18 +48,18 @@ export const MenuWrapper = styled(m.div)`
 `;
 
 export const MenuContent = styled(m.div)`
-    background: rgba(0, 0, 0, 0.8);
-    padding: 12px 10px;
+    background: #444;
+    padding: 20px;
     border-radius: 8px;
 
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 20px;
 
     min-width: 260px;
     max-height: calc(100vh - 100px);
     overflow-y: auto;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 `;
 
 export const AdminButton = styled('button')<{ $isActive?: boolean }>`


### PR DESCRIPTION
The top right area of the UI will be used for future UI elements, so i'm moving the Admin Menu to a better spot that's more out of the way. 

I placed it over the Tari logo in the sidebar.

<img width="2600" height="1396" alt="CleanShot 2025-07-16 at 11 14 06@2x" src="https://github.com/user-attachments/assets/2060422e-0505-4b43-ad2a-2c7bb4cc570a" />
