### PR TITLE
fix: security prompt dialog

### DIFF
--- a/src/containers/floating/security/prompt/SecurityPromptDialog.tsx
+++ b/src/containers/floating/security/prompt/SecurityPromptDialog.tsx
@@ -28,7 +28,7 @@ export default function SecurityPromptDialog() {
     function handleClick() {
         if (!seedBackedUp) {
             setModal('verify_seedphrase');
-        } else {
+        } else if (!pinLocked) {
             void invoke('create_pin');
         }
     }
@@ -37,11 +37,11 @@ export default function SecurityPromptDialog() {
         invoke('is_seed_backed_up').then((r) => {
             setSeedBackedUp(!!r);
         });
-    }, []);
+    }, [isOpen]);
 
     useEffect(() => {
         invoke('is_pin_locked').then((r) => setPinLocked(r));
-    }, []);
+    }, [isOpen]);
 
     const steps: StepItem[] = [
         {

--- a/src/containers/floating/security/seedphrase/SeedPhrase.tsx
+++ b/src/containers/floating/security/seedphrase/SeedPhrase.tsx
@@ -29,10 +29,11 @@ export default function SeedPhrase() {
             invoke('get_seed_words').then((r) => {
                 if (r?.length) {
                     setSeedPhrase(r);
+                    setModal('verify_seedphrase');
                 }
             });
         }
-    }, [isOpen, seedPhrase?.length]);
+    }, [isOpen, seedPhrase?.length, setModal]);
 
     const content = isVerify ? (
         <>


### PR DESCRIPTION
Closes #2558

Fix
---
* update `is_seed_backed_up` and `is_pin_locked` flags on each modal open / don't redirect to the pin creation when already locked
* `SeedPhrase` dialog invokes `getTariSeed` which displays pin entering dialog(if locked) causing the `SecurityPromptDIalog`'s flow break. Re-display it after fetching seed words.

https://github.com/user-attachments/assets/71027a69-e445-4629-9ad6-7218a254ab7d


