### PR TITLE
feat: Add minimum days check for claimable rewards

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/sections/CrewSection/CrewList/CrewEntry/CrewEntry.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/CrewSection/CrewList/CrewEntry/CrewEntry.tsx
@@ -21,7 +21,8 @@ export default function CrewEntry({ entry, isClaimed }: Props) {
     const [nudgeCooldowns, setNudgeCooldowns] = useState<Record<string, number>>({});
 
     const { invalidate: invalidateCrewMembers } = useCrewMembers();
-    const { invalidate: invalidateReferrerProgress } = useReferrerProgress();
+    const { invalidate: invalidateReferrerProgress, data: referrerProgress } = useReferrerProgress();
+    const meetsRequirements = referrerProgress?.referrerProgress.meetsMinimumDays;
 
     const canClaim = progress && progress >= 100;
 
@@ -100,7 +101,7 @@ export default function CrewEntry({ entry, isClaimed }: Props) {
                 <TopRow>
                     <Username>{handle}</Username>
                     <CrewProgressPill
-                        canClaim={Boolean(canClaim && !isClaimingReward)}
+                        canClaim={Boolean(canClaim && !isClaimingReward && meetsRequirements)}
                         canNudge={canNudge && !isSendingNudge}
                         isClaimed={isClaimed ?? false}
                         timeRemaining={timeRemaining ?? { current: 0, total: 0, unit: '' }}

--- a/src/hooks/crew/useCrewMembers.ts
+++ b/src/hooks/crew/useCrewMembers.ts
@@ -52,6 +52,7 @@ export function useCrewMembers() {
         enabled: !!airdropToken && !!walletReceiveKey,
         refetchOnWindowFocus: true,
         staleTime: 30 * 1000,
+        refetchInterval: 60 * 1000,
         retry: 2,
     });
 

--- a/src/hooks/crew/useReferrerProgress.ts
+++ b/src/hooks/crew/useReferrerProgress.ts
@@ -38,6 +38,7 @@ export function useReferrerProgress() {
         enabled: !!airdropToken && !!walletReceiveKey,
         refetchOnWindowFocus: true,
         staleTime: 30 * 1000,
+        refetchInterval: 60 * 1000,
         retry: 2,
     });
 


### PR DESCRIPTION
Adds a check for minimum days before allowing a crew reward to be claimed. Fixes an issue where users could claim rewards before meeting all the requirements. Also adds a refetch interval to the crew member and referrer progress hooks to ensure the data is always up to date.
