### PR TITLE
fix: balance validation blocking shutdown

### DIFF
--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -409,23 +409,6 @@ impl WalletManager {
                                 } else {
                                     log::warn!(target: LOG_TARGET, "Wallet Balance is None after initial scanning");
                                 }
-
-                                // Balance might be invalid right after initial scanning but it should be revalidated every 5 seconds for 2 minutes
-                                let mut interval = tokio::time::interval(Duration::from_secs(5));
-                                let end_time = tokio::time::Instant::now() + Duration::from_secs(120);
-
-                                while tokio::time::Instant::now() < end_time {
-                                    interval.tick().await;
-                                    let wallet_status = wallet_state_receiver.borrow().clone();
-                                    if let Some(wallet_state) = wallet_status {
-                                        if let Some(balance) = wallet_state.balance {
-                                            info!(target: LOG_TARGET, "Updating wallet balance after initial scanning: {balance:?}");
-
-                                            ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
-                                            EventsEmitter::emit_wallet_balance_update(balance).await;
-                                        }
-                                    }
-                                }
                                 break;
                             }
                             Err(e) => {
@@ -439,6 +422,52 @@ impl WalletManager {
 
             Ok(())
         });
+
+        // Balance might be invalid right after initial scanning but it should be revalidated shortly after
+        let wallet_state_receiver_clone = wallet_state_receiver.clone();
+        TasksTrackers::current()
+            .wallet_phase
+            .get_task_tracker()
+            .await
+            .spawn(async move {
+                WalletManager::validate_balance_after_scan(wallet_state_receiver_clone)
+                    .await
+                    .inspect_err(|e| {
+                        log::error!(target: LOG_TARGET, "Balance validation failed: {}", e);
+                    })
+            });
+
+        Ok(())
+    }
+
+    async fn validate_balance_after_scan(
+        wallet_state_receiver: watch::Receiver<Option<WalletState>>,
+    ) -> Result<(), WalletManagerError> {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        let end_time = tokio::time::Instant::now() + Duration::from_secs(120);
+        let mut shutdown_signal = TasksTrackers::current().wallet_phase.get_signal().await;
+
+        loop {
+            tokio::select! {
+                _ = shutdown_signal.wait() => {
+                    info!(target: LOG_TARGET, "Shutdown signal received, stopping balance validation");
+                    break;
+                }
+                _ = interval.tick() => {
+                    if tokio::time::Instant::now() >= end_time {
+                        break;
+                    }
+
+                    let wallet_status = wallet_state_receiver.borrow().clone();
+                    if let Some(wallet_state) = wallet_status {
+                        if let Some(balance) = wallet_state.balance {
+                            ConfigWallet::update_field(ConfigWalletContent::set_last_known_balance, balance.available_balance).await?;
+                            EventsEmitter::emit_wallet_balance_update(balance).await;
+                        }
+                    }
+                }
+            }
+        }
 
         Ok(())
     }

--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -433,7 +433,7 @@ impl WalletManager {
                 WalletManager::validate_balance_after_scan(wallet_state_receiver_clone)
                     .await
                     .inspect_err(|e| {
-                        log::error!(target: LOG_TARGET, "Balance validation failed: {}", e);
+                        log::error!(target: LOG_TARGET, "Balance validation failed: {e}");
                     })
             });
 


### PR DESCRIPTION
Description
---
Closes: #2655 

Fixes blocking operation done by wallet scanning which took 2 minutes and blocked shutdown.

How Has This Been Tested?
---
Launch app and try to close app right after initial scan completed which will be indicated with these logs:
```
14:33:49 INFO  Wallet scan completed up to block height 62616
14:33:49 INFO  Initial wallet scan complete up to 62616 block height. Available balance: 10114.597741 T
```

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
