### PR TITLE
fix: exchange specific miners

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1545,6 +1545,12 @@ pub async fn start_cpu_mining(
 
     let cpu_miner = state.cpu_miner.read().await;
     let cpu_miner_running = cpu_miner.is_running().await;
+
+    let mut cpu_config = state.cpu_miner_config.write().await;
+    let tari_address = InternalWallet::tari_address().await;
+    cpu_config.load_from_config_pools(ConfigPools::content().await.clone(), &tari_address);
+    drop(cpu_config);
+
     drop(cpu_miner);
     let cpu_miner_config = state.cpu_miner_config.read().await;
     drop(cpu_miner_config);

--- a/src-tauri/src/configs/config_pools.rs
+++ b/src-tauri/src/configs/config_pools.rs
@@ -188,16 +188,8 @@ pub struct ConfigPools {
 
 impl ConfigPools {
     pub async fn initialize(app_handle: AppHandle) {
-        let state = app_handle.state::<UniverseAppState>();
         let mut config = Self::current().write().await;
         config.load_app_handle(app_handle.clone()).await;
-
-        let mut cpu_config = state.cpu_miner_config.write().await;
-        let tari_address = InternalWallet::tari_address().await;
-        cpu_config.load_from_config_pools(config.content.clone(), &tari_address);
-        drop(cpu_config);
-
-        EventsEmitter::emit_pools_config_loaded(config.content.clone()).await;
     }
 }
 

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -317,7 +317,7 @@ impl EventsEmitter {
             error!(target: LOG_TARGET, "Failed to emit MiningConfigLoaded event: {e:?}");
         }
     }
-    pub async fn emit_pools_config_loaded(payload: ConfigPoolsContent) {
+    pub async fn emit_pools_config_loaded(payload: &ConfigPoolsContent) {
         let _unused = FrontendReadyChannel::current().wait_for_ready().await;
         let event = Event {
             event_type: EventType::ConfigPoolsLoaded,

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -110,6 +110,22 @@ impl InternalWallet {
         Ok(())
     }
 
+    pub async fn is_external() -> bool {
+        let internal_wallet_guard = InternalWallet::current().read().await;
+        matches!(
+            internal_wallet_guard.tari_address_type,
+            TariAddressType::External
+        )
+    }
+
+    pub async fn is_internal() -> bool {
+        let internal_wallet_guard = InternalWallet::current().read().await;
+        matches!(
+            internal_wallet_guard.tari_address_type,
+            TariAddressType::Internal
+        )
+    }
+
     pub async fn initialize_seedless(
         app_handle: &tauri::AppHandle,
         new_external_tari_address: Option<TariAddress>,

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -277,6 +277,7 @@ impl SetupManager {
         ConfigWallet::initialize(app_handle.clone()).await;
         ConfigMining::initialize(app_handle.clone()).await;
         ConfigUI::initialize(app_handle.clone()).await;
+        ConfigPools::initialize(app_handle.clone()).await;
 
         let node_type = ConfigCore::content().await.node_type().clone();
         info!(target: LOG_TARGET, "Retrieved initial node type: {node_type:?}");
@@ -299,6 +300,7 @@ impl SetupManager {
         EventsEmitter::emit_core_config_loaded(&ConfigCore::content().await).await;
         EventsEmitter::emit_mining_config_loaded(&ConfigMining::content().await).await;
         EventsEmitter::emit_ui_config_loaded(&ConfigUI::content().await).await;
+        EventsEmitter::emit_pools_config_loaded(&ConfigPools::content().await).await;
 
         let is_on_exchange_specific_variant = ConfigCore::content()
             .await
@@ -355,8 +357,6 @@ impl SetupManager {
                 };
             }
         }
-
-        ConfigPools::initialize(app_handle.clone()).await;
 
         // Trigger it here so we can update UI when new wallet is created
         // We should probably change events to be loaded from internal wallet directly


### PR DESCRIPTION
### [ Summary ]
- Disable wallet scanning and staged security modal for external tari addresses
- Fixed panic caused by using internal wallet in pool config before its initialization
- Fixed panic caused by internal wallet not being initialized on second time of opening the app