### PR TITLE
fix: telemetry using uninitialized configs

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -410,9 +410,7 @@ impl NodeManager {
 
     pub async fn get_identity(&self) -> Result<NodeIdentity, anyhow::Error> {
         let current_service = self.get_current_service().await?;
-        current_service.get_identity().await.inspect_err(|e| {
-            error!(target: LOG_TARGET, "Error getting node identity: {e}");
-        })
+        current_service.get_identity().await
     }
 
     pub async fn get_connection_details(

--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -224,31 +224,6 @@ impl SetupManager {
         let state = app_handle.state::<UniverseAppState>();
         let in_memory_config = state.in_memory_config.clone();
 
-        let _unused = state
-            .telemetry_manager
-            .write()
-            .await
-            .initialize(app_handle.clone())
-            .await;
-
-        let mut telemetry_id = state
-            .telemetry_manager
-            .read()
-            .await
-            .get_unique_string()
-            .await;
-        if telemetry_id.is_empty() {
-            telemetry_id = "unknown_miner_tari_universe".to_string();
-        }
-
-        let app_version = app_handle.package_info().version.clone();
-        let _unused = state
-            .telemetry_service
-            .write()
-            .await
-            .init(app_version.to_string(), telemetry_id.clone())
-            .await;
-
         let mut websocket_events_manager_guard = state.websocket_event_manager.write().await;
         websocket_events_manager_guard.set_app_handle(app_handle.clone());
         drop(websocket_events_manager_guard);
@@ -402,6 +377,31 @@ impl SetupManager {
         // Trigger it here so we can update UI when new wallet is created
         // We should probably change events to be loaded from internal wallet directly
         EventsEmitter::emit_wallet_config_loaded(&ConfigWallet::content().await).await;
+
+        {
+            let _unused = state
+                .telemetry_manager
+                .write()
+                .await
+                .initialize(app_handle.clone())
+                .await;
+            let mut telemetry_id = state
+                .telemetry_manager
+                .read()
+                .await
+                .get_unique_string()
+                .await;
+            if telemetry_id.is_empty() {
+                telemetry_id = "unknown_miner_tari_universe".to_string();
+            }
+            let app_version = app_handle.package_info().version.clone();
+            let _unused = state
+                .telemetry_service
+                .write()
+                .await
+                .init(app_version.to_string(), telemetry_id.clone())
+                .await;
+        }
 
         // If we open different specific exchange miner build then previous one we always want to prompt user to provide tari address
         if is_on_exchange_miner_build && built_in_exchange_id.ne(&last_config_exchange_id) {


### PR DESCRIPTION
Description
---
Telemetry service was accessing configs that aren't initialized yet(wallet related in this case):
```
thread 'tokio-runtime-worker' panicked at src/internal_wallet.rs:93:24:
InternalWallet is not initialized
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
I postponed it until configs are loaded

Additionally:
* Silence manually triggered error. Error is handled in the upper scope, no need to always log error manually. It's used for displaying on the FE side. Not important
```
09:12:46 ERROR Error getting node identity: transport error
```
