### PR TITLE
fix: wallet balance showing 0 on remote node

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -445,14 +445,14 @@ impl NodeManager {
         Err(anyhow::anyhow!("grpc_address not set"))
     }
 
-    pub async fn get_http_api_url(&self) -> Result<String, anyhow::Error> {
+    pub async fn get_http_api_url(&self) -> Option<String> {
         let current_adapter = self.current_adapter.read().await;
 
         if let Some(http_api_url) = current_adapter.get_http_api_port() {
-            return Ok(format!("http://127.0.0.1:{http_api_url}"));
+            return Some(format!("http://127.0.0.1:{http_api_url}"));
         }
 
-        Ok("https://rpc.esmeralda.tari.com".to_string())
+        None
     }
 
     pub async fn check_if_is_orphan_chain(&self) -> Result<bool, anyhow::Error> {

--- a/src-tauri/src/spend_wallet_manager.rs
+++ b/src-tauri/src/spend_wallet_manager.rs
@@ -120,7 +120,7 @@ impl SpendWalletManager {
         let (public_key, public_address) = self.node_manager.get_connection_details().await?;
         self.adapter.base_node_public_key = Some(public_key.clone());
         self.adapter.base_node_address = Some(public_address.clone());
-        self.adapter.http_client_url = Some(self.node_manager.get_http_api_url().await?);
+        self.adapter.http_client_url = self.node_manager.get_http_api_url().await;
         info!(target: LOG_TARGET, "[send_one_sided_to_stealth_address] with node {public_key:?}:{public_address:?}");
 
         // Prevent from erasing wallet data when sending in progress

--- a/src-tauri/src/wallet_manager.rs
+++ b/src-tauri/src/wallet_manager.rs
@@ -123,7 +123,7 @@ impl WalletManager {
         let (public_key, public_address) = self.node_manager.get_connection_details().await?;
         process_watcher.adapter.base_node_public_key = Some(public_key.clone());
         process_watcher.adapter.base_node_address = Some(public_address.clone());
-        process_watcher.adapter.http_client_url = Some(self.node_manager.get_http_api_url().await?);
+        process_watcher.adapter.http_client_url = self.node_manager.get_http_api_url().await;
         process_watcher.adapter.use_tor(config.use_tor);
         info!(target: LOG_TARGET, "Using Tor: {}", config.use_tor);
         process_watcher


### PR DESCRIPTION
Description
---
Removes redundant `http_server_url` field from remote wallet which is no longer needed. It caused bug where remote wallet couldn't get user balance since it's value for mainnet was:
```
-p wallet.http_server_url=https://rpc.esmeralda.tari.com
```

Now this value is not needed since wallet can deduce the correct http server but it should still be there if wallet is connected to the local node.

How Has This Been Tested?
---
Launch TU with pool mining enabled in settings and verify that balances in wallet card are correct. Check that logs lack argument `-p wallet.http_server_url`:
```
15:30:48 INFO  Starting wallet process with args: -b /home/maciej/.local/share/com.tari.universe.alpha/wallet --non-interactive-mode --log-config=/home/maciej/.local/share/com.tari.universe.alpha/logs/wallet/configs/log4rs_config_wallet.yml --grpc-enabled --grpc-address /ip4/127.0.0.1/tcp/44813 -p wallet.custom_base_node=38b1141d8486d77dfb5d00f4ed2d6910e3f14601a80e2d5713dc25168cd2f314::/ip4/51.89.173.211/tcp/18189 --birthday 1262 -p wallet.p2p.transport.tor.proxy_bypass_for_outbound_tcp=true -p mainnet.p2p.seeds.dns_seeds=seeds.tari.com
```


But it's present on the local node:
```
15:24:30 INFO  Starting wallet process with args: -b /home/maciej/.local/share/com.tari.universe.alpha/wallet --non-interactive-mode --log-config=/home/maciej/.local/share/com.tari.universe.alpha/logs/wallet/configs/log4rs_config_wallet.yml --grpc-enabled --grpc-address /ip4/127.0.0.1/tcp/34913 -p wallet.custom_base_node=4ca89c234f49c5a347a3fb34abf9b1b56e07528500675848e1b8bfd79f6a4b44::/ip4/127.0.0.1/tcp/34713 -p wallet.http_server_url=http://127.0.0.1:32879 --birthday 1262 -p wallet.base_node.base_node_monitor_max_refresh_interval=1 -p wallet.p2p.transport.type=tcp -p wallet.p2p.public_addresses=/ip4/127.0.0.1/tcp/46733 -p wallet.p2p.transport.tcp.listener_address=/ip4/0.0.0.0/tcp/46733 -p mainnet.p2p.seeds.dns_seeds=ip4.seeds.tari.com,ip6.seeds.tari.com
```
`-p wallet.http_server_url=http://127.0.0.1:32879`

What process can a PR reviewer use to test or verify this change?
---
Same as above. Launch TU on mainnet and check if balances and transaction history is correct. 

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
