### PR TITLE
fix: remove overwriting graxil batch size

### DIFF
--- a/src-tauri/src/gpu_miner_sha.rs
+++ b/src-tauri/src/gpu_miner_sha.rs
@@ -112,11 +112,7 @@ impl GpuMinerSha {
 
         process_watcher.adapter.tari_address = Some(tari_address);
         process_watcher.adapter.worker_name = Some(telemetry_id.to_string());
-        process_watcher.adapter.batch_size = if gpu_usage_percentage.gt(&50) {
-            Some(10000)
-        } else {
-            Some(1000)
-        };
+        process_watcher.adapter.batch_size = None; // Its better to allow miner to calculate batch size dynamically
         process_watcher.adapter.intensity = Some(gpu_usage_percentage);
         info!(target: LOG_TARGET, "Starting sha miner");
         process_watcher


### PR DESCRIPTION
### [ Summary ] 
- Removed overwriting batch_size for graxil miner
- That part of code was there because when graxil calculated batch_size for top end gpu's it cause overflow on u32 which will be fixed in 1.0.5 release
