### PR TITLE
fix(ui): exchange miner loading text

### DIFF
--- a/src/components/sync/Sync.tsx
+++ b/src/components/sync/Sync.tsx
@@ -16,20 +16,28 @@ export function Sync() {
 
     const generalSyncMarkup =
         showSync && !!currentPhaseToShow ? (
-            <Wrapper>
-                <TextWrapper>
-                    {setupPhaseTitle ? <Title>{t(`phase-title.${setupPhaseTitle}`)}</Title> : null}
-                    {setupTitle ? <Text>{t(`title.${setupTitle}`, { ...setupParams })}</Text> : null}
-                </TextWrapper>
-                <ProgressWrapper>
-                    <Title>
-                        {stageProgress} / {stageTotal}
-                    </Title>
-                    <CircularProgress />
-                </ProgressWrapper>
-            </Wrapper>
+            <SettingsGroupWrapper>
+                <Wrapper>
+                    <TextWrapper>
+                        {setupPhaseTitle ? <Title>{t(`phase-title.${setupPhaseTitle}`)}</Title> : null}
+                        {setupTitle ? <Text>{t(`title.${setupTitle}`, { ...setupParams })}</Text> : null}
+                    </TextWrapper>
+                    <ProgressWrapper>
+                        <Title>
+                            {stageProgress} / {stageTotal}
+                        </Title>
+                        <CircularProgress />
+                    </ProgressWrapper>
+                </Wrapper>
+            </SettingsGroupWrapper>
         ) : null;
 
-    const syncMarkup = isRemoteUntilLocal ? <LocalNode /> : generalSyncMarkup;
-    return showSync || isRemoteUntilLocal ? <SettingsGroupWrapper>{syncMarkup}</SettingsGroupWrapper> : null;
+    const syncMarkup = isRemoteUntilLocal ? (
+        <SettingsGroupWrapper>
+            <LocalNode />
+        </SettingsGroupWrapper>
+    ) : (
+        generalSyncMarkup
+    );
+    return showSync || isRemoteUntilLocal ? syncMarkup : null;
 }

--- a/src/containers/navigation/components/MiningTiles/MiningTiles.tsx
+++ b/src/containers/navigation/components/MiningTiles/MiningTiles.tsx
@@ -3,15 +3,17 @@ import CPUTile from './CPU.tsx';
 import GPUTile from './GPU.tsx';
 
 import { TopRow, Wrapper } from './styles';
+import { useConfigBEInMemoryStore } from '@app/store';
 
 export default function MiningTiles() {
+    const isExchangeSpecific = useConfigBEInMemoryStore((s) => s.exchangeId !== 'universal');
     return (
         <Wrapper>
             <TopRow>
                 <CPUTile />
                 <GPUTile />
             </TopRow>
-            <ExchangeButton />
+            {!isExchangeSpecific && <ExchangeButton />}
         </Wrapper>
     );
 }

--- a/src/containers/navigation/components/MiningTiles/components/SyncData/SyncData.tsx
+++ b/src/containers/navigation/components/MiningTiles/components/SyncData/SyncData.tsx
@@ -20,7 +20,7 @@ export default function SyncData() {
                     />
                     {isStarted && !isComplete && t('wallet:sync-message.line2')}
                 </CountdownText>
-                <Label>{t(`phase-title.${setupPhaseTitle}`, { context: 'compact' })}</Label>
+                {setupPhaseTitle && <Label>{t(`phase-title.${setupPhaseTitle}`, { context: 'compact' })}</Label>}
             </TextWrapper>
         </Wrapper>
     );


### PR DESCRIPTION
Description
---

- hide second line for Sync details if no `setupPhaseTitle` 
- hide `Mine directly to an exchange` CTA if on exchange specific miner
- small settings style change so there's no big gap from `SettingsGroupWrapper`'s padding when syncing isn't displayed yet

Motivation and Context
---

<img width="730" height="176" alt="optimised_30-07_12-07_909" src="https://github.com/user-attachments/assets/d075add5-0f31-4d81-8aad-68ab6db008b7" />


How Has This Been Tested?
---

- locally:

<img width="916" height="1300" alt="optimised_30-07_12-07_910" src="https://github.com/user-attachments/assets/e7b40ef3-dab6-4c56-bf1b-b76e4074f091" />

