### PR TITLE
fix(ui): improve contrast on dark mode tooltips

### DIFF
--- a/src/components/wallet/components/details/actions/styles.ts
+++ b/src/components/wallet/components/details/actions/styles.ts
@@ -42,7 +42,7 @@ export const AddressTooltip = styled(m.div)`
     align-items: center;
     justify-content: center;
 
-    background: ${({ theme }) => theme.palette.background.paper};
+    background: ${({ theme }) => theme.palette.background.tooltip};
     z-index: 1;
 
     padding: 10px;

--- a/src/containers/main/Airdrop/sidebar/components/item.style.ts
+++ b/src/containers/main/Airdrop/sidebar/components/item.style.ts
@@ -45,8 +45,8 @@ export const ActionHoveredWrapper = styled.div`
 `;
 
 export const TooltipBox = styled(m.div)`
-    background: ${({ theme }) => theme.palette.background.main};
-    box-shadow: 0 0 45px 0 rgba(0, 0, 0, 0.15);
+    background: ${({ theme }) => theme.palette.background.tooltip};
+    box-shadow: 0 3px 25px 0 rgba(0, 0, 0, 0.25);
     border-radius: 10px;
     padding: 16px;
     display: flex;

--- a/src/theme/palettes/dark.ts
+++ b/src/theme/palettes/dark.ts
@@ -61,11 +61,11 @@ const darkPalette: ThemePalette = {
         background: {
             default: c.grey[900],
             paper: c.grey[700],
-
             accent: 'rgba(255,255,255,0.06)',
             main: c.grey[600],
             splash: c.grey[700],
             secondary: c.greyscale[900],
+            tooltip: c.greyscale[600],
         },
         success: {
             main: c.green[600],

--- a/src/theme/palettes/light.ts
+++ b/src/theme/palettes/light.ts
@@ -65,6 +65,7 @@ const lightPalette: ThemePalette = {
             accent: c.grey[100],
             splash: '#e5e5e5',
             secondary: '#000000',
+            tooltip: '#fff',
         },
         success: {
             main: c.success[300],

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -53,6 +53,7 @@ interface Palette {
         accent: string;
         main: string;
         secondary: string;
+        tooltip: string;
     };
     action: {
         hover: Colour;


### PR DESCRIPTION
The tooltip background color for dark mode was too subtle and blended in with the content below it. This update makes it slightly lighter to improve the visual hierarchy. 

Before:

<img width="764" height="522" alt="CleanShot 2025-08-06 at 15 58 01@2x" src="https://github.com/user-attachments/assets/a9b5e01c-052c-46d9-922b-37b0527e603c" />

After: 

<img width="1090" height="626" alt="CleanShot 2025-08-06 at 15 57 30@2x" src="https://github.com/user-attachments/assets/7f14a435-3c3c-468e-812f-512068d71e2e" />


