### PR TITLE
chore: bump tauri deps and clean install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: cargo tauri build
         working-directory: ./src-tauri
         run: |
-          cargo install tauri-cli --version "2.4.0" --locked
+          cargo install tauri-cli
           cargo tauri --version
           cargo tauri build --ci --no-bundle
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tari-universe",
-    "version": "1.2.21",
+    "version": "1.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tari-universe",
-            "version": "1.2.21",
+            "version": "1.5.1",
             "dependencies": {
                 "@floating-ui/react": "^0.27.13",
                 "@lottiefiles/dotlottie-react": "^0.13.5",
@@ -42,7 +42,7 @@
                 "@eslint/js": "^9.9.0",
                 "@nabla/vite-plugin-eslint": "^2.0.5",
                 "@taplo/cli": "^0.7.0",
-                "@tauri-apps/cli": "^2.7.0",
+                "@tauri-apps/cli": "^2.7.1",
                 "@types/node": "^24.0.15",
                 "@types/react": "^19.1.8",
                 "@types/react-dom": "^19.1.6",
@@ -378,14 +378,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/types": "^7.28.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -491,9 +491,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+            "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -534,9 +534,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.1",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-            "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1210,9 +1210,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.31.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
-            "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1266,9 +1266,9 @@
             }
         },
         "node_modules/@floating-ui/react": {
-            "version": "0.27.13",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.13.tgz",
-            "integrity": "sha512-Qmj6t9TjgWAvbygNEu1hj4dbHI9CY0ziCMIJrmYoDIn9TUAH5lRmiIeZmRd4c6QEZkzdoH7jNnoNyoY1AIESiA==",
+            "version": "0.27.14",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.14.tgz",
+            "integrity": "sha512-aSf9JXfyXpRQWMbtuW+CJQrnhzHu4Hg1Th9AkvR1o+wSW/vCUVMrtgXaRY5ToV5Fh5w3I7lXJdvlKVvYrQrppw==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/react-dom": "^2.1.4",
@@ -1423,9 +1423,9 @@
             "license": "MIT"
         },
         "node_modules/@nabla/vite-plugin-eslint": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nabla/vite-plugin-eslint/-/vite-plugin-eslint-2.0.5.tgz",
-            "integrity": "sha512-m6Q8ZVM0ASZfYyfFbG661mDklhZQZEeBMQgtB26NhdadxPSctHzHsUbF87msdSb0V4Z8R1p/vRkB5SHNOpANAQ==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@nabla/vite-plugin-eslint/-/vite-plugin-eslint-2.0.6.tgz",
+            "integrity": "sha512-QQZwq7aTx2WtG2/c2ASF+amNAytbLY8LYYc71bECIMzRr7Y7Cx3o6oAQrcb1qQbq2+z2S2rq7i7o5LTskQi8sA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1435,7 +1435,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.45 || ^9",
-                "vite": "^4 || ^5 || ^6"
+                "vite": "^4 || ^5 || ^6 || ^7"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -1793,9 +1793,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-            "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.1.tgz",
+            "integrity": "sha512-oENme6QxtLCqjChRUUo3S6X8hjCXnWmJWnedD7VbGML5GUtaOtAyx+fEEXnBXVf0CBZApMQU0Idwi0FmyxzQhw==",
             "cpu": [
                 "arm"
             ],
@@ -1807,9 +1807,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-            "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.1.tgz",
+            "integrity": "sha512-OikvNT3qYTl9+4qQ9Bpn6+XHM+ogtFadRLuT2EXiFQMiNkXFLQfNVppi5o28wvYdHL2s3fM0D/MZJ8UkNFZWsw==",
             "cpu": [
                 "arm64"
             ],
@@ -1821,9 +1821,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-            "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.1.tgz",
+            "integrity": "sha512-EFYNNGij2WllnzljQDQnlFTXzSJw87cpAs4TVBAWLdkvic5Uh5tISrIL6NRcxoh/b2EFBG/TK8hgRrGx94zD4A==",
             "cpu": [
                 "arm64"
             ],
@@ -1835,9 +1835,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-            "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.1.tgz",
+            "integrity": "sha512-ZaNH06O1KeTug9WI2+GRBE5Ujt9kZw4a1+OIwnBHal92I8PxSsl5KpsrPvthRynkhMck4XPdvY0z26Cym/b7oA==",
             "cpu": [
                 "x64"
             ],
@@ -1849,9 +1849,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-            "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.1.tgz",
+            "integrity": "sha512-n4SLVebZP8uUlJ2r04+g2U/xFeiQlw09Me5UFqny8HGbARl503LNH5CqFTb5U5jNxTouhRjai6qPT0CR5c/Iig==",
             "cpu": [
                 "arm64"
             ],
@@ -1863,9 +1863,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-            "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.1.tgz",
+            "integrity": "sha512-8vu9c02F16heTqpvo3yeiu7Vi1REDEC/yES/dIfq3tSXe6mLndiwvYr3AAvd1tMNUqE9yeGYa5w7PRbI5QUV+w==",
             "cpu": [
                 "x64"
             ],
@@ -1877,9 +1877,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-            "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.1.tgz",
+            "integrity": "sha512-K4ncpWl7sQuyp6rWiGUvb6Q18ba8mzM0rjWJ5JgYKlIXAau1db7hZnR0ldJvqKWWJDxqzSLwGUhA4jp+KqgDtQ==",
             "cpu": [
                 "arm"
             ],
@@ -1891,9 +1891,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-            "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.1.tgz",
+            "integrity": "sha512-YykPnXsjUjmXE6j6k2QBBGAn1YsJUix7pYaPLK3RVE0bQL2jfdbfykPxfF8AgBlqtYbfEnYHmLXNa6QETjdOjQ==",
             "cpu": [
                 "arm"
             ],
@@ -1905,9 +1905,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-            "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.1.tgz",
+            "integrity": "sha512-kKvqBGbZ8i9pCGW3a1FH3HNIVg49dXXTsChGFsHGXQaVJPLA4f/O+XmTxfklhccxdF5FefUn2hvkoGJH0ScWOA==",
             "cpu": [
                 "arm64"
             ],
@@ -1919,9 +1919,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-            "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.1.tgz",
+            "integrity": "sha512-zzX5nTw1N1plmqC9RGC9vZHFuiM7ZP7oSWQGqpbmfjK7p947D518cVK1/MQudsBdcD84t6k70WNczJOct6+hdg==",
             "cpu": [
                 "arm64"
             ],
@@ -1933,9 +1933,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-            "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.1.tgz",
+            "integrity": "sha512-O8CwgSBo6ewPpktFfSDgB6SJN9XDcPSvuwxfejiddbIC/hn9Tg6Ai0f0eYDf3XvB/+PIWzOQL+7+TZoB8p9Yuw==",
             "cpu": [
                 "loong64"
             ],
@@ -1946,10 +1946,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-            "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.1.tgz",
+            "integrity": "sha512-JnCfFVEKeq6G3h3z8e60kAp8Rd7QVnWCtPm7cxx+5OtP80g/3nmPtfdCXbVl063e3KsRnGSKDHUQMydmzc/wBA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1961,9 +1961,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-            "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.1.tgz",
+            "integrity": "sha512-dVxuDqS237eQXkbYzQQfdf/njgeNw6LZuVyEdUaWwRpKHhsLI+y4H/NJV8xJGU19vnOJCVwaBFgr936FHOnJsQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1975,9 +1975,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-            "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.1.tgz",
+            "integrity": "sha512-CvvgNl2hrZrTR9jXK1ye0Go0HQRT6ohQdDfWR47/KFKiLd5oN5T14jRdUVGF4tnsN8y9oSfMOqH6RuHh+ck8+w==",
             "cpu": [
                 "riscv64"
             ],
@@ -1989,9 +1989,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-            "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.1.tgz",
+            "integrity": "sha512-x7ANt2VOg2565oGHJ6rIuuAon+A8sfe1IeUx25IKqi49OjSr/K3awoNqr9gCwGEJo9OuXlOn+H2p1VJKx1psxA==",
             "cpu": [
                 "s390x"
             ],
@@ -2003,9 +2003,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-            "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.1.tgz",
+            "integrity": "sha512-9OADZYryz/7E8/qt0vnaHQgmia2Y0wrjSSn1V/uL+zw/i7NUhxbX4cHXdEQ7dnJgzYDS81d8+tf6nbIdRFZQoQ==",
             "cpu": [
                 "x64"
             ],
@@ -2017,9 +2017,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-            "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.1.tgz",
+            "integrity": "sha512-NuvSCbXEKY+NGWHyivzbjSVJi68Xfq1VnIvGmsuXs6TCtveeoDRKutI5vf2ntmNnVq64Q4zInet0UDQ+yMB6tA==",
             "cpu": [
                 "x64"
             ],
@@ -2031,9 +2031,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-            "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.1.tgz",
+            "integrity": "sha512-mWz+6FSRb82xuUMMV1X3NGiaPFqbLN9aIueHleTZCc46cJvwTlvIh7reQLk4p97dv0nddyewBhwzryBHH7wtPw==",
             "cpu": [
                 "arm64"
             ],
@@ -2045,9 +2045,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-            "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.1.tgz",
+            "integrity": "sha512-7Thzy9TMXDw9AU4f4vsLNBxh7/VOKuXi73VH3d/kHGr0tZ3x/ewgL9uC7ojUKmH1/zvmZe2tLapYcZllk3SO8Q==",
             "cpu": [
                 "ia32"
             ],
@@ -2059,9 +2059,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-            "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.1.tgz",
+            "integrity": "sha512-7GVB4luhFmGUNXXJhH2jJwZCFB3pIOixv2E3s17GQHBFUOQaISlt7aGcQgqvCaDSxTZJUzlK/QJ1FN8S94MrzQ==",
             "cpu": [
                 "x64"
             ],
@@ -2109,9 +2109,9 @@
             }
         },
         "node_modules/@tari-project/tari-tower": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@tari-project/tari-tower/-/tari-tower-0.1.0.tgz",
-            "integrity": "sha512-pW7W+M7/2Jaas9RMFFIb93HEF/1HVpfHhjvRj5DQ+UFQe8DsG8HIZiwuOoYH8ExaM90LWBQ4XbByjtzNe4ZUxQ==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@tari-project/tari-tower/-/tari-tower-0.1.1.tgz",
+            "integrity": "sha512-dRlSoNOxqi7UwsWL1IgyxiSyn5538pkLnr2/hAo7tN4Hf5ZImB1rZGHC0g9+hSRsA0gf7yjOVsaI9ymT/Aptyg==",
             "license": "ISC",
             "peerDependencies": {
                 "min-signal": "^1.0.2",
@@ -3563,9 +3563,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.190",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
-            "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
+            "version": "1.5.191",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
+            "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
             "dev": true,
             "license": "ISC"
         },
@@ -3818,9 +3818,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.31.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
-            "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
+            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3830,8 +3830,8 @@
                 "@eslint/config-helpers": "^0.3.0",
                 "@eslint/core": "^0.15.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.31.0",
-                "@eslint/plugin-kit": "^0.3.1",
+                "@eslint/js": "9.32.0",
+                "@eslint/plugin-kit": "^0.3.4",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -4363,12 +4363,12 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.23.6",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.6.tgz",
-            "integrity": "sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==",
+            "version": "12.23.11",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.11.tgz",
+            "integrity": "sha512-VzNi+exyI3bn7Pzvz1Fjap1VO9gQu8mxrsSsNamMidsZ8AA8W2kQsR+YQOciEUbMtkKAWIbPHPttfn5e9jqqJQ==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.23.6",
+                "motion-dom": "^12.23.9",
                 "motion-utils": "^12.23.6",
                 "tslib": "^2.4.0"
             },
@@ -5344,9 +5344,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+            "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6265,12 +6265,12 @@
             }
         },
         "node_modules/motion": {
-            "version": "12.23.6",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.6.tgz",
-            "integrity": "sha512-6U55IW5i6Vut2ryKEhrZKg55490k9d6qdGXZoNSf98oQgDj5D7bqTnVJotQ6UW3AS6QfbW6KSLa7/e1gy+a07g==",
+            "version": "12.23.11",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.11.tgz",
+            "integrity": "sha512-AHv/2SivIz9fjvND8wwN2LldDTuwkPyTSWecAY/xzB1/2eF7zxvh9JRkf8aF4eGoGsy1e2YKp+CQC5yxcssnEw==",
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^12.23.6",
+                "framer-motion": "^12.23.11",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -6291,9 +6291,9 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.23.6",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.6.tgz",
-            "integrity": "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==",
+            "version": "12.23.9",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
+            "integrity": "sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==",
             "license": "MIT",
             "dependencies": {
                 "motion-utils": "^12.23.6"
@@ -6859,9 +6859,9 @@
             }
         },
         "node_modules/react-hook-form": {
-            "version": "7.60.0",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
-            "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+            "version": "7.61.1",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+            "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -7109,9 +7109,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.45.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-            "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+            "version": "4.46.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.1.tgz",
+            "integrity": "sha512-33xGNBsDJAkzt0PvninskHlWnTIPgDtTwhg0U38CUoNP/7H6wI2Cz6dUeoNPbjdTdsYTGuiFFASuUOWovH0SyQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -7125,26 +7125,26 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.45.1",
-                "@rollup/rollup-android-arm64": "4.45.1",
-                "@rollup/rollup-darwin-arm64": "4.45.1",
-                "@rollup/rollup-darwin-x64": "4.45.1",
-                "@rollup/rollup-freebsd-arm64": "4.45.1",
-                "@rollup/rollup-freebsd-x64": "4.45.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-                "@rollup/rollup-linux-arm64-musl": "4.45.1",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-                "@rollup/rollup-linux-x64-gnu": "4.45.1",
-                "@rollup/rollup-linux-x64-musl": "4.45.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-                "@rollup/rollup-win32-x64-msvc": "4.45.1",
+                "@rollup/rollup-android-arm-eabi": "4.46.1",
+                "@rollup/rollup-android-arm64": "4.46.1",
+                "@rollup/rollup-darwin-arm64": "4.46.1",
+                "@rollup/rollup-darwin-x64": "4.46.1",
+                "@rollup/rollup-freebsd-arm64": "4.46.1",
+                "@rollup/rollup-freebsd-x64": "4.46.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.46.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.46.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.46.1",
+                "@rollup/rollup-linux-arm64-musl": "4.46.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.46.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.46.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.46.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.46.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.46.1",
+                "@rollup/rollup-linux-x64-gnu": "4.46.1",
+                "@rollup/rollup-linux-x64-musl": "4.46.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.46.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.46.1",
+                "@rollup/rollup-win32-x64-msvc": "4.46.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -8127,9 +8127,9 @@
             }
         },
         "node_modules/vfile-message": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-            "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+            "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@eslint/js": "^9.9.0",
         "@nabla/vite-plugin-eslint": "^2.0.5",
         "@taplo/cli": "^0.7.0",
-        "@tauri-apps/cli": "^2.7.0",
+        "@tauri-apps/cli": "^2.7.1",
         "@types/node": "^24.0.15",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8701,9 +8701,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "2.6.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124e129c9c0faa6bec792c5948c89e86c90094133b0b9044df0ce5f0a8efaa0d"
+checksum = "352a4bc7bf6c25f5624227e3641adf475a6535707451b09bb83271df8b7a6ac7"
 dependencies = [
  "anyhow",
  "bytes 1.10.1",
@@ -8754,9 +8754,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f025c389d3adb83114bec704da973142e82fc6ec799c7c750c5e21cefaec83"
+checksum = "182d688496c06bf08ea896459bf483eb29cdff35c1c4c115fb14053514303064"
 dependencies = [
  "anyhow",
  "cargo_toml 0.22.1",
@@ -8777,9 +8777,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df493a1075a241065bc865ed5ef8d0fbc1e76c7afdc0bf0eccfaa7d4f0e406"
+checksum = "b54a99a6cd8e01abcfa61508177e6096a4fe2681efecee9214e962f2f073ae4a"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -8804,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f237fbea5866fa5f2a60a21bea807a2d6e0379db070d89c3a10ac0f2d4649bbc"
+checksum = "7945b14dc45e23532f2ded6e120170bbdd4af5ceaa45784a6b33d250fbce3f9e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -8865,9 +8865,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c341290d31991dbca38b31d412c73dfbdb070bb11536784f19dd2211d13b778f"
+checksum = "8c6ef84ee2f2094ce093e55106d90d763ba343fad57566992962e8f76d113f99"
 dependencies = [
  "anyhow",
  "dunce",
@@ -8887,9 +8887,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-http"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c1a38da944b357ffa23bafd563b1579f18e6fbd118fcd84769406d35dcc5c7"
+checksum = "fcde333d97e565a7765aad82f32d8672458f7bd77b6ee653830d5dded9d7b5c2"
 dependencies = [
  "bytes 1.10.1",
  "cookie_store",
@@ -8976,9 +8976,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b441b6d5d1a194e9fee0b358fe0d602ded845d0f580e1f8c8ef78ebc3c8b225d"
+checksum = "50a0e5a4ce43cb3a733c3aef85e8478bc769dac743c615e26639cbf5d953faf7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8986,7 +8986,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "windows-sys 0.60.2",
- "zbus 5.8.0",
+ "zbus 5.9.0",
 ]
 
 [[package]]
@@ -9023,9 +9023,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7bb73d1bceac06c20b3f755b2c8a2cb13b20b50083084a8cf3700daf397ba4"
+checksum = "2b1cc885be806ea15ff7b0eb47098a7b16323d9228876afda329e34e2d6c4676"
 dependencies = [
  "cookie",
  "dpi",
@@ -9045,9 +9045,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902b5aa9035e16f342eb64f8bf06ccdc2808e411a2525ed1d07672fa4e780bad"
+checksum = "fe653a2fbbef19fe898efc774bc52c8742576342a33d3d028c189b57eb1d2439"
 dependencies = [
  "gtk",
  "http",
@@ -9072,9 +9072,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41743bbbeb96c3a100d234e5a0b60a46d5aa068f266160862c7afdbf828ca02e"
+checksum = "9330c15cabfe1d9f213478c9e8ec2b0c76dab26bb6f314b8ad1c8a568c1d186e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9082,7 +9082,7 @@ dependencies = [
  "cargo_metadata",
  "ctor",
  "dunce",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "glob",
  "html5ever",
  "http",
@@ -11282,9 +11282,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast 0.7.2",
  "async-executor",
@@ -11308,7 +11308,7 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.59.0",
  "winnow 0.7.11",
- "zbus_macros 5.8.0",
+ "zbus_macros 5.9.0",
  "zbus_names 4.2.0",
  "zvariant 5.6.0",
 ]
@@ -11328,9 +11328,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.8.0"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,17 +4,19 @@ import { createRoot } from 'react-dom/client';
 const AppWrapper = lazy(() => import('./App/AppWrapper.tsx'));
 
 const rootEl = document.getElementById('root');
-const options = {
-    onUncaughtError: (error, errorInfo) => {
-        console.error('Uncaught error: ', error, errorInfo);
-    },
-    onCaughtError: (error, errorInfo) => {
-        console.error('Caught error: ', error, errorInfo);
-    },
-};
 
 if (rootEl) {
-    const root = createRoot(rootEl, options);
+    const root = createRoot(rootEl, {
+        onUncaughtError: (error, errorInfo) => {
+            console.error('Uncaught error: ', error, errorInfo);
+        },
+        onCaughtError: (error, errorInfo) => {
+            console.error('Caught error: ', error, errorInfo);
+        },
+        onRecoverableError: (error, errorInfo) => {
+            console.error('RecoverableError error: ', error, errorInfo);
+        },
+    });
     root.render(
         <StrictMode>
             <Suspense fallback={<div />}>


### PR DESCRIPTION
Description
---

this is a continuation of https://github.com/tari-project/universe/pull/2494 and a replacement for https://github.com/tari-project/universe/pull/2490 which i just closed because i got carried away with unrelated changes

- bump tauri's cargo packages 
- bump tauri's npm packages (only cli was behind)
- update the CI workflow so `tauri-cli` is not locked any more (was quite far behind - 2.4.0 vs latest 2.7.1)
- added `onRecoverableError` logging in main too 

Motivation and Context
---

- initially the motivation was just to get rid of last console error WRT tauri events but can't be sure this solves it ... so:
- keep up to date on tauri changes and bug fixes 

How Has This Been Tested?
---

- locally, **BUT** when i tried to get a video with the last remaining listener (console) error on `main` for comparison - it wasn't happening 😅 though it did happen earlier today, so i know it was still there. this makes me think i can't confirm 100% that it's not going to still crop up even with these updates 
