### PR TITLE
fix(ui): hide plus and minus in the wallet history list when the balance is hidden

### DIFF
--- a/src/components/transactions/history/ListItem.tsx
+++ b/src/components/transactions/history/ListItem.tsx
@@ -24,7 +24,15 @@ import { getTxTitle, getTxTypeByStatus } from '@app/utils/getTxStatus.ts';
 import { TransactionDirection } from '@app/types/transactions.ts';
 import BridgeItemHover from './BridgeHoveredItem.tsx';
 
-const BaseItem = memo(function BaseItem({ title, time, value, direction, chip, onClick }: BaseItemProps) {
+const BaseItem = memo(function BaseItem({
+    title,
+    time,
+    value,
+    direction,
+    chip,
+    onClick,
+    hideWalletBalance,
+}: BaseItemProps) {
     // note re. isPositiveValue:
     // amounts in the tx response are always positive numbers but
     // if the transaction is Outbound, the value is negative
@@ -47,9 +55,11 @@ const BaseItem = memo(function BaseItem({ title, time, value, direction, chip, o
                 ) : null}
 
                 <ValueWrapper>
-                    <ValueChangeWrapper $isPositiveValue={isPositiveValue}>
-                        {isPositiveValue ? `+` : `-`}
-                    </ValueChangeWrapper>
+                    {!hideWalletBalance && (
+                        <ValueChangeWrapper $isPositiveValue={isPositiveValue}>
+                            {isPositiveValue ? `+` : `-`}
+                        </ValueChangeWrapper>
+                    )}
                     {value}
                     <CurrencyText>{`XTM`}</CurrencyText>
                 </ValueWrapper>
@@ -88,6 +98,7 @@ const HistoryListItem = memo(function ListItem({
             value={earningsFormatted}
             direction={item.walletTransactionDetails.direction}
             chip={itemIsNew ? t('new') : ''}
+            hideWalletBalance={hideWalletBalance}
         />
     );
 

--- a/src/components/transactions/types.ts
+++ b/src/components/transactions/types.ts
@@ -17,4 +17,5 @@ export interface BaseItemProps {
     value: string;
     chip?: string;
     onClick?: () => void;
+    hideWalletBalance?: boolean;
 }


### PR DESCRIPTION
This PR hides the + / - in the wallet history when the wallet balance is set to `hidden`. 

Im just hiding it, no need for a * or placeholder.

Issue: https://github.com/tari-project/universe/issues/2680

<img width="1118" height="888" alt="CleanShot 2025-08-11 at 14 26 35@2x" src="https://github.com/user-attachments/assets/7b305ae6-089c-40b4-b4e5-7cf691f20b24" />
