### PR TITLE
fix(ui): activate bridge button once setup is complete

### DIFF
--- a/src/containers/navigation/Sidebars/buttons/BridgeButton.tsx
+++ b/src/containers/navigation/Sidebars/buttons/BridgeButton.tsx
@@ -4,21 +4,22 @@ import { useUIStore } from '@app/store/useUIStore.ts';
 import { setSidebarOpen, setShowTapplet } from '@app/store/actions/uiStoreActions';
 import { BRIDGE_TAPPLET_ID } from '@app/store/consts.ts';
 import { useTappletsStore } from '@app/store/useTappletsStore.ts';
-import { useWalletStore } from '@app/store/useWalletStore.ts';
+import { useSetupStore } from '@app/store/useSetupStore.ts';
 
 const BridgeButton = memo(function BridgeButton() {
     const showTapplet = useUIStore((s) => s.showTapplet);
     const setActiveTappById = useTappletsStore((s) => s.setActiveTappById);
-    const isWalletScanning = useWalletStore((s) => s.wallet_scanning?.is_scanning);
+    const isSettingUp = useSetupStore((s) => !s.appUnlocked);
 
     function handleToggleOpen() {
+        if (isSettingUp) return;
         setActiveTappById(BRIDGE_TAPPLET_ID, true);
         setShowTapplet(true);
         setSidebarOpen(false);
     }
 
     return (
-        <Button $isActive={showTapplet} type="button" onClick={handleToggleOpen} disabled={isWalletScanning}>
+        <Button $isActive={showTapplet} type="button" onClick={handleToggleOpen} disabled={isSettingUp}>
             <svg width="28" height="33" viewBox="0 0 28 33" fill="none">
                 <path
                     d="M15.2582 18.0473L15.2582 12.7737L9.47676 12.7737L0.23841 21.8571L9.48501e-07 21.7388L5.69432e-07 13.0667L7.80789 5.27356L15.2582 5.27356L15.2582 -6.82703e-07L24.4286 8.98146L15.2582 18.0473Z"


### PR DESCRIPTION
The Bridge button was disabled until the wallet scanning is complete. Now that the wallet scanning is much faster, it's happening before the Setup Sync screen is hidden. So the Sync screen UI is blocking the bridge section. 

This update changes it, so the Bridge button is only enabled once the setup is complete. 