### PR TITLE
fix: reference correct store for API URL

### DIFF
--- a/src/hooks/airdrop/utils/useHandleRequest.ts
+++ b/src/hooks/airdrop/utils/useHandleRequest.ts
@@ -1,5 +1,6 @@
 import { useAirdropStore } from '@app/store/useAirdropStore';
 import { handleRefreshAirdropTokens } from '@app/hooks/airdrop/stateHelpers/useAirdropTokensRefresh.ts';
+import { useConfigBEInMemoryStore } from '@app/store';
 
 interface RequestProps {
     path: string;
@@ -22,9 +23,11 @@ async function retryHandler(errorMessage: string) {
 }
 
 export async function handleAirdropRequest<T>({ body, method, path, onError, headers, publicRequest }: RequestProps) {
+    // use useConfigBEInMemoryStore now, not airdrop store for the URL
+    const baseUrl = useConfigBEInMemoryStore.getState().airdropApiUrl; // TODO rename url vars?
+
     const airdropToken = useAirdropStore.getState().airdropTokens?.token;
     const airdropTokenExpiration = useAirdropStore.getState().airdropTokens?.expiresAt;
-    const baseUrl = useAirdropStore.getState().backendInMemoryConfig?.airdropApiUrl;
 
     const isTokenExpired = !airdropTokenExpiration || airdropTokenExpiration * 1000 < Date.now();
 
@@ -47,7 +50,7 @@ export async function handleAirdropRequest<T>({ body, method, path, onError, hea
 
     // If no token and no public request, return
     if (!baseUrl || (!airdropToken && !publicRequest)) {
-        console.warn(`No token or baseUrl, skipping request to ${path}`);
+        console.warn(`No ${!baseUrl ? 'baseUrl' : 'token'}, skipping request to ${path}`);
         return;
     }
 

--- a/src/hooks/exchanges/fetchExchangeContent.ts
+++ b/src/hooks/exchanges/fetchExchangeContent.ts
@@ -1,4 +1,4 @@
-import { useUIStore } from '@app/store';
+import { useConfigBEInMemoryStore, useUIStore } from '@app/store';
 import { useQuery } from '@tanstack/react-query';
 import { setShowExchangeModal, universalExchangeMinerOption, useExchangeStore } from '@app/store/useExchangeStore.ts';
 import { ExchangeBranding } from '@app/types/exchange.ts';
@@ -33,10 +33,11 @@ export const queryfn = async (exchangeId: string) => {
 export function useFetchExchangeBranding() {
     const theme = useTheme();
     const exchangeId = useExchangeStore((s) => s.currentExchangeMinerId);
+    const baseUrl = useConfigBEInMemoryStore((s) => s.airdropApiUrl);
 
     return useQuery({
         queryKey: [KEY_XC_CONTENT, exchangeId],
-        enabled: !!exchangeId?.length,
+        enabled: !!exchangeId?.length && !!baseUrl.length,
         queryFn: () => queryfn(exchangeId),
         select: (data) => {
             if (data) {


### PR DESCRIPTION
Description
---

- get `baseUrl` from the correct store (for `handleAirdropRequest`)
- adjusted the console.warn just so we can get a better idea of what's missing
- check for the `baseUrl` for enabled too in `useFetchExchangeBranding`

Motivation and Context
---

- we use the airdrop request now for exchange content, and `handleAirdropRequest` still used `useAirdropStore` to grab the API URL - which may not be set right on startup (though `useConfigBEInMemoryStore` is)

How Has This Been Tested?
---

- locally
