### PR TITLE
fix(ui): minor wallet transaction ui tweaks

### DIFF
--- a/src/components/transactions/history/ListItem.styles.ts
+++ b/src/components/transactions/history/ListItem.styles.ts
@@ -21,9 +21,15 @@ export const HoverWrapper = styled(m.div)`
     inset: 0;
     z-index: 4;
     transition: background-color 1s ease;
-    background-color: ${({ theme }) => convertHexToRGBA(theme.palette.background.main, 0.7)};
     height: 100%;
-    backdrop-filter: blur(1.5px);
+
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        transparent 32%,
+        ${({ theme }) => (theme.mode === 'dark' ? '#1B1B1B' : theme.palette.background.paper)} 38%,
+        ${({ theme }) => (theme.mode === 'dark' ? '#1B1B1B' : theme.palette.background.paper)} 100%
+    );
 `;
 
 export const ContentWrapper = styled.div`
@@ -143,6 +149,7 @@ export const ButtonWrapper = styled(m.div)`
     height: 100%;
     gap: 6px;
 `;
+
 export const FlexButton = styled.button`
     display: flex;
     height: 31px;

--- a/src/components/wallet/components/history/styles.ts
+++ b/src/components/wallet/components/history/styles.ts
@@ -11,7 +11,7 @@ export const HistoryListWrapper = styled(m.div)`
     align-items: flex-end;
     justify-content: flex-end;
     position: relative;
-    mask-image: linear-gradient(to bottom, transparent -10px, black 10px, black calc(100% - 40px), transparent 100%);
+    mask-image: linear-gradient(to bottom, black 0px, black 10px, black calc(100% - 40px), transparent 100%);
     mask-position: bottom;
     mask-size: 50% 100%;
 

--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -144,7 +144,9 @@ export default function SidebarWallet({ section, setSection }: SidebarWalletProp
                     <WalletWrapper key="wallet" variants={swapTransition} initial="show" exit="hide" animate="show">
                         <Wrapper $seedlessUI={!isStandardWalletUI || isSyncing}>
                             {isSyncing ? <SyncLoading>{syncMarkup}</SyncLoading> : walletMarkup}
-                            <BuyTariButton onClick={() => setIsSwapping(true)}>{'Buy Tari (XTM)'}</BuyTariButton>
+                            <BuyTariButton onClick={() => setIsSwapping(true)}>
+                                <span>{'Buy Tari (XTM)'}</span>
+                            </BuyTariButton>
                         </Wrapper>
                     </WalletWrapper>
                 )}

--- a/src/components/wallet/sidebarWallet/styles.ts
+++ b/src/components/wallet/sidebarWallet/styles.ts
@@ -131,8 +131,20 @@ export const BuyTariButton = styled.button`
     transition: all 0.2s ease-in-out;
     flex-shrink: 0;
 
+    span {
+        transition: transform 0.2s ease-in-out;
+    }
+
     &:hover {
-        opacity: 0.9;
+        span {
+            transform: scale(1.075);
+        }
+    }
+
+    &:active {
+        span {
+            transform: scale(1);
+        }
     }
 `;
 

--- a/src/containers/navigation/components/Wallet/ListLoadingAnimation/ListLoadingAnimation.tsx
+++ b/src/containers/navigation/components/Wallet/ListLoadingAnimation/ListLoadingAnimation.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ListItemsWrapper, LoadingText, Rectangle, Wrapper } from './styles';
+import { Trans } from 'react-i18next';
 
 interface Props {
     loadingText?: string;
@@ -46,7 +47,9 @@ export default function ListLoadingAnimation({ loadingText }: Props) {
 
     return (
         <Wrapper>
-            <LoadingText>{loadingText}</LoadingText>
+            <LoadingText>
+                <Trans>{loadingText}</Trans>
+            </LoadingText>
             <ListItemsWrapper>
                 {Array.from({ length: totalSquares }).map((_, index) => (
                     <Rectangle

--- a/src/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts
+++ b/src/containers/navigation/components/Wallet/ListLoadingAnimation/styles.ts
@@ -17,7 +17,6 @@ export const ListItemsWrapper = styled.div`
     flex-direction: column;
     gap: 4px;
     width: 100%;
-    padding-top: 6px;
 `;
 
 export const Rectangle = styled(m.div)`


### PR DESCRIPTION
1. remove blur from list item hover and add a gradient instead to cover the number below the buttons. This is cleaner and looks more professional. The blur was too much.
 
<img width="1256" height="744" alt="CleanShot 2025-07-30 at 15 59 20@2x" src="https://github.com/user-attachments/assets/d35de51e-cdab-4928-9f05-3bec307c3e3d" />

2. There was a slight gradient mask showing through on the top of the list, this was effecting the top list item. I just removed it so the top of the list is clean.

<img width="1238" height="656" alt="CleanShot 2025-07-30 at 16 00 10@2x" src="https://github.com/user-attachments/assets/cc7d6b2e-048c-4441-8ff8-cdb468ae5b65" />

3. Add a subtle text scale hover effect to the "Buy Tari" button.

<img width="1258" height="452" alt="CleanShot 2025-07-30 at 16 01 22@2x" src="https://github.com/user-attachments/assets/6dbb934c-461c-4c04-8d3c-3a3baed15114" />

4. The loading UI had some extra padding at the top, The loading text also had an HTML tag within it that was rendering as text. I don't think this loading UI is shown anymore, so this was missed. 

<img width="1442" height="706" alt="CleanShot 2025-07-30 at 16 02 20@2x" src="https://github.com/user-attachments/assets/aba0b082-3c67-4b69-a4af-8b18e6385f14" />
