### PR TITLE
feat: use new text explorer api

### DIFF
--- a/src-tauri/src/network_utils.rs
+++ b/src-tauri/src/network_utils.rs
@@ -23,7 +23,6 @@
 use crate::requests::utils::create_user_agent;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Deserialize;
-use std::fmt::Write as _;
 use tari_common::configuration::Network;
 
 fn create_client() -> Result<reqwest::Client, anyhow::Error> {


### PR DESCRIPTION
This pull request updates how block information is fetched and parsed from the TextExplore API endpoints in `src-tauri/src/network_utils.rs`. The main focus is on simplifying the data structures and updating the endpoints to reflect changes in the API responses, resulting in cleaner and more maintainable code.

**API Endpoint Updates:**

* Changed the block info endpoint URLs in `get_text_explore_blocks_url` and `get_text_explore_url` to use `/header` and `/tip/height` instead of the old `?json` endpoints, aligning with the latest API structure. [[1]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L48-R51) [[2]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L60-R62)

**Response Parsing and Struct Simplification:**

* Simplified the response parsing in `get_best_block_from_block_scan` by replacing nested structs with a single-level struct containing just the `height` field, reflecting the new API response format. [[1]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L71-R71) [[2]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L92-R91)
* Updated `get_block_info_from_block_scan` to expect `height` and `hash` as top-level fields in the response, removing the need for nested structs and manual byte-to-hex conversion. [[1]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L92-R91) [[2]](diffhunk://#diff-ec165c67a990ec7638e2294a9e94ac52f49c1d95685738d55a5ea49f6272dbc3L134-R107)