### PR TITLE
fix(ui): set tower initialized flag on visual mode toggle

### DIFF
--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -34,10 +34,12 @@ async function initializeAnimation() {
         try {
             await loadTowerAnimation({ canvasId: TOWER_CANVAS_ID, offset: offset });
             useUIStore.setState({ towerInitalized: true });
+
             loaded = true;
         } catch (error) {
             console.error('Failed to set animation state:', error);
             useUIStore.setState({ towerInitalized: false });
+
             loaded = false;
         } finally {
             if (loaded) {

--- a/src/store/actions/uiStoreActions.ts
+++ b/src/store/actions/uiStoreActions.ts
@@ -35,16 +35,19 @@ async function loadAnimation() {
 
     try {
         await loadTowerAnimation({ canvasId: TOWER_CANVAS_ID, offset: towerSidebarOffset });
+        useUIStore.setState((c) => ({ ...c, towerInitalized: true }));
         if (setupComplete) {
             setAnimationState('showVisual');
         }
     } catch (e) {
         console.error('Could not enable visual mode. Error at loadTowerAnimation:', e);
+        useUIStore.setState((c) => ({ ...c, towerInitalized: false }));
     }
 }
 async function removeAnimation() {
     try {
         await removeTowerAnimation({ canvasId: TOWER_CANVAS_ID });
+        useUIStore.setState((c) => ({ ...c, towerInitalized: false }));
         // Force garbage collection to clean up WebGL context
         if (window.gc) {
             window.gc();


### PR DESCRIPTION
Description
---

- just added switching that flag in the visual mode toggle action too

Motivation and Context
---

added a check for `towerInitialized` in `useMiningUiStateMachine` (in https://github.com/tari-project/universe/pull/2612) but forgot to set that value in the visual mode toggle actions 😬 so if you toggled VM off, then back on, the mining state would have no affect on the animation 

How Has This Been Tested?
---

- locally:

https://github.com/user-attachments/assets/b2ba7576-f349-4bf9-8cbc-7432756aa078


