### PR TITLE
Fix/wallet sync section

### DIFF
--- a/public/locales/af/wallet.json
+++ b/public/locales/af/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Beursie gekoppel",
-  "wallet-is-scanning": "Beursie skandeer...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/cn/wallet.json
+++ b/public/locales/cn/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "钱包已连接",
-  "wallet-is-scanning": "钱包正在扫描...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/de/wallet.json
+++ b/public/locales/de/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Wallet verbunden",
-  "wallet-is-scanning": "Wallet wird gescannt...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/en/wallet.json
+++ b/public/locales/en/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Wallet Connected",
-  "wallet-is-scanning": "Syncing wallet...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/fr/wallet.json
+++ b/public/locales/fr/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Portefeuille connecté",
-  "wallet-is-scanning": "Le portefeuille est en cours de scan...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/hi/wallet.json
+++ b/public/locales/hi/wallet.json
@@ -163,8 +163,8 @@
   "tari": "तारी",
   "transactions": "Transactions",
   "wallet-connected": "वॉलेट कनेक्टेड",
-  "wallet-is-scanning": "वॉलेट स्कैन कर रहा है...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/id/wallet.json
+++ b/public/locales/id/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Dompet Terhubung",
-  "wallet-is-scanning": "Dompet sedang memindai...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ja/wallet.json
+++ b/public/locales/ja/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "ウォレット接続済み",
-  "wallet-is-scanning": "ウォレットをスキャン中...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ko/wallet.json
+++ b/public/locales/ko/wallet.json
@@ -163,8 +163,8 @@
   "tari": "타리",
   "transactions": "Transactions",
   "wallet-connected": "지갑 연결됨",
-  "wallet-is-scanning": "지갑 스캔 중...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/pl/wallet.json
+++ b/public/locales/pl/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Portfel połączony",
-  "wallet-is-scanning": "Portfel skanuje...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/ru/wallet.json
+++ b/public/locales/ru/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Кошелек подключен",
-  "wallet-is-scanning": "Кошелек сканируется...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/tr/wallet.json
+++ b/public/locales/tr/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Cüzdan Bağlandı",
-  "wallet-is-scanning": "Cüzdan taranıyor...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/public/locales/vi/wallet.json
+++ b/public/locales/vi/wallet.json
@@ -163,8 +163,8 @@
   "tari": "Tari",
   "transactions": "Transactions",
   "wallet-connected": "Đã kết nối ví",
-  "wallet-is-scanning": "Đang đồng bộ ví...",
-  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> ({{scanned}}/{{total}})",
+  "wallet-is-scanning": "<strong>Wallet is loading...</strong>",
+  "wallet-scanning-with-progress": "<strong>Wallet is loading {{percentage}}%</strong> {{scanned}} / {{total}}",
   "xc": {
     "buy-tari": "Buy Tari from an exchange",
     "buy-tari-subtitle": "Available on selected exchanges.",

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -59,11 +59,13 @@ export const WalletBalance = () => {
         <Typography>
             {scanData ? (
                 <Trans>
-                    {t('wallet-scanning-with-progress', {
-                        percentage: scanProgress,
-                        scanned: scanData.scanned_height,
-                        total: scanData.total_height,
-                    })}
+                    {scanProgress < 100
+                        ? t('wallet-scanning-with-progress', {
+                              percentage: scanProgress,
+                              scanned: scanData.scanned_height,
+                              total: scanData.total_height,
+                          })
+                        : t('wallet-is-scanning')}
                 </Trans>
             ) : null}
             {!isConnected && (
@@ -83,7 +85,7 @@ export const WalletBalance = () => {
 
     const progressMarkup = isLoading && (
         <ScanProgressWrapper>
-            <Progress percentage={scanProgress} isInfinite={!isConnected} />
+            <Progress percentage={scanProgress} isInfinite={!isConnected || scanProgress === 100} />
         </ScanProgressWrapper>
     );
 

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { IoEyeOffOutline, IoEyeOutline } from 'react-icons/io5';
 import { useConfigWalletStore, useMiningMetricsStore, useUIStore, useWalletStore } from '@app/store';
 
-import { roundToTwoDecimals, removeXTMCryptoDecimals, formatNumber, FormatPreset } from '@app/utils';
+import { roundToTwoDecimals, removeXTMCryptoDecimals, formatNumber, FormatPreset, formatValue } from '@app/utils';
 import { Typography } from '@app/components/elements/Typography.tsx';
 
 import {
@@ -15,6 +15,7 @@ import {
     ScanProgressWrapper,
     SuffixWrapper,
     Wrapper,
+    LoadingText,
 } from './styles.ts';
 import { toggleHideWalletBalance } from '@app/store/actions/uiStoreActions.ts';
 import { useState } from 'react';
@@ -56,14 +57,14 @@ export const WalletBalance = () => {
         : t('history.my-balance');
 
     const loadingMarkup = (
-        <Typography>
+        <LoadingText>
             {scanData ? (
                 <Trans>
                     {scanProgress < 100
                         ? t('wallet-scanning-with-progress', {
                               percentage: scanProgress,
-                              scanned: scanData.scanned_height,
-                              total: scanData.total_height,
+                              scanned: formatValue(scanData.scanned_height),
+                              total: formatValue(scanData.total_height),
                           })
                         : t('wallet-is-scanning')}
                 </Trans>
@@ -78,7 +79,7 @@ export const WalletBalance = () => {
                     {isStarted && !isComplete && t('sync-message.line2')}
                 </>
             )}
-        </Typography>
+        </LoadingText>
     );
 
     const bottomMarkup = !isLoading ? <Typography>{balanceText}</Typography> : loadingMarkup;

--- a/src/components/wallet/components/balance/styles.ts
+++ b/src/components/wallet/components/balance/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Typography } from '@app/components/elements/Typography.tsx';
 
 export const Wrapper = styled.div`
     display: flex;
@@ -46,14 +47,22 @@ export const BottomWrapper = styled.div`
     font-weight: 500;
     gap: 4px;
     color: rgba(255, 255, 255, 0.7);
-
-    strong {
-        color: #fff;
-    }
 `;
 
 export const ScanProgressWrapper = styled.div`
     position: absolute;
     bottom: 0;
     right: 0;
+`;
+
+export const LoadingText = styled(Typography)`
+    font-weight: 500;
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: -0.21px;
+    strong {
+        font-weight: 500;
+        color: #fff;
+        margin-right: 4px;
+    }
 `;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -179,4 +179,4 @@ export const formatCountdown = (targetDate: string): string => {
     return `${days}D ${hours}H ${minutes}M`;
 };
 
-export { formatDecimalCompact, roundToTwoDecimals, removeDecimals, removeXTMCryptoDecimals };
+export { formatDecimalCompact, roundToTwoDecimals, removeDecimals, removeXTMCryptoDecimals, formatValue };


### PR DESCRIPTION
Description
---

- adjust the font styling and formatting to better suit the new designs
- update copy for the `Wallet is loading` text - sans progress - so we can hide the percentage once completed/node sync time is there 

Motivation and Context
---

- @stringhandler  experienced this _not-so-aesthetic_ state:

<img width="338" height="45" alt="image" src="https://github.com/user-attachments/assets/e4d1375a-a728-47cc-a484-f1341e25b4ce" />


How Has This Been Tested?
---

<img width="514" height="280" alt="image" src="https://github.com/user-attachments/assets/3cb55376-fea9-4ebc-83c4-f0ebc20be4dd" />
