### PR TITLE
fix(ui): xstate banner position for when the rewards widget is minimized

### DIFF
--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -1,7 +1,11 @@
 import * as m from 'motion/react-m';
 import styled, { css } from 'styled-components';
 
-export const BannerContent = styled(m.div)<{ $crewRewardsActive: boolean; $isLoggedIn: boolean }>`
+export const BannerContent = styled(m.div)<{
+    $crewRewardsActive: boolean;
+    $isLoggedIn: boolean;
+    $crewRewardsMinimized: boolean;
+}>`
     position: fixed;
     top: 16px;
     right: 20px;
@@ -35,6 +39,13 @@ export const BannerContent = styled(m.div)<{ $crewRewardsActive: boolean; $isLog
         $crewRewardsActive &&
         css`
             top: 296px;
+            right: 12px;
+        `}
+
+    ${({ $crewRewardsMinimized }) =>
+        $crewRewardsMinimized &&
+        css`
+            top: 64px;
             right: 12px;
         `}
 `;

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -22,18 +22,29 @@ import { AnimatePresence } from 'motion/react';
 import { useCrewRewardsStore } from '@app/store/useCrewRewardsStore';
 import { useUIStore } from '@app/store';
 
+const testingXSpaceEvent = {
+    text: 'test',
+    visibilityStart: '2025-08-20T12:00:00Z',
+    visibilityEnd: '2025-08-20T12:00:00Z',
+    goingLive: '2025-08-20T12:00:00Z',
+    link: 'https://x.com/test',
+    type: XSpaceEventType.event,
+};
+
 const XSpaceEventBanner = () => {
-    const latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
+    const latestXSpaceEvent = testingXSpaceEvent; //useAirdropStore((state) => state.latestXSpaceEvent);
     const showTapplet = useUIStore((s) => s.showTapplet);
     const [isTextTooLong, setIsTextTooLong] = useState(false);
     const [transitionPixelWidth, setTransitionPixelWidth] = useState(0);
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = useState(true);
     const [isLive, setIsLive] = useState(false);
     const titleRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const { t } = useTranslation('common', { useSuspense: false });
-    const crewRewardsActive = useCrewRewardsStore((s) => s.showWidget);
+
     const isLoggedIn = useAirdropStore((s) => !!s.airdropTokens);
+    const crewRewardsActive = useCrewRewardsStore((s) => s.showWidget);
+    const crewRewardsMinimized = useCrewRewardsStore((s) => s.isMinimized);
 
     useEffect(() => {
         if (!latestXSpaceEvent) return;
@@ -81,11 +92,12 @@ const XSpaceEventBanner = () => {
                         open(latestXSpaceEvent.link);
                     }}
                     $crewRewardsActive={crewRewardsActive && !showTapplet}
+                    $crewRewardsMinimized={crewRewardsMinimized && crewRewardsActive && !showTapplet}
                     $isLoggedIn={isLoggedIn}
                 >
                     <FlexWrapper>
                         <IconContainer>
-                            <XSpaceSvg></XSpaceSvg>
+                            <XSpaceSvg />
                         </IconContainer>
                         <ContentContainer
                             initial={{ width: 0, opacity: 0, marginLeft: 0 }}

--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.tsx
@@ -22,6 +22,10 @@ import { AnimatePresence } from 'motion/react';
 import { useCrewRewardsStore } from '@app/store/useCrewRewardsStore';
 import { useUIStore } from '@app/store';
 
+/*
+
+// testing data for xspace event banner
+
 const testingXSpaceEvent = {
     text: 'test',
     visibilityStart: '2025-08-20T12:00:00Z',
@@ -31,12 +35,14 @@ const testingXSpaceEvent = {
     type: XSpaceEventType.event,
 };
 
+*/
+
 const XSpaceEventBanner = () => {
-    const latestXSpaceEvent = testingXSpaceEvent; //useAirdropStore((state) => state.latestXSpaceEvent);
+    const latestXSpaceEvent = useAirdropStore((state) => state.latestXSpaceEvent);
     const showTapplet = useUIStore((s) => s.showTapplet);
     const [isTextTooLong, setIsTextTooLong] = useState(false);
     const [transitionPixelWidth, setTransitionPixelWidth] = useState(0);
-    const [isVisible, setIsVisible] = useState(true);
+    const [isVisible, setIsVisible] = useState(false);
     const [isLive, setIsLive] = useState(false);
     const titleRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
This update adjusts the XStateBanner position for when the Crew Rewards widget is minimized. 

The banner has a different position for each of the following cases:

- Crew rewards is disabled
- Crew rewards is active ( not logged in )
- Crew rewards is active ( logged in )
- Crew rewards is minimized

<img width="910" height="554" alt="CleanShot 2025-08-20 at 11 27 30@2x" src="https://github.com/user-attachments/assets/5edb443f-dfe1-42c6-801b-e77f868a3062" />

Loom Video of all the possible positions:

https://www.loom.com/share/0e5030c121ec4a8cbc381983bce011fb?sid=e3f29564-7928-4cae-9ed3-07dc811ed65e


