### PR TITLE
chore(ui): add block scan to wallet progress copy

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Beursie gekoppel",
   "wallet-is-scanning": "Beursie skandeer...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Beursie gekoppel",
   "wallet-is-scanning": "Beursie skandeer...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "钱包已连接",
   "wallet-is-scanning": "钱包正在扫描...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "钱包已连接",
   "wallet-is-scanning": "钱包正在扫描...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Wallet verbunden",
   "wallet-is-scanning": "Wallet wird gescannt...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Wallet verbunden",
   "wallet-is-scanning": "Wallet wird gescannt...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Wallet Connected",
   "wallet-is-scanning": "Syncing wallet...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Wallet Connected",
   "wallet-is-scanning": "Syncing wallet...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Portefeuille connecté",
   "wallet-is-scanning": "Le portefeuille est en cours de scan...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Portefeuille connecté",
   "wallet-is-scanning": "Le portefeuille est en cours de scan...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "वॉलेट कनेक्टेड",
   "wallet-is-scanning": "वॉलेट स्कैन कर रहा है...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "वॉलेट कनेक्टेड",
   "wallet-is-scanning": "वॉलेट स्कैन कर रहा है...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Dompet Terhubung",
   "wallet-is-scanning": "Dompet sedang memindai...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Dompet Terhubung",
   "wallet-is-scanning": "Dompet sedang memindai...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "ウォレット接続済み",
   "wallet-is-scanning": "ウォレットをスキャン中...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "ウォレット接続済み",
   "wallet-is-scanning": "ウォレットをスキャン中...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "지갑 연결됨",
   "wallet-is-scanning": "지갑 스캔 중...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "지갑 연결됨",
   "wallet-is-scanning": "지갑 스캔 중...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Portfel połączony",
   "wallet-is-scanning": "Portfel skanuje...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Portfel połączony",
   "wallet-is-scanning": "Portfel skanuje...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Кошелек подключен",
   "wallet-is-scanning": "Кошелек сканируется...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Кошелек подключен",
   "wallet-is-scanning": "Кошелек сканируется...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Cüzdan Bağlandı",
   "wallet-is-scanning": "Cüzdan taranıyor...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Cüzdan Bağlandı",
   "wallet-is-scanning": "Cüzdan taranıyor...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/vi/wallet.json
+++ b/public/locales/vi/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Đã kết nối ví",
   "wallet-is-scanning": "Đang đồng bộ ví...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading</strong> {{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/vi/wallet.json
+++ b/public/locales/vi/wallet.json
@@ -164,7 +164,7 @@
   "transactions": "Transactions",
   "wallet-connected": "Đã kết nối ví",
   "wallet-is-scanning": "Đang đồng bộ ví...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading{{percentage}}</strong>{{progressValue}}",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -43,7 +43,7 @@ export const WalletBalance = () => {
     const scanData = useWalletStore((s) => s.wallet_scanning);
 
     const isScanning = scanData.is_scanning;
-    const scanProgress = Math.floor(scanData.progress);
+    const scanProgress = Math.round(scanData.progress * 10) / 10;
 
     const balance = removeXTMCryptoDecimals(roundToTwoDecimals((isScanning ? cached : total) || 0));
     const balanceMismatch = removeXTMCryptoDecimals(roundToTwoDecimals(available || 0)) != balance;
@@ -57,12 +57,15 @@ export const WalletBalance = () => {
 
     const loadingMarkup = (
         <Typography>
-            <Trans>
-                {t('wallet-scanning-with-progress', {
-                    percentage: isConnected ? `${scanProgress}%` : '',
-                    progessValue: `${scanData.scanned_height}/${scanData.total_height}`,
-                })}
-            </Trans>
+            {scanData ? (
+                <Trans>
+                    {t('wallet-scanning-with-progress', {
+                        percentage: scanProgress,
+                        scanned: scanData.scanned_height,
+                        total: scanData.total_height,
+                    })}
+                </Trans>
+            ) : null}
             {!isConnected && (
                 <>
                     <SyncCountdown

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -58,7 +58,10 @@ export const WalletBalance = () => {
     const loadingMarkup = (
         <Typography>
             <Trans>
-                {t('wallet-scanning-with-progress', { progressValue: isConnected ? `${scanProgress}%` : '' })}
+                {t('wallet-scanning-with-progress', {
+                    percentage: isConnected ? `${scanProgress}%` : '',
+                    progessValue: `${scanData.scanned_height}/${scanData.total_height}`,
+                })}
             </Trans>
             {!isConnected && (
                 <>


### PR DESCRIPTION
Description
---

- updated the `wallet-scanning-with-progress` copy to include the block sync progress (again:D)
- fixed the rounding on the percentage (to include 1 decimal)

Motivation and Context
---
- better feedback that something _is_ happening, since wallet scanning could potentially take a long time

How Has This Been Tested?
---
- locally:

https://github.com/user-attachments/assets/12b38160-0025-49e0-9c9c-09cff8d24e0f

