### PR TITLE
fix(ui): seed words copy | space banner on bridge view

### DIFF
--- a/src/components/wallet/seedwords/SeedWords.tsx
+++ b/src/components/wallet/seedwords/SeedWords.tsx
@@ -109,7 +109,7 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
     }
     const handleCopyClick = useCallback(() => {
         startTransition(async () => {
-            if (seedWords && seedWordsFetched) {
+            if (seedWords?.length && seedWordsFetched) {
                 copyToClipboard(seedWords.join(' '));
             } else {
                 getSeedWords().then((r) => {

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -19,9 +19,11 @@ import { XSpaceEventType } from '@app/utils/XSpaceEventType';
 import { useTranslation } from 'react-i18next';
 import { formatDateForEvent } from './formatDate';
 import { AnimatePresence } from 'motion/react';
+import { useUIStore } from '@app/store';
 
 const XSpaceEventBanner = () => {
     const latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
+    const showTapplet = useUIStore((s) => s.showTapplet);
     const [isTextTooLong, setIsTextTooLong] = useState(false);
     const [transitionPixelWidth, setTransitionPixelWidth] = useState(0);
     const [isVisible, setIsVisible] = useState(false);
@@ -70,7 +72,7 @@ const XSpaceEventBanner = () => {
 
     return (
         <AnimatePresence>
-            {latestXSpaceEvent && isVisible && (
+            {latestXSpaceEvent && isVisible && !showTapplet && (
                 <BannerContent
                     onClick={() => {
                         open(latestXSpaceEvent.link);

--- a/src/store/actions/miningStoreActions.ts
+++ b/src/store/actions/miningStoreActions.ts
@@ -3,9 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useMiningMetricsStore } from '../useMiningMetricsStore.ts';
 
 import { useMiningStore } from '../useMiningStore.ts';
-import { setGpuMiningEnabled } from './appConfigStoreActions.ts';
 import { setError } from './appStateStoreActions.ts';
-import { setGpuDevices } from '../actions/miningMetricsStoreActions.ts';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { useConfigMiningStore } from '../useAppConfigStore.ts';
 import { Network } from '@app/utils/network.ts';


### PR DESCRIPTION
Description
---

- close space banner if taplet screen is open
- check for seedwords length, not just if exists
- lints

Motivation and Context
---

- closes https://github.com/tari-project/universe/issues/2537
- closes https://github.com/tari-project/universe/issues/2632
- during testing also confirmed to be able to close https://github.com/tari-project/universe/issues/2477

How Has This Been Tested?
---
- locally:


https://github.com/user-attachments/assets/090204d8-cb71-4e7b-a828-1c1609d4c949

