### PR TITLE
fix(ui): add initial letter to the avatar component when image is blank

### DIFF
--- a/src/containers/main/Airdrop/sidebar/User.tsx
+++ b/src/containers/main/Airdrop/sidebar/User.tsx
@@ -32,7 +32,7 @@ export default function User() {
     );
     return (
         <SidebarItem tooltipContent={tooltipContent}>
-            <Avatar username={name} />
+            <Avatar image={profileimageurl} username={name} />
         </SidebarItem>
     );
 }

--- a/src/containers/main/Airdrop/sidebar/User.tsx
+++ b/src/containers/main/Airdrop/sidebar/User.tsx
@@ -32,7 +32,7 @@ export default function User() {
     );
     return (
         <SidebarItem tooltipContent={tooltipContent}>
-            <Avatar image={profileimageurl} username={name} />
+            <Avatar username={name} />
         </SidebarItem>
     );
 }

--- a/src/containers/main/Airdrop/sidebar/components/Avatar/Avatar.tsx
+++ b/src/containers/main/Airdrop/sidebar/components/Avatar/Avatar.tsx
@@ -24,6 +24,10 @@ const generateColor = (seed: Seed): string => {
     return `rgb(${r}, ${g}, ${b})`;
 };
 
+const firstLetter = (username: string): string => {
+    return username.charAt(0).toUpperCase();
+};
+
 interface Props {
     username?: string;
     image?: string;
@@ -32,6 +36,7 @@ interface Props {
 export default function Avatar({ username, image }: Props) {
     const finalUsername = username ? `@${username}` : '';
     let finalImage = `url(${image})`;
+    let finalLetter = '';
 
     if (!image && username) {
         const seed = hashString(username);
@@ -41,7 +46,12 @@ export default function Avatar({ username, image }: Props) {
         const yPos = Math.floor(seededRandom(seed + 7) * 100);
 
         finalImage = `radial-gradient(circle at ${xPos}% ${yPos}%, ${color1}, ${color2})`;
+        finalLetter = firstLetter(username);
     }
 
-    return <AvatarWrapper $image={finalImage} aria-label={finalUsername} title={finalUsername} />;
+    return (
+        <AvatarWrapper $image={finalImage} aria-label={finalUsername} title={finalUsername}>
+            {finalLetter}
+        </AvatarWrapper>
+    );
 }

--- a/src/containers/main/Airdrop/sidebar/components/Avatar/styles.ts
+++ b/src/containers/main/Airdrop/sidebar/components/Avatar/styles.ts
@@ -11,4 +11,13 @@ export const AvatarWrapper = styled.div<{ $image: string }>`
     background-position: center;
     background-repeat: no-repeat;
     background-color: ${({ theme }) => theme.palette.contrastAlpha};
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 16px;
+    font-weight: 600;
+    color: #fff;
+    cursor: default;
 `;


### PR DESCRIPTION
When the logged in user doesn't have an avatar image, it now shows the first initial of their username along with a seed generated gradient background. This makes the generated avatar feel more complete and personalized. 

<img width="758" height="606" alt="CleanShot 2025-08-19 at 17 19 51@2x" src="https://github.com/user-attachments/assets/3d91fc41-ca2d-4a1e-9602-fa87e01e03e6" />
