### PR TITLE
fix(ui): add state animation to the sidebar

### DIFF
--- a/src/containers/navigation/SidebarNavigation.tsx
+++ b/src/containers/navigation/SidebarNavigation.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
-import { AnimatePresence } from 'motion/react';
 import { useUIStore } from '@app/store/useUIStore.ts';
 import SidebarMini from './Sidebars/SidebarMini.tsx';
 import Sidebar from './Sidebars/Sidebar.tsx';
 import { SidebarNavigationWrapper } from './SidebarNavigation.styles.ts';
 import { setSidebarOpen } from '@app/store/actions/uiStoreActions';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
+import { AnimatePresence } from 'motion/react';
 
 export default function SidebarNavigation() {
     const sidebarOpen = useUIStore((s) => s.sidebarOpen);

--- a/src/containers/navigation/Sidebars/Sidebar.styles.ts
+++ b/src/containers/navigation/Sidebars/Sidebar.styles.ts
@@ -1,20 +1,9 @@
-import { Variants } from 'motion/react';
 import styled, { css } from 'styled-components';
 import * as m from 'motion/react-m';
 import { SB_WIDTH } from '@app/theme/styles.ts';
 import { convertHexToRGBA } from '@app/utils';
 
-const variants: Variants = {
-    open: { opacity: 1, left: 0, transition: { duration: 0.2, ease: 'linear' } },
-    closed: { opacity: 0, left: -50, transition: { duration: 0.05, ease: 'linear' } },
-};
-
-export const SidebarWrapper = styled(m.div).attrs({
-    variants,
-    initial: 'open',
-    animate: 'open',
-    exit: 'closed',
-})`
+export const SidebarWrapper = styled(m.div)`
     pointer-events: all;
     background: ${({ theme }) => theme.palette.background.default};
     box-shadow: 0 0 45px 0 rgba(0, 0, 0, 0.15);
@@ -22,7 +11,7 @@ export const SidebarWrapper = styled(m.div).attrs({
     border-radius: 20px;
     height: 100%;
     flex-shrink: 0;
-    padding: 15px 10px;
+    padding: 15px 10px 10px 10px;
     position: relative;
     width: ${SB_WIDTH}px;
 

--- a/src/containers/navigation/Sidebars/Sidebar.tsx
+++ b/src/containers/navigation/Sidebars/Sidebar.tsx
@@ -7,7 +7,20 @@ import { AnimatePresence } from 'motion/react';
 export default function Sidebar() {
     const isSwapping = useWalletStore((s) => s.is_swapping);
     return (
-        <SidebarWrapper key="sidebar">
+        <SidebarWrapper
+            initial={{
+                opacity: 0,
+                left: -10,
+            }}
+            animate={{
+                opacity: 1,
+                left: 0,
+            }}
+            exit={{
+                opacity: 0,
+                left: -10,
+            }}
+        >
             <WrapperGrid>
                 <GridAreaTop>
                     <MiningSection />


### PR DESCRIPTION
The sidebar was not animating properly when open/closed. There were some props there for an animation, but i'm taking a more simplified approach here. 

The sidebar now animates when it opens and exits. The effect is subtle but adds more visual flare as opposed to popping in and out. 

Here's a video of the animation. 

https://www.loom.com/share/c71e99aefcb9412b908e6c7b907ad77c?sid=dae3c0df-901a-4c91-b532-1bef541e5af7

<img width="2678" height="1540" alt="CleanShot 2025-08-11 at 15 23 22@2x" src="https://github.com/user-attachments/assets/ec66053b-03e9-4d13-9fc0-a157aae4e280" />
