### PR TITLE
fix: cpu mining resuming when pool toggling

### DIFF
--- a/src-tauri/src/setup/listeners/listener_unlock_cpu_mining.rs
+++ b/src-tauri/src/setup/listeners/listener_unlock_cpu_mining.rs
@@ -120,7 +120,7 @@ impl UnlockConditionsListenerTrait for ListenerUnlockCpuMining {
     }
 
     async fn conditions_met_callback(&self) {
-        info!(target: LOG_TARGET, "Unlocking Mining");
+        info!(target: LOG_TARGET, "Unlocking Cpu Mining");
         EventsEmitter::emit_unlock_cpu_mining().await;
     }
 

--- a/src-tauri/src/setup/listeners/listener_unlock_gpu_mining.rs
+++ b/src-tauri/src/setup/listeners/listener_unlock_gpu_mining.rs
@@ -119,7 +119,7 @@ impl UnlockConditionsListenerTrait for ListenerUnlockGpuMining {
         *self.listener.lock().await = Some(listener_task);
     }
     async fn conditions_met_callback(&self) {
-        info!(target: LOG_TARGET, "Unlocking Mining");
+        info!(target: LOG_TARGET, "Unlocking Gpu Mining");
         EventsEmitter::emit_unlock_gpu_mining().await;
     }
 

--- a/src-tauri/src/setup/phase_core.rs
+++ b/src-tauri/src/setup/phase_core.rs
@@ -144,7 +144,7 @@ impl SetupPhaseImpl for CoreSetupPhase {
                 let _unused = SetupDefaultAdapter::setup(self).await;
             }
             Err(err) => {
-                log::error!("Core Phase pre-setup failed: {}", err);
+                log::error!("Core Phase pre-setup failed: {err}");
             }
         }
     }

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -579,40 +579,45 @@ impl SetupManager {
                 }
             }
         }
-        ListenerUnlockCpuMining::current().handle_restart().await;
-        ListenerUnlockGpuMining::current().handle_restart().await;
-        ListenerUnlockWallet::current().handle_restart().await;
     }
 
     pub async fn resume_phases(&self, phases: Vec<SetupPhase>) {
-        if !phases.is_empty() {
-            EventsEmitter::emit_restarting_phases(phases.clone()).await;
-            let _unused = self.resolve_setup_features().await;
-            self.features
-                .write()
-                .await
-                .add_feature(SetupFeature::Restarting);
+        if phases.is_empty() {
+            return;
         }
 
+        EventsEmitter::emit_restarting_phases(phases.clone()).await;
+        let _unused = self.resolve_setup_features().await;
+        self.features
+            .write()
+            .await
+            .add_feature(SetupFeature::Restarting);
+
         let setup_features = self.features.read().await.clone();
+
         ListenerSetupFinished::current()
             .load_setup_features(setup_features.clone())
             .await;
-        ListenerSetupFinished::current().start_listener().await;
 
         ListenerUnlockCpuMining::current()
             .load_setup_features(setup_features.clone())
             .await;
-        ListenerUnlockCpuMining::current().start_listener().await;
 
         ListenerUnlockGpuMining::current()
             .load_setup_features(setup_features.clone())
             .await;
-        ListenerUnlockGpuMining::current().start_listener().await;
 
         ListenerUnlockWallet::current()
             .load_setup_features(setup_features.clone())
             .await;
+
+        ListenerUnlockCpuMining::current().handle_restart().await;
+        ListenerUnlockGpuMining::current().handle_restart().await;
+        ListenerUnlockWallet::current().handle_restart().await;
+
+        ListenerSetupFinished::current().start_listener().await;
+        ListenerUnlockCpuMining::current().start_listener().await;
+        ListenerUnlockGpuMining::current().start_listener().await;
         ListenerUnlockWallet::current().start_listener().await;
 
         for phase in phases {

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -102,9 +102,9 @@ export const setAirdropTokensInConfig = (
 ) => {
     const airdropTokens = airdropTokensParam
         ? {
-            token: airdropTokensParam.token,
-            refresh_token: airdropTokensParam.refreshToken,
-        }
+              token: airdropTokensParam.token,
+              refresh_token: airdropTokensParam.refreshToken,
+          }
         : undefined;
 
     invoke('set_airdrop_tokens', { airdropTokens })

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -102,9 +102,9 @@ export const setAirdropTokensInConfig = (
 ) => {
     const airdropTokens = airdropTokensParam
         ? {
-              token: airdropTokensParam.token,
-              refresh_token: airdropTokensParam.refreshToken,
-          }
+            token: airdropTokensParam.token,
+            refresh_token: airdropTokensParam.refreshToken,
+        }
         : undefined;
 
     invoke('set_airdrop_tokens', { airdropTokens })


### PR DESCRIPTION
### [ Summary ]
handle_restart methods didn't have newest setup features loaded which for cpu case made it lock mining and not unlock it 