### PR TITLE
fix(ui): tab accessibility improvements

### DIFF
--- a/src/components/elements/ToggleSwitch.tsx
+++ b/src/components/elements/ToggleSwitch.tsx
@@ -56,7 +56,8 @@ const Switch = styled.div<{ $hasDecorators?: boolean }>`
               : theme.colors.grey[300]};
 
     border-radius: 24px;
-    transition: 300ms all;
+    transition: background 0.2s ease-in-out;
+
     width: 36px;
     height: 20px;
     padding: 3px 2px;
@@ -90,8 +91,8 @@ const Input = styled.input<{ $isSolid?: boolean; $hasDecorators?: boolean; $isLo
         cursor: not-allowed;
     }
 
-    &:focus + ${Switch} {
-        outline: 3px solid #c9eb00;
+    &:focus-visible + ${Switch} {
+        outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
         outline-offset: 2px;
     }
 
@@ -138,7 +139,7 @@ const Decorator = styled.div<{ $first?: boolean; $checked?: boolean }>`
     height: 20px;
 
     color: ${({ $checked, theme }) => theme.colors.greyscale[$checked ? 50 : 950]};
-    // TODO: revisit and make proper custom component for this
+
     ${({ $first }) =>
         $first
             ? css`
@@ -148,7 +149,7 @@ const Decorator = styled.div<{ $first?: boolean; $checked?: boolean }>`
             : css`
                   top: -1px;
                   right: -3px;
-              `};
+              `}
 `;
 
 interface ToggleSwitchProps extends InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -35,7 +35,7 @@ export const TriggerWrapper = styled.div<StyleProps>`
     }
 
     &:focus-visible {
-        outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+        outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
         outline-offset: 2px;
     }
 
@@ -47,7 +47,7 @@ export const TriggerWrapper = styled.div<StyleProps>`
             padding: 0 15px;
 
             &:focus-visible {
-                outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+                outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
                 outline-offset: 2px;
             }
         `}
@@ -149,7 +149,7 @@ export const StyledOption = styled.div<StyleProps>`
     }
 
     &:focus-visible {
-        outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+        outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
         outline-offset: -2px;
     }
 

--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -27,18 +27,29 @@ export const TriggerWrapper = styled.div<StyleProps>`
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
+    border-radius: 10px;
+
     img {
         width: 12px;
         display: flex;
     }
 
+    &:focus-visible {
+        outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+        outline-offset: 2px;
+    }
+
     ${({ $isBordered, theme }) =>
         $isBordered &&
         css`
-            border-radius: 10px;
             border: 1px solid ${theme.palette.divider};
             background: rgba(0, 0, 0, 0.01);
             padding: 0 15px;
+
+            &:focus-visible {
+                outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+                outline-offset: 2px;
+            }
         `}
 
     ${({ $isSync }) =>
@@ -124,7 +135,6 @@ export const StyledOption = styled.div<StyleProps>`
     line-height: 1;
     cursor: ${({ $loading }) => ($loading ? 'wait' : 'pointer')};
     border-radius: 10px;
-    transition: all 0.2s ease-in-out;
 
     height: 38px;
     padding: 0 12px;
@@ -136,6 +146,11 @@ export const StyledOption = styled.div<StyleProps>`
 
     &:hover {
         background: ${({ theme }) => theme.palette.action.hover.default};
+    }
+
+    &:focus-visible {
+        outline: 2px solid ${({ theme }) => theme.palette.primary.main};
+        outline-offset: -2px;
     }
 
     ${({ $isBordered }) =>

--- a/src/components/elements/inputs/Select.styles.ts
+++ b/src/components/elements/inputs/Select.styles.ts
@@ -83,6 +83,7 @@ export const Options = styled.div<StyleProps>`
     z-index: 10;
     max-height: 200px;
     overflow-y: auto;
+    overscroll-behavior: contain;
 `;
 
 export const SelectedOption = styled.div<StyleProps>`

--- a/src/containers/main/Airdrop/sidebar/components/SidebarItem.tsx
+++ b/src/containers/main/Airdrop/sidebar/components/SidebarItem.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useState } from 'react';
-import { offset, safePolygon, useFloating, useHover, useInteractions } from '@floating-ui/react';
+import { offset, safePolygon, useFloating, useHover, useFocus, useInteractions } from '@floating-ui/react';
 import { ActionHoveredWrapper, ActionText, ActionWrapper, ContentWrapper, TooltipBox } from './item.style.ts';
 import { AnimatePresence } from 'motion/react';
 
@@ -25,10 +25,12 @@ export function SidebarItem({ children, text, hoverContent, tooltipContent }: Ac
         handleClose: safePolygon(),
     });
 
-    const { getReferenceProps, getFloatingProps } = useInteractions([hover]);
+    const focus = useFocus(context);
+
+    const { getReferenceProps, getFloatingProps } = useInteractions([hover, focus]);
 
     return (
-        <ActionWrapper ref={refs.setReference} {...getReferenceProps()}>
+        <ActionWrapper ref={refs.setReference} {...getReferenceProps()} tabIndex={0}>
             <ContentWrapper>{hovered && hoverContent ? hoverContent : children}</ContentWrapper>
             {text ? <ActionText>{text}</ActionText> : null}
             <AnimatePresence>

--- a/src/containers/main/Airdrop/sidebar/components/item.style.ts
+++ b/src/containers/main/Airdrop/sidebar/components/item.style.ts
@@ -24,8 +24,10 @@ export const ActionWrapper = styled.div`
     height: 60px;
     width: 60px;
 
-    &:hover {
+    &:hover,
+    &:focus {
         box-shadow: ${({ theme }) => `${convertHexToRGBA(theme.palette.contrast, 0.03)} 0 0 2px 2px`};
+        outline: none;
     }
 `;
 

--- a/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/ModeDropdown/ModeDropdown.tsx
+++ b/src/containers/navigation/components/MiningButtonCombined/MiningButton/components/ModeDropdown/ModeDropdown.tsx
@@ -19,7 +19,7 @@ import SelectedIcon from './icons/SelectedIcon';
 import ecoIcon from './images/eco.png';
 import ludicIcon from './images/ludicrous.png';
 import customIcon from '@app/assets/icons/emoji/custom.png';
-import { offset, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
+import { offset, useClick, useDismiss, useFloating, useInteractions, FloatingFocusManager } from '@floating-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useConfigMiningStore } from '@app/store';
 import { setDialogToShow } from '@app/store/actions/uiStoreActions';
@@ -130,27 +130,38 @@ export default function ModeDropdown({ disabled, loading }: Props) {
             </Trigger>
             <AnimatePresence>
                 {isOpen && !disabled && !loading && (
-                    <FloatingWrapper ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-                        <Menu
-                            initial={{ opacity: 0, y: -5 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -5 }}
-                        >
-                            {modes.map((mode) => (
-                                <Option
-                                    key={mode.name}
-                                    onClick={() => handleSelectMode(mode)}
-                                    $isSelected={mode.name === selectedMiningMode?.mode_name}
-                                >
-                                    <OptionIcon src={mode.icon} alt="" aria-hidden="true" className="option-icon" />
-                                    <OptionText>{mode.name}</OptionText>
-                                    {mode.name === selectedMiningMode?.mode_name && (
-                                        <SelectedIcon className="selected-icon" />
-                                    )}
-                                </Option>
-                            ))}
-                        </Menu>
-                    </FloatingWrapper>
+                    <FloatingFocusManager context={context} modal={true}>
+                        <FloatingWrapper ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+                            <Menu
+                                initial={{ opacity: 0, y: -5 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                exit={{ opacity: 0, y: -5 }}
+                            >
+                                {modes.map((mode) => (
+                                    <Option
+                                        key={mode.name}
+                                        onClick={() => handleSelectMode(mode)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault();
+                                                handleSelectMode(mode);
+                                            }
+                                        }}
+                                        tabIndex={0}
+                                        role="option"
+                                        aria-selected={mode.name === selectedMiningMode?.mode_name}
+                                        $isSelected={mode.name === selectedMiningMode?.mode_name}
+                                    >
+                                        <OptionIcon src={mode.icon} alt="" aria-hidden="true" className="option-icon" />
+                                        <OptionText>{mode.name}</OptionText>
+                                        {mode.name === selectedMiningMode?.mode_name && (
+                                            <SelectedIcon className="selected-icon" />
+                                        )}
+                                    </Option>
+                                ))}
+                            </Menu>
+                        </FloatingWrapper>
+                    </FloatingFocusManager>
                 )}
             </AnimatePresence>
         </Wrapper>

--- a/src/theme/GlobalStyle.ts
+++ b/src/theme/GlobalStyle.ts
@@ -19,8 +19,9 @@ export const GlobalReset = createGlobalStyle`
         font: inherit;
 
         &:focus-visible {
-            outline: 3px solid #c9eb00;
+            outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
             outline-offset: 2px;
+            transition: none;
         }
     }
 
@@ -43,8 +44,9 @@ export const GlobalReset = createGlobalStyle`
         }
 
         &:focus-visible {
-            outline: 3px solid #c9eb00;
+            outline: 2px solid ${({ theme }) => theme.palette.focusOutline};
             outline-offset: 2px;
+            transition: none;
         }
     }
 `;

--- a/src/theme/palettes/dark.ts
+++ b/src/theme/palettes/dark.ts
@@ -31,6 +31,7 @@ const darkPalette: ThemePalette = {
         base: '#000',
         contrast: '#fff',
         contrastAlpha: alpha.lightAlpha[5],
+        focusOutline: c.brightGreen[500],
         primary: {
             main: c.tariPurple[900],
             dark: c.tariPurple[950],

--- a/src/theme/palettes/light.ts
+++ b/src/theme/palettes/light.ts
@@ -31,6 +31,7 @@ const lightPalette: ThemePalette = {
         base: '#fff',
         contrast: '#000000',
         contrastAlpha: colorsAlpha.darkAlpha[5],
+        focusOutline: c.tariPurple[500],
         primary: {
             main: c.tariPurple[600],
             dark: c.tariPurple[700],

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -38,6 +38,7 @@ interface Palette {
     base: string;
     contrast: string;
     contrastAlpha: string;
+    focusOutline: string;
     primary: Omit<StandardColour, 'primary' | 'secondary' | 'default'>;
     secondary: Colour;
     success: Colour;


### PR DESCRIPTION
This update improves the tab navigation through the app. It's still not perfect, but is now much improved. 

1. Fixed overscroll on select menus. If you scroll with your mouse to the bottom of an open select menu, the page below would scroll. This is now fixed so scrolling the menu does not effect the parent page.

Video of the bug:
https://www.loom.com/share/a62ddfbb0cf54b1db0cbbf9df527cd97?sid=d98fc581-ad99-41b0-a75f-4b7ff79709cc

Video of the fix:
https://www.loom.com/share/07a491d4f5484f34b6d537826cf4c007?sid=ad2318b4-16c2-4513-9718-28a444c0bf89

2. Added tab focus support to the option items within the Select dropdown component. Tabbing through an open list now "captures" the tab so the user can cycle through each list item within the open menu.

3. I updated the outline focus color to be purple on light mode, and green on dark mode. This offers better visual contrast for accessibility. I also removed the animation from all focus outlines to make it feel snappy.

<img width="1166" height="560" alt="CleanShot 2025-08-06 at 15 38 37@2x" src="https://github.com/user-attachments/assets/da638fa8-b0ef-436f-b943-55b8aa1123c0" />

<img width="1014" height="438" alt="CleanShot 2025-08-06 at 15 39 02@2x" src="https://github.com/user-attachments/assets/e46727df-a43d-4b65-a0e4-c92b60a38a43" />


4. Added the same tab focus functionality to the mode select dropdown.

<img width="916" height="512" alt="CleanShot 2025-08-06 at 15 39 52@2x" src="https://github.com/user-attachments/assets/dca41d3f-e44f-4582-b381-20009be6c252" />

5. Added tab select availability to the logged in sidebar items. Before these were not tab focusable at all. 

<img width="1030" height="578" alt="CleanShot 2025-08-06 at 15 41 04@2x" src="https://github.com/user-attachments/assets/0daaa2fa-1bba-4af0-8f66-45d9a256c92c" />


