### PR TITLE
fix: refresh balance after initial scan is completed

### DIFF
--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -403,14 +403,21 @@ impl WalletManager {
                                 } else {
                                     log::warn!(target: LOG_TARGET, "Wallet Balance is None after initial scanning");
                                 }
-                                // Balance might be invalid right after initial scanning but it should be revalidated after around 30 seconds
-                                tokio::time::sleep(Duration::from_secs(30)).await;
-                                let wallet_status = wallet_state_receiver.borrow().clone();
-                                if let Some(wallet_state) = wallet_status {
-                                    if let Some(balance) = wallet_state.balance {
-                                        info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {balance:?}");
-                                        ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
-                                        EventsEmitter::emit_wallet_balance_update(balance).await;
+
+                                // Balance might be invalid right after initial scanning but it should be revalidated every 5 seconds for 2 minutes
+                                let mut interval = tokio::time::interval(Duration::from_secs(5));
+                                let end_time = tokio::time::Instant::now() + Duration::from_secs(120);
+
+                                while tokio::time::Instant::now() < end_time {
+                                    interval.tick().await;
+                                    let wallet_status = wallet_state_receiver.borrow().clone();
+                                    if let Some(wallet_state) = wallet_status {
+                                        if let Some(balance) = wallet_state.balance {
+                                            info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {balance:?}");
+
+                                            ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
+                                            EventsEmitter::emit_wallet_balance_update(balance).await;
+                                        }
                                     }
                                 }
                                 break;

--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -297,13 +297,14 @@ impl WalletManager {
             return Err(WalletManagerError::WalletNotStarted);
         }
         let wallet_state_receiver = process_watcher.adapter.state_broadcast.subscribe();
+        let wallet_state_receiver_clone = wallet_state_receiver.clone();
         drop(process_watcher);
 
         let node_status_watch_rx_progress = node_status_watch_rx.clone();
         let initial_scan_completed = self.initial_scan_completed.clone();
         // Start a background task to monitor the wallet state and emit scan progress updates
         TasksTrackers::current().wallet_phase.get_task_tracker().await.spawn(async move {
-            let mut wallet_state_rx = wallet_state_receiver;
+            let mut wallet_state_rx = wallet_state_receiver_clone;
             let mut shutdown_signal = TasksTrackers::current().wallet_phase.get_signal().await;
 
             loop {
@@ -399,8 +400,20 @@ impl WalletManager {
 
                                     wallet_manager.initial_scan_completed
                                         .store(true, std::sync::atomic::Ordering::Relaxed);
+
                                 } else {
                                     log::warn!(target: LOG_TARGET, "Wallet Balance is None after initial scanning");
+                                }
+
+                                // Balance might be invalid right after initial scanning but it should be revalidated after around 30 seconds
+                                tokio::time::sleep(Duration::from_secs(30)).await;
+                                let wallet_status = wallet_state_receiver.borrow().clone();
+                                if let Some(wallet_state) = wallet_status {
+                                    if let Some(balance) = wallet_state.balance {
+                                        info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {:?}", balance);
+                                        ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
+                                        EventsEmitter::emit_wallet_balance_update(balance).await;
+                                    }
                                 }
                                 break;
                             }

--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -400,17 +400,15 @@ impl WalletManager {
 
                                     wallet_manager.initial_scan_completed
                                         .store(true, std::sync::atomic::Ordering::Relaxed);
-
                                 } else {
                                     log::warn!(target: LOG_TARGET, "Wallet Balance is None after initial scanning");
                                 }
-
                                 // Balance might be invalid right after initial scanning but it should be revalidated after around 30 seconds
                                 tokio::time::sleep(Duration::from_secs(30)).await;
                                 let wallet_status = wallet_state_receiver.borrow().clone();
                                 if let Some(wallet_state) = wallet_status {
                                     if let Some(balance) = wallet_state.balance {
-                                        info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {:?}", balance);
+                                        info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {balance:?}");
                                         ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
                                         EventsEmitter::emit_wallet_balance_update(balance).await;
                                     }


### PR DESCRIPTION
Description
---
Fixes: #2564 

After importing wallet, the scanned balance was invalid but wallet would re-validate it after around ~30 seconds. To fix it I added flat 30 seconds timeout to check balances again and change it.


How Has This Been Tested?
---
Imported wallet and confirmed that balance was correct.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
