### PR TITLE
chore(ci): bump trusted-signing-cli to v0.8.0

### DIFF
--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -214,7 +214,7 @@ jobs:
           echo '{}' > ./tauri.windows.conf.json
           yq eval ".bundle.windows.signCommand = env(WINDOWS_SIGN_COMMAND)" --output-format=json -i ./tauri.windows.conf.json
           cat ./tauri.windows.conf.json
-          cargo install trusted-signing-cli@0.5.0 --locked
+          cargo install trusted-signing-cli@0.8.0 --locked
 
       - name: Install Dependencies - Node
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           echo '{}' > ./tauri.windows.conf.json
           yq eval ".bundle.windows.signCommand = env(WINDOWS_SIGN_COMMAND)" --output-format=json -i ./tauri.windows.conf.json
           cat ./tauri.windows.conf.json
-          cargo install trusted-signing-cli@0.5.0 --locked
+          cargo install trusted-signing-cli@0.8.0 --locked
 
       - name: Install Dependencies - Node
         run: |


### PR DESCRIPTION
Description
bump trusted-signing-cli to v0.8.0

Motivation and Context
resolve windows code signing.

How Has This Been Tested?
Builds in branch without problems
