### PR TITLE
fix: deadlock when switching to local node

### DIFF
--- a/src-tauri/src/setup/setup_manager.rs
+++ b/src-tauri/src/setup/setup_manager.rs
@@ -819,16 +819,13 @@ impl SetupManager {
     }
 
     pub async fn handle_switch_to_local_node(&self) {
-        if let Some(app_handle) = self.app_handle.lock().await.clone() {
-            info!(target: LOG_TARGET, "Handle Switching to Local Node in Setup Manager");
-            EventsManager::handle_node_type_update(&app_handle).await;
+        let app_handle = self.app_handle().await;
+        info!(target: LOG_TARGET, "Handle Switching to Local Node in Setup Manager");
+        EventsManager::handle_node_type_update(&app_handle).await;
 
-            info!(target: LOG_TARGET, "Restarting Phases");
-            self.restart_phases(vec![SetupPhase::Wallet, SetupPhase::Mining])
-                .await;
-        } else {
-            error!(target: LOG_TARGET, "Failed to reset phases after switching to Local Node: app_handle not defined");
-        }
+        info!(target: LOG_TARGET, "Restarting Phases");
+        self.restart_phases(vec![SetupPhase::Wallet, SetupPhase::Mining])
+            .await;
     }
 
     pub async fn spawn_sleep_mode_handler() {


### PR DESCRIPTION
Closes #2719

Potentially Closes #2711
Potentially Closes #2763

Description
---
There was a deadlock that was preventing phases from restarting when local node synced and can be switched from remote one.

```rust
    pub async fn handle_switch_to_local_node(&self) {
        if let Some(app_handle) = self.app_handle.lock().await.clone() {
            ...
            // app_handle lock is held here, when it's locked again here:
            self.restart_phases(vec![SetupPhase::Wallet, SetupPhase::Mining])
                .await;
        }
    }
```