### PR TITLE
chore: improve wallet error handling

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -202,14 +202,14 @@ pub async fn select_exchange_miner(
     app_handle: tauri::AppHandle,
     exchange_miner: ExchangeMiner,
     mining_address: String,
-) -> Result<(), InvokeError> {
+) -> Result<(), String> {
     let new_external_tari_address =
         TariAddress::from_str(&mining_address).map_err(|e| format!("Invalid Tari address: {e}"))?;
 
     // Validate PIN if pin locked
     let _unused = PinManager::get_validated_pin_if_defined(&app_handle)
         .await
-        .map_err(InvokeError::from_anyhow)?;
+        .map_err(|e| e.to_string())?;
 
     match InternalWallet::initialize_seedless(&app_handle, Some(new_external_tari_address)).await {
         Ok(_) => {
@@ -226,7 +226,7 @@ pub async fn select_exchange_miner(
         exchange_miner.id.clone(),
     )
     .await
-    .map_err(InvokeError::from_anyhow)?;
+    .map_err(|e| e.to_string())?;
 
     EventsEmitter::emit_exchange_id_changed(exchange_miner.id.clone()).await;
 

--- a/src-tauri/src/configs/config_wallet.rs
+++ b/src-tauri/src/configs/config_wallet.rs
@@ -96,15 +96,15 @@ impl Default for ConfigWalletContent {
     fn default() -> Self {
         Self {
             version: 0,
-            tari_wallets: Vec::new(),
+            tari_wallets: Vec::new(), // Owned wallets` ids
             monero_address: "".to_string(),
             monero_address_is_generated: false,
             keyring_accessed: false,
             wallet_migration_nonce: 0,
             created_at: SystemTime::now(),
-            selected_external_tari_address: None,
+            selected_external_tari_address: None, // Takes precedence over an owned address
             external_tari_addresses_book: HashMap::new(),
-            tari_wallet_details: None,
+            tari_wallet_details: None, // Owned tari address details
             pin_locker_state: PinLockerState::default(),
             seed_backed_up: false,
         }
@@ -135,8 +135,7 @@ impl ConfigWalletContent {
                 address,
             },
         );
-        self.tari_wallet_details = None;
-
+        // Don't clear tari_wallet_details
         self
     }
 

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -780,6 +780,7 @@ impl InternalWallet {
         })
     }
 
+    /** Method safe to use before init - fallbacks to the credential manager */
     pub async fn get_tari_seed(
         pin_password: Option<SafePassword>,
     ) -> Result<CipherSeed, anyhow::Error> {
@@ -836,6 +837,7 @@ impl InternalWallet {
         }
     }
 
+    /** Method safe to use before init - fallbacks to the credential manager */
     pub async fn get_monero_seed(
         pin_password: Option<SafePassword>,
     ) -> Result<MoneroSeed, anyhow::Error> {

--- a/src-tauri/src/pin/pin_manager.rs
+++ b/src-tauri/src/pin/pin_manager.rs
@@ -70,9 +70,11 @@ impl PinManager {
             ));
         }
 
+        let wallet_config = ConfigWallet::content().await;
+        // TODO: We can set a flag to validate against monero so user don't need to enter kerying twice
+
         // Validate pin against Tari Seed or Monero Seed
-        if InternalWallet::is_initialized() && InternalWallet::tari_wallet_details().await.is_some()
-        {
+        if wallet_config.tari_wallet_details().is_some() {
             match InternalWallet::get_tari_seed(Some(pin_password.clone())).await {
                 Ok(_unused) => {
                     log::info!(target: LOG_TARGET, "Pin validated successfully against Tari Seed!");

--- a/src-tauri/src/pin/pin_manager.rs
+++ b/src-tauri/src/pin/pin_manager.rs
@@ -71,7 +71,8 @@ impl PinManager {
         }
 
         // Validate pin against Tari Seed or Monero Seed
-        if InternalWallet::tari_wallet_details().await.is_some() {
+        if InternalWallet::is_initialized() && InternalWallet::tari_wallet_details().await.is_some()
+        {
             match InternalWallet::get_tari_seed(Some(pin_password.clone())).await {
                 Ok(_unused) => {
                     log::info!(target: LOG_TARGET, "Pin validated successfully against Tari Seed!");
@@ -94,7 +95,8 @@ impl PinManager {
                 }
             }
         } else {
-            log::info!(target: LOG_TARGET, "Neither Tari Seed nor Monero Seed available to validate against.");
+            log::error!(target: LOG_TARGET, "Neither Tari Seed nor Monero Seed available to validate against.");
+            panic!("Neither Tari Seed nor Monero Seed available to validate against.");
             // Edge case, we can't actually validate the pin
             // because we don't have neither a Tari wallet nor a Monero wallet
             // to check against.
@@ -145,6 +147,7 @@ where
     if let Some(pin) = pin {
         Ok(pin.to_string())
     } else {
+        log::info!("PIN entry cancelled");
         Err(anyhow::anyhow!("PIN entry cancelled"))
     }
 }

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -318,7 +318,7 @@ impl SetupManager {
                 let _unused = ConfigUI::set_wallet_ui_mode(WalletUIMode::Seedless).await;
                 if let Err(e) = InternalWallet::initialize_seedless(&app_handle, None).await {
                     EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                        title: Some("Wallet not initialized!".to_string()),
+                        title: Some("Wallet(Seedless) not initialized!".to_string()),
                         description: Some(
                             "Encountered an error while initializing the wallet.".to_string(),
                         ),
@@ -332,7 +332,7 @@ impl SetupManager {
                     Ok(()) => {
                         if let Err(e) = ConfigWallet::migrate().await {
                             EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                                title: Some("Wallet migration failed!".to_string()),
+                                title: Some("Wallet config migration failed!".to_string()),
                                 description: Some(
                                     "Encountered an error while migrating the wallet.".to_string(),
                                 ),
@@ -342,8 +342,15 @@ impl SetupManager {
                         }
                     }
                     Err(e) => {
-                        // Handle this as critical error
                         error!(target: LOG_TARGET, "Error loading internal wallet: {e:?}");
+                        EventsEmitter::emit_critical_problem(CriticalProblemPayload {
+                            title: Some("Wallet(seed) not initialized!".to_string()),
+                            description: Some(
+                                "Encountered an error while initializing the wallet.".to_string(),
+                            ),
+                            error_message: Some(e.to_string()),
+                        })
+                        .await;
                     }
                 };
             }

--- a/src/components/exchanges/universal/option/InternalWalletOption.tsx
+++ b/src/components/exchanges/universal/option/InternalWalletOption.tsx
@@ -51,7 +51,13 @@ export const InternalWalletOption = ({ isCurrent = false, isActive, onActiveClic
             })
             .catch((e) => {
                 console.error('Could not revert to internal wallet', e);
-                setError('Could not revert to internal wallet', e);
+                const errorMessage = e as unknown as string;
+                if (
+                    !errorMessage.includes('User canceled the operation') &&
+                    !errorMessage.includes('PIN entry cancelled')
+                ) {
+                    setError(errorMessage);
+                }
             });
     };
 

--- a/src/components/exchanges/universal/option/XCOption.tsx
+++ b/src/components/exchanges/universal/option/XCOption.tsx
@@ -67,7 +67,13 @@ export const XCOption = ({ isCurrent = false, isActive, content, onActiveClick, 
             })
             .catch((e) => {
                 console.error('Could not set Exchange address', e);
-                setError('Could not change Exchange address: ' + e.message);
+                const errorMessage = e as unknown as string;
+                if (
+                    !errorMessage.includes('User canceled the operation') &&
+                    !errorMessage.includes('PIN entry cancelled')
+                ) {
+                    setError(errorMessage);
+                }
             });
     };
 

--- a/src/components/security/pin/EnterPin.tsx
+++ b/src/components/security/pin/EnterPin.tsx
@@ -28,7 +28,7 @@ export default function EnterPin({ onSubmit }: EnterPinProps) {
     }
 
     function handleForgot() {
-        // stop backend listener for entering the pin
+        // close backend listener for entering the pin
         emit('pin-dialog-response', { pin: undefined }).then(() => {
             setModal('forgot_pin');
             methods.reset();

--- a/src/components/wallet/seedwords/SeedWords.tsx
+++ b/src/components/wallet/seedwords/SeedWords.tsx
@@ -115,11 +115,12 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
                 getSeedWords().then((r) => {
                     if (r?.length) {
                         copyToClipboard(r.join(' '));
+                        setSeedWords([]);
                     }
                 });
             }
         });
-    }, [copyToClipboard, getSeedWords, seedWords, seedWordsFetched]);
+    }, [copyToClipboard, getSeedWords, seedWords, setSeedWords, seedWordsFetched]);
 
     const displayCTAs = (
         <>

--- a/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
+++ b/src/containers/floating/Settings/sections/wallet/SeedWordsMarkup/useGetSeedWords.ts
@@ -25,7 +25,10 @@ export function useGetSeedWords(args?: Arguments) {
             }
         } catch (e) {
             const errorMessage = e as unknown as string;
-            if (errorMessage !== 'PIN entry cancelled') {
+            if (
+                !errorMessage.includes('User canceled the operation') &&
+                !errorMessage.includes('PIN entry cancelled')
+            ) {
                 setError(errorMessage);
             }
             console.error('Could not get seed words', e);

--- a/src/containers/floating/security/pin/ForgotPinDialog.tsx
+++ b/src/containers/floating/security/pin/ForgotPinDialog.tsx
@@ -7,7 +7,7 @@ import CloseButton from '@app/components/elements/buttons/CloseButton.tsx';
 import { Header, Heading, Wrapper } from './styles.ts';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { InputArea, WalletSettingsGrid } from '@app/containers/floating/Settings/sections/wallet/styles.ts';
+import { InputArea } from '@app/containers/floating/Settings/sections/wallet/styles.ts';
 import { Edit } from '@app/components/wallet/seedwords/components/Edit.tsx';
 import { Form } from '@app/components/wallet/seedwords/components/edit.styles.ts';
 import { invoke } from '@tauri-apps/api/core';

--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -115,7 +115,10 @@ export const importSeedWords = async (seedWords: string[]) => {
             type: 'success',
         });
     } catch (error) {
-        setError(`Could not import seed words: ${error}`, true);
+        const errorMessage = error as unknown as string;
+        if (!errorMessage.includes('User canceled the operation') && !errorMessage.includes('PIN entry cancelled')) {
+            setError(`Could not import seed words: ${error}`, true);
+        }
         useWalletStore.setState({ is_wallet_importing: false });
     } finally {
         useWalletStore.setState({ is_wallet_importing: false });


### PR DESCRIPTION
Description
---
* Before loading an owned(internal) tari wallet, validate if config wallet contains all required details. If no, try to extract all missing
* Don't remove tari wallet details from the wallet config file, when switching to external tari address. It allows us to smoothly switch to Standard Universe - no keyring prompt, easier flow
* Make it possible to get tari and monero seed before InitialWallet is even initialized
* Hide error tooltips when user cancelled keyring access or pin entering
* DIsplay errors if something else happened