### PR TITLE
fix(ui): send form | review button disabled upon going back

### DIFF
--- a/src/components/transactions/WalletSidebarContent.tsx
+++ b/src/components/transactions/WalletSidebarContent.tsx
@@ -15,7 +15,7 @@ export default function WalletSidebarContent() {
                 <SidebarWallet section={section} setSection={setSection} />
             </WalletSections>
 
-            <SendModal section={section} setSection={setSection} />
+            {section !== 'history' && <SendModal section={section} setSection={setSection} />}
 
             <TransactionModal
                 show={section === 'receive'}

--- a/src/components/transactions/send/SendForm.tsx
+++ b/src/components/transactions/send/SendForm.tsx
@@ -34,6 +34,7 @@ export function SendForm({ isBack }: Props) {
     const { control, formState, setError, setValue, clearErrors, getValues } = useFormContext<SendInputs>();
     const { isSubmitting, errors } = formState;
     const isAmountValid = !errors.amount;
+
     const isValid = isAddressValid && isAmountValid;
 
     useEffect(() => {
@@ -58,6 +59,8 @@ export function SendForm({ isBack }: Props) {
         void validateAddress(address);
         if (address.length === 0) {
             setIsAddressValid(false);
+        } else {
+            setAddress(address);
         }
     }, [getValues, validateAddress]);
 

--- a/src/components/transactions/send/SendModal.tsx
+++ b/src/components/transactions/send/SendModal.tsx
@@ -27,12 +27,12 @@ export default function SendModal({ section, setSection }: SendModalProps) {
         mode: 'all',
     });
 
-    const { setError, reset } = methods;
+    const { reset } = methods;
 
     const resetForm = () => {
-        setStatus('fields');
-        setIsBack(false);
         reset();
+        setIsBack(false);
+        setStatus('fields');
     };
 
     function handleClose() {
@@ -44,6 +44,8 @@ export default function SendModal({ section, setSection }: SendModalProps) {
         setStatus('fields');
         setIsBack(true);
     }
+
+    const setError = methods.setError;
 
     const handleFormSubmit = useCallback(
         async (data: SendInputs) => {
@@ -96,6 +98,22 @@ export default function SendModal({ section, setSection }: SendModalProps) {
         return `${t('tabs.send')} ${t('tari')}`;
     };
 
+    const formContentMarkup =
+        status === 'fields' ? (
+            <SendForm isBack={isBack} />
+        ) : (
+            <SendReview
+                status={status}
+                setStatus={setStatus}
+                amount={methods.getValues().amount}
+                address={methods.getValues().address}
+                message={methods.getValues().message}
+                networkFee={0.06}
+                feePercentage={0.02}
+                handleClose={handleClose}
+            />
+        );
+
     return (
         <TransactionModal
             show={section === 'send'}
@@ -105,22 +123,7 @@ export default function SendModal({ section, setSection }: SendModalProps) {
         >
             <FormProvider {...methods}>
                 <Wrapper $isLoading={methods.formState.isSubmitting}>
-                    <StyledForm onSubmit={methods.handleSubmit(handleFormSubmit)}>
-                        {status === 'fields' ? (
-                            <SendForm isBack={isBack} />
-                        ) : (
-                            <SendReview
-                                status={status}
-                                setStatus={setStatus}
-                                amount={methods.getValues().amount}
-                                address={methods.getValues().address}
-                                message={methods.getValues().message}
-                                networkFee={0.06}
-                                feePercentage={0.02}
-                                handleClose={handleClose}
-                            />
-                        )}
-                    </StyledForm>
+                    <StyledForm onSubmit={methods.handleSubmit(handleFormSubmit)}>{formContentMarkup}</StyledForm>
                 </Wrapper>
             </FormProvider>
         </TransactionModal>


### PR DESCRIPTION
Description
---


- set state `address` if the form value exists (like in the case of going back to review)
- also in `WalletSidebarContent.tsx` just removing the `SendModal` from the DOM if not needed so the form values clear entirely on reset without having to close the sidebar)


Motivation and Context
---

- fixes https://github.com/tari-project/universe/issues/2647

How Has This Been Tested?
---

- locally:

switched between review with/without changes, closing entirely, adding more in a different field etc

https://github.com/user-attachments/assets/d76553c6-abfa-4739-a283-4bf88bce6179
