### PR TITLE
fix: move mmproxy and wallet download to the begining of node phase

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -190,14 +190,11 @@ impl BinaryManager {
                 )
             })?;
 
-        info!(target: LOG_TARGET, "Checksum file downloaded to: {checksum_file:?}");
-
         let expected_checksum = self
             .adapter
             .get_expected_checksum(checksum_file.clone(), &download_info.name)
             .await?;
 
-        info!(target: LOG_TARGET, "Expected checksum: {expected_checksum:?}");
         info!(target: LOG_TARGET, "In-progress file zip path: {in_progress_file_zip:?}");
 
         // Debug: Check if the file actually exists before attempting validation
@@ -208,8 +205,6 @@ impl BinaryManager {
                 in_progress_file_zip
             ));
         }
-
-        info!(target: LOG_TARGET, "Archive file exists, proceeding with checksum validation");
 
         match validate_checksum(in_progress_file_zip.clone(), expected_checksum).await {
             Ok(is_valid_checksum) => {

--- a/src-tauri/src/progress_trackers/progress_plans.rs
+++ b/src-tauri/src/progress_trackers/progress_plans.rs
@@ -97,6 +97,8 @@ impl ProgressStep for ProgressSetupCorePlan {
 pub enum ProgressSetupNodePlan {
     BinariesTor,
     BinariesNode,
+    BinariesWallet,
+    BinariesMergeMiningProxy,
     StartTor,
     MigratingDatabase,
     StartingNode,
@@ -117,6 +119,8 @@ impl ProgressStep for ProgressSetupNodePlan {
         match self {
             ProgressSetupNodePlan::BinariesTor => 1,
             ProgressSetupNodePlan::BinariesNode => 1,
+            ProgressSetupNodePlan::BinariesWallet => 1,
+            ProgressSetupNodePlan::BinariesMergeMiningProxy => 1,
             ProgressSetupNodePlan::StartTor => 1,
             ProgressSetupNodePlan::MigratingDatabase => 1,
             ProgressSetupNodePlan::StartingNode => 1,
@@ -131,6 +135,10 @@ impl ProgressStep for ProgressSetupNodePlan {
         match self {
             ProgressSetupNodePlan::BinariesTor => "binaries-tor".to_string(),
             ProgressSetupNodePlan::BinariesNode => "binaries-node".to_string(),
+            ProgressSetupNodePlan::BinariesWallet => "binaries-wallet".to_string(),
+            ProgressSetupNodePlan::BinariesMergeMiningProxy => {
+                "binaries-merge-mining-proxy".to_string()
+            }
             ProgressSetupNodePlan::StartTor => "start-tor".to_string(),
             ProgressSetupNodePlan::MigratingDatabase => "migrating-database".to_string(),
             ProgressSetupNodePlan::StartingNode => "starting-node".to_string(),
@@ -192,7 +200,6 @@ impl ProgressStep for ProgressSetupHardwarePlan {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum ProgressSetupWalletPlan {
-    BinariesWallet,
     StartWallet,
     SetupBridge,
     Done,
@@ -207,7 +214,6 @@ impl ProgressStep for ProgressSetupWalletPlan {
 
     fn get_progress_weight(&self) -> u8 {
         match self {
-            ProgressSetupWalletPlan::BinariesWallet => 2,
             ProgressSetupWalletPlan::StartWallet => 1,
             ProgressSetupWalletPlan::SetupBridge => 1,
             ProgressSetupWalletPlan::Done => 1,
@@ -216,7 +222,6 @@ impl ProgressStep for ProgressSetupWalletPlan {
 
     fn get_title(&self) -> String {
         match self {
-            ProgressSetupWalletPlan::BinariesWallet => "binaries-wallet".to_string(),
             ProgressSetupWalletPlan::StartWallet => "start-wallet".to_string(),
 
             ProgressSetupWalletPlan::SetupBridge => "setup-bridge".to_string(),
@@ -234,7 +239,6 @@ impl ProgressStep for ProgressSetupWalletPlan {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum ProgressSetupMiningPlan {
-    BinariesMergeMiningProxy,
     MMProxy,
     Done,
 }
@@ -248,7 +252,6 @@ impl ProgressStep for ProgressSetupMiningPlan {
 
     fn get_progress_weight(&self) -> u8 {
         match self {
-            ProgressSetupMiningPlan::BinariesMergeMiningProxy => 2,
             ProgressSetupMiningPlan::MMProxy => 1,
             ProgressSetupMiningPlan::Done => 1,
         }
@@ -256,9 +259,6 @@ impl ProgressStep for ProgressSetupMiningPlan {
 
     fn get_title(&self) -> String {
         match self {
-            ProgressSetupMiningPlan::BinariesMergeMiningProxy => {
-                "binaries-merge-mining-proxy".to_string()
-            }
             ProgressSetupMiningPlan::MMProxy => "mm-proxy".to_string(),
             ProgressSetupMiningPlan::Done => "done".to_string(),
         }

--- a/src-tauri/src/setup/phase_mining.rs
+++ b/src-tauri/src/setup/phase_mining.rs
@@ -27,7 +27,6 @@ use super::{
     utils::{setup_default_adapter::SetupDefaultAdapter, timeout_watcher::TimeoutWatcher},
 };
 use crate::{
-    binaries::{Binaries, BinaryResolver},
     configs::{config_core::ConfigCore, trait_config::ConfigImpl},
     events_emitter::EventsEmitter,
     internal_wallet::InternalWallet,
@@ -127,9 +126,6 @@ impl SetupPhaseImpl for MiningSetupPhase {
         timeout_watcher_sender: Sender<u64>,
     ) -> ProgressStepper {
         ProgressStepperBuilder::new()
-            .add_step(ProgressPlans::Mining(
-                ProgressSetupMiningPlan::BinariesMergeMiningProxy,
-            ))
             .add_step(ProgressPlans::Mining(ProgressSetupMiningPlan::MMProxy))
             .add_step(ProgressPlans::Mining(ProgressSetupMiningPlan::Done))
             .build(app_handle.clone(), timeout_watcher_sender)
@@ -153,17 +149,6 @@ impl SetupPhaseImpl for MiningSetupPhase {
     async fn setup_inner(&self) -> Result<(), Error> {
         info!(target: LOG_TARGET, "[ {} Phase ] Starting setup inner", SetupPhase::Mining);
         let mut progress_stepper = self.progress_stepper.lock().await;
-        let binary_resolver = BinaryResolver::current();
-
-        let mmproxy_binary_progress_tracker = progress_stepper.channel_step_range_updates(
-            ProgressPlans::Mining(ProgressSetupMiningPlan::BinariesMergeMiningProxy),
-            Some(ProgressPlans::Mining(ProgressSetupMiningPlan::MMProxy)),
-        );
-
-        binary_resolver
-            .initialize_binary(Binaries::MergeMiningProxy, mmproxy_binary_progress_tracker)
-            .await?;
-
         if self
             .setup_features
             .is_feature_disabled(SetupFeature::CpuPool)

--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -134,9 +134,6 @@ impl SetupPhaseImpl for WalletSetupPhase {
         timeout_watcher_sender: Sender<u64>,
     ) -> ProgressStepper {
         ProgressStepperBuilder::new()
-            .add_step(ProgressPlans::Wallet(
-                ProgressSetupWalletPlan::BinariesWallet,
-            ))
             .add_step(ProgressPlans::Wallet(ProgressSetupWalletPlan::StartWallet))
             .add_step(ProgressPlans::Wallet(ProgressSetupWalletPlan::SetupBridge))
             .add_step(ProgressPlans::Wallet(ProgressSetupWalletPlan::Done))
@@ -158,15 +155,6 @@ impl SetupPhaseImpl for WalletSetupPhase {
         let state = self.app_handle.state::<UniverseAppState>();
 
         let binary_resolver = BinaryResolver::current();
-
-        let wallet_binary_progress_tracker = progress_stepper.channel_step_range_updates(
-            ProgressPlans::Wallet(ProgressSetupWalletPlan::BinariesWallet),
-            Some(ProgressPlans::Wallet(ProgressSetupWalletPlan::StartWallet)),
-        );
-
-        binary_resolver
-            .initialize_binary(Binaries::Wallet, wallet_binary_progress_tracker)
-            .await?;
 
         progress_stepper
             .resolve_step(ProgressPlans::Wallet(ProgressSetupWalletPlan::StartWallet))


### PR DESCRIPTION
### [ Summary ]
- Prevent race condition in case when remote node do not download node binary in node_phase which results in mining_phase and wallet_phase trying to download tari_suite simultaneous 
