### PR TITLE
fix: optional z index for dialogs

### DIFF
--- a/src/components/elements/dialog/Dialog.styles.ts
+++ b/src/components/elements/dialog/Dialog.styles.ts
@@ -8,6 +8,7 @@ export interface ContentWrapperProps {
     $disableOverflow?: boolean;
     $borderRadius?: string;
     $transparentBg?: boolean;
+    $zIndex?: number;
 }
 export const ContentWrapper = styled.div<ContentWrapperProps>`
     border-radius: ${({ theme, $borderRadius }) => $borderRadius || theme.shape.borderRadius.dialog};
@@ -47,10 +48,14 @@ export const ContentWrapper = styled.div<ContentWrapperProps>`
         `}
 `;
 
-export const Overlay = styled(FloatingOverlay)`
+interface OverlayProps {
+    $zIndex?: number;
+}
+
+export const Overlay = styled(FloatingOverlay)<OverlayProps>`
     display: flex;
     align-items: center;
     justify-content: center;
     background-color: ${colorsAll.darkAlpha[50]};
-    z-index: 100;
+    z-index: ${({ $zIndex }) => $zIndex || 100};
 `;

--- a/src/components/elements/dialog/Dialog.tsx
+++ b/src/components/elements/dialog/Dialog.tsx
@@ -127,7 +127,7 @@ export const DialogContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement
             <FloatingNode id={context.nodeId} key={context.nodeId}>
                 {context.open ? (
                     <FloatingPortal>
-                        <Overlay lockScroll className="overlay">
+                        <Overlay lockScroll className="overlay" $zIndex={props.$zIndex}>
                             <FloatingFocusManager context={context.context} modal={false}>
                                 <ContentWrapper
                                     ref={ref}

--- a/src/containers/floating/security/pin/CreatePinDialog.tsx
+++ b/src/containers/floating/security/pin/CreatePinDialog.tsx
@@ -39,7 +39,7 @@ export default function CreatePinDialog() {
 
     return (
         <Dialog open={isOpen} onOpenChange={handleClose}>
-            <DialogContent $transparentBg $unPadded>
+            <DialogContent $transparentBg $unPadded $zIndex={105}>
                 <Wrapper>
                     <Header>
                         <div /> <CloseButton onClick={handleClose} />

--- a/src/containers/floating/security/pin/EnterPinDialog.tsx
+++ b/src/containers/floating/security/pin/EnterPinDialog.tsx
@@ -26,7 +26,7 @@ export default function EnterPinDialog() {
 
     return (
         <Dialog open={isOpen} onOpenChange={handleClose}>
-            <DialogContent $transparentBg $unPadded>
+            <DialogContent $transparentBg $unPadded $zIndex={105}>
                 <Wrapper>
                     <Header>
                         <Heading>{t('security.pin.enter')}</Heading> <CloseButton onClick={handleClose} />


### PR DESCRIPTION
Closes #2609

Description
---
* Optional z-index for Dialogs to prevent from unwanted covering
* Prioritize entering Pin over sync with phone
<img width="1273" height="875" alt="Screenshot 2025-08-01 at 12 39 48" src="https://github.com/user-attachments/assets/9038ff34-5462-42d0-9139-11e55cc8cec7" />

