### PR TITLE
chore: remote node calls optimization

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2280,6 +2280,17 @@ pub async fn parse_tari_address(address: String) -> Result<TariAddressVariants, 
 }
 
 #[tauri::command]
+pub async fn list_connected_peers(
+    state: tauri::State<'_, UniverseAppState>,
+) -> Result<Vec<String>, String> {
+    state
+        .node_manager
+        .list_connected_peers()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn refresh_wallet_history(
     state: tauri::State<'_, UniverseAppState>,
     app_handle: tauri::AppHandle,

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -43,7 +43,6 @@ pub enum EventType {
     GpuPoolStatsUpdate,
     CpuMiningUpdate,
     GpuMiningUpdate,
-    ConnectedPeersUpdate,
     NewBlockHeight,
     CloseSplashscreen,
     DetectedDevices,

--- a/src-tauri/src/events_emitter.rs
+++ b/src-tauri/src/events_emitter.rs
@@ -441,20 +441,6 @@ impl EventsEmitter {
         }
     }
 
-    pub async fn emit_connected_peers_update(connected_peers: Vec<String>) {
-        let _unused = FrontendReadyChannel::current().wait_for_ready().await;
-        let event = Event {
-            event_type: EventType::ConnectedPeersUpdate,
-            payload: connected_peers,
-        };
-        if let Err(e) = Self::get_app_handle()
-            .await
-            .emit(BACKEND_STATE_UPDATE, event)
-        {
-            error!(target: LOG_TARGET, "Failed to emit ConnectedPeersUpdate event: {e:?}");
-        }
-    }
-
     pub async fn emit_new_block_mined(
         block_height: u64,
         coinbase_transaction: Option<TransactionInfo>,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -637,7 +637,8 @@ fn main() {
             commands::update_selected_cpu_pool_config,
             commands::reset_gpu_pool_config,
             commands::reset_cpu_pool_config,
-            commands::restart_phases
+            commands::restart_phases,
+            commands::list_connected_peers
         ])
         .build(tauri::generate_context!())
         .inspect_err(|e| {

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -311,12 +311,6 @@ impl NodeAdapterService {
     }
 
     pub async fn check_if_is_orphan_chain(&self) -> Result<bool, anyhow::Error> {
-        let BaseNodeStatus { is_synced, .. } = self.get_network_state().await?;
-        if !is_synced {
-            info!(target: LOG_TARGET, "Node is not synced, skipping orphan chain check");
-            return Ok(false);
-        }
-
         let network = Network::get_current_or_user_setting_or_default();
         let block_scan_tip = get_best_block_from_block_scan(network).await?;
         let heights: Vec<u64> = vec![

--- a/src-tauri/src/telemetry_manager.rs
+++ b/src-tauri/src/telemetry_manager.rs
@@ -493,10 +493,7 @@ async fn get_telemetry_data_inner(
 
     let p2pool_enabled = *config.is_p2pool_enabled() && p2pool_stats.is_some();
     let mut extra_data = HashMap::new();
-    let is_orphan = node_manager
-        .check_if_is_orphan_chain()
-        .await
-        .unwrap_or(false);
+    let is_orphan = node_manager.is_on_orphan_chain();
     extra_data.insert("is_orphan".to_string(), is_orphan.to_string());
     extra_data.insert(
         "config_cpu_enabled".to_string(),

--- a/src/components/transactions/history/List.tsx
+++ b/src/components/transactions/history/List.tsx
@@ -3,7 +3,7 @@ import { useInView } from 'react-intersection-observer';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 
-import { CombinedBridgeWalletTransaction, useMiningMetricsStore, useWalletStore } from '@app/store';
+import { CombinedBridgeWalletTransaction, useNodeStore, useWalletStore } from '@app/store';
 
 import { useFetchTxHistory } from '@app/hooks/wallet/useFetchTxHistory.ts';
 
@@ -28,7 +28,7 @@ export function List({ setIsScrolled, targetRef }: Props) {
     const { t } = useTranslation('wallet');
     const walletScanning = useWalletStore((s) => s.wallet_scanning);
     const bridgeTransactions = useWalletStore((s) => s.bridge_transactions);
-    const currentBlockHeight = useMiningMetricsStore((s) => s.base_node_status.block_height);
+    const currentBlockHeight = useNodeStore((s) => s.base_node_status.block_height);
     const coldWalletAddress = useWalletStore((s) => s.cold_wallet_address);
     const tariAddress = useWalletStore((s) => s.tari_address_base58);
     const tx_history_filter = useWalletStore((s) => s.tx_history_filter);

--- a/src/components/transactions/history/details/getListEntries.tsx
+++ b/src/components/transactions/history/details/getListEntries.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 import { formatNumber, FormatPreset } from '@app/utils';
 import { StatusListEntry } from '@app/components/transactions/components/StatusList/StatusList.tsx';
 import { getExplorerUrl, Network } from '@app/utils/network.ts';
-import { CombinedBridgeWalletTransaction, useMiningMetricsStore, useMiningStore } from '@app/store';
+import { CombinedBridgeWalletTransaction, useNodeStore, useMiningStore } from '@app/store';
 import { getTxStatusTitleKey, getTxTitle } from '@app/utils/getTxStatus.ts';
 import { EmojiAddressWrapper } from '@app/components/transactions/history/details/styles.ts';
 
@@ -42,7 +42,7 @@ function getPaymentReferenceValue(transaction: CombinedBridgeWalletTransaction):
     if (transaction.walletTransactionDetails.paymentReference) {
         return transaction.walletTransactionDetails.paymentReference;
     }
-    const currentBlockHeight = useMiningMetricsStore.getState().base_node_status.block_height;
+    const currentBlockHeight = useNodeStore.getState().base_node_status.block_height;
     if (!transaction.mined_in_block_height || !currentBlockHeight) {
         return i18n.t('common:pending');
     }

--- a/src/components/wallet/components/balance/WalletBalance.tsx
+++ b/src/components/wallet/components/balance/WalletBalance.tsx
@@ -2,7 +2,7 @@ import i18n from 'i18next';
 import NumberFlow, { type Format } from '@number-flow/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { IoEyeOffOutline, IoEyeOutline } from 'react-icons/io5';
-import { useConfigWalletStore, useMiningMetricsStore, useUIStore, useWalletStore } from '@app/store';
+import { useConfigWalletStore, useNodeStore, useUIStore, useWalletStore } from '@app/store';
 
 import { roundToTwoDecimals, removeXTMCryptoDecimals, formatNumber, FormatPreset, formatValue } from '@app/utils';
 import { Typography } from '@app/components/elements/Typography.tsx';
@@ -37,7 +37,7 @@ export const WalletBalance = () => {
     const [hovering, setHovering] = useState(false);
 
     const hideBalance = useUIStore((s) => s.hideWalletBalance);
-    const isConnected = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnected = useNodeStore((s) => s.isNodeConnected);
     const cached = useConfigWalletStore((s) => s.last_known_balance);
     const available = useWalletStore((s) => s.balance?.available_balance);
     const total = useWalletStore((s) => s.calculated_balance);

--- a/src/components/wallet/sidebarWallet/SidebarWallet.tsx
+++ b/src/components/wallet/sidebarWallet/SidebarWallet.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence } from 'motion/react';
-import { useMiningMetricsStore, useConfigUIStore, useWalletStore } from '@app/store';
+import { useNodeStore, useConfigUIStore, useWalletStore } from '@app/store';
 import { useSetupStore } from '@app/store/useSetupStore';
 import { swapTransition } from '@app/components/transactions/wallet/transitions.ts';
 import { Swap } from '@app/components/transactions/wallet/Swap/Swap.tsx';
@@ -62,7 +62,7 @@ export default function SidebarWallet({ section, setSection }: SidebarWalletProp
     const walletModule = useSetupStore(setupStoreSelectors.selectWalletModule);
     const isWalletModuleFailed = walletModule?.status === AppModuleStatus.Failed;
 
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTariNetwork = useNodeStore((s) => s.isNodeConnected);
     const isWalletScanning = useWalletStore((s) => s.wallet_scanning?.is_scanning);
 
     const targetRef = useRef<HTMLDivElement>(null) as RefObject<HTMLDivElement>;

--- a/src/containers/floating/Settings/sections/connections/ConnectionStatus.tsx
+++ b/src/containers/floating/Settings/sections/connections/ConnectionStatus.tsx
@@ -4,11 +4,11 @@ import { IoCheckmarkCircle, IoCloudOfflineOutline } from 'react-icons/io5';
 import { ConnectionIcon } from '../../components/Settings.styles.tsx';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { useTranslation } from 'react-i18next';
-import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+import { useNodeStore } from '@app/store/useNodeStore.ts';
 
 export default function ConnectionStatus() {
     const { t } = useTranslation('settings');
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTariNetwork = useNodeStore((s) => s.isNodeConnected);
 
     return (
         <Stack direction="row" justifyContent="right" alignItems="center">

--- a/src/containers/floating/Settings/sections/connections/Network.tsx
+++ b/src/containers/floating/Settings/sections/connections/Network.tsx
@@ -12,11 +12,11 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 import { formatHashrate } from '@app/utils/formatters.ts';
-import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+import { useNodeStore } from '@app/store/useNodeStore.ts';
 
 export default function Network() {
     const { t } = useTranslation('settings');
-    const baseNodeStatus = useMiningMetricsStore((state) => state?.base_node_status);
+    const baseNodeStatus = useNodeStore((state) => state?.base_node_status);
 
     const sha_network_hashrate = baseNodeStatus?.sha_network_hashrate || 0;
     const tari_randomx_network_hashrate = baseNodeStatus?.tari_randomx_network_hashrate || 0;

--- a/src/containers/floating/Settings/sections/connections/Peers.tsx
+++ b/src/containers/floating/Settings/sections/connections/Peers.tsx
@@ -9,7 +9,9 @@ import {
     SettingsGroupTitle,
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
-import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+import { useNodeStore } from '@app/store/useNodeStore.ts';
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 
 const Count = styled.div<{ $count: number }>`
     border-radius: 11px;
@@ -28,10 +30,14 @@ const Count = styled.div<{ $count: number }>`
 
 export default function Peers() {
     const { t } = useTranslation('settings');
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
-    const connectedPeers = useMiningMetricsStore((state) => state?.connected_peers || []);
-    const connectedPeersCount = connectedPeers?.length || 0;
+    const isConnectedToTariNetwork = useNodeStore((state) => state.isNodeConnected);
+    const nodeIdentity = useNodeStore((state) => state.node_identity);
+    const [connectedPeers, setConnectedPeers] = useState<string[]>([]);
     const listMarkup = connectedPeers.map((peer, i) => <li key={`peer-${peer}:${i}`}>{peer}</li>);
+
+    useEffect(() => {
+        invoke('list_connected_peers').then((peers) => setConnectedPeers(peers));
+    }, [nodeIdentity]);
 
     return (
         <SettingsGroupWrapper>
@@ -39,15 +45,15 @@ export default function Peers() {
                 <SettingsGroupContent>
                     <SettingsGroupTitle>
                         <Typography variant="h6">{t('connected-peers')}</Typography>
-                        {connectedPeersCount ? (
-                            <Count $count={connectedPeersCount}>
-                                <Typography>{connectedPeersCount}</Typography>
+                        {connectedPeers?.length ? (
+                            <Count $count={connectedPeers.length}>
+                                <Typography>{connectedPeers.length}</Typography>
                             </Count>
                         ) : null}
                     </SettingsGroupTitle>
 
                     <Stack style={{ fontSize: '12px' }}>
-                        {connectedPeersCount ? (
+                        {connectedPeers?.length ? (
                             <ol>{listMarkup}</ol>
                         ) : (
                             <p>{isConnectedToTariNetwork ? 0 : t('not-connected-to-tari')}</p>

--- a/src/containers/floating/Settings/sections/experimental/DebugSettings.tsx
+++ b/src/containers/floating/Settings/sections/experimental/DebugSettings.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import useBlockTime from '@app/hooks/mining/useBlockTime.ts';
-import { useMiningMetricsStore } from '@app/store';
+import { useNodeStore } from '@app/store';
 import { Typography } from '@app/components/elements/Typography.tsx';
 import { Stack } from '@app/components/elements/Stack.tsx';
 import {
@@ -14,7 +14,7 @@ import {
 export default function DebugSettings() {
     const { t } = useTranslation('settings');
 
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTariNetwork = useNodeStore((s) => s.isNodeConnected);
 
     const { currentTimeParts } = useBlockTime();
 

--- a/src/containers/main/Dashboard/MiningView/components/BlockTime.tsx
+++ b/src/containers/main/Dashboard/MiningView/components/BlockTime.tsx
@@ -1,13 +1,13 @@
 import { useTranslation } from 'react-i18next';
 
 import useBlockTime from '@app/hooks/mining/useBlockTime.ts';
-import { useMiningMetricsStore } from '@app/store/useMiningMetricsStore.ts';
+import { useNodeStore } from '@app/store/useNodeStore.ts';
 import { BlockTimeContainer, SpacedNum, TimerTypography, TitleTypography } from './BlockTime.styles';
 
 function BlockTime() {
     const { currentTimeParts } = useBlockTime();
     const { t } = useTranslation('mining-view', { useSuspense: false });
-    const isConnectedToTari = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTari = useNodeStore((s) => s.isNodeConnected);
     const { daysString, hoursString, minutes, seconds } = currentTimeParts || {};
 
     const renderHours = hoursString && parseInt(hoursString) > 0;

--- a/src/containers/navigation/components/MiningTiles/components/Tile/Tile.tsx
+++ b/src/containers/navigation/components/MiningTiles/components/Tile/Tile.tsx
@@ -3,7 +3,7 @@ import i18n from 'i18next';
 import { Ref, useEffect, useMemo, useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import NumberFlow from '@number-flow/react';
-import { useConfigUIStore, useMiningMetricsStore, useUIStore } from '@app/store';
+import { useConfigUIStore, useNodeStore, useUIStore } from '@app/store';
 import SuccessAnimation from '../SuccessAnimation/SuccessAnimation';
 import SyncData from '@app/containers/navigation/components/MiningTiles/components/SyncData/SyncData.tsx';
 import LoadingDots from '@app/components/elements/loaders/LoadingDots.tsx';
@@ -73,7 +73,7 @@ export default function Tile({
     const animationState = animationStatus;
     const visualMode = useConfigUIStore((s) => s.visual_mode);
     const towerInitalized = useUIStore((s) => s.towerInitalized);
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTariNetwork = useNodeStore((s) => s.isNodeConnected);
     const [showSuccessAnimation, setShowSuccessAnimation] = useState(false);
 
     const canAnimateTower = useMemo(

--- a/src/containers/navigation/components/VersionChip/ConnectedPulse/ConnectedPulse.tsx
+++ b/src/containers/navigation/components/VersionChip/ConnectedPulse/ConnectedPulse.tsx
@@ -1,8 +1,8 @@
 import { Dot, Pulse, Wrapper } from './styles';
-import { useMiningMetricsStore } from '@app/store';
+import { useNodeStore } from '@app/store';
 
 export default function ConnectedPulse({ size = 5 }: { size?: number }) {
-    const isConnectedToTariNetwork = useMiningMetricsStore((s) => s.isNodeConnected);
+    const isConnectedToTariNetwork = useNodeStore((s) => s.isNodeConnected);
     return (
         <Wrapper $size={size}>
             <Dot $isConnected={isConnectedToTariNetwork} $size={size} />

--- a/src/hooks/app/useTauriEventsListener.ts
+++ b/src/hooks/app/useTauriEventsListener.ts
@@ -4,13 +4,7 @@ import { listen } from '@tauri-apps/api/event';
 import { BACKEND_STATE_UPDATE, BackendStateUpdateEvent } from '@app/types/backend-state.ts';
 
 import { handleNewBlockPayload, useBlockchainVisualisationStore } from '@app/store/useBlockchainVisualisationStore';
-import {
-    handleBaseNodeStatusUpdate,
-    handleConnectedPeersUpdate,
-    setCpuMiningStatus,
-    setGpuDevices,
-    setGpuMiningStatus,
-} from '@app/store/actions/miningMetricsStoreActions';
+import { setCpuMiningStatus, setGpuDevices, setGpuMiningStatus } from '@app/store/actions/miningMetricsStoreActions';
 import {
     handleAskForRestart,
     handleCloseSplashscreen,
@@ -31,7 +25,12 @@ import {
     setIsStuckOnOrphanChain,
     setNetworkStatus,
 } from '@app/store/actions/appStateStoreActions';
-import { setWalletBalance, updateWalletScanningProgress, useSecurityStore } from '@app/store';
+import {
+    handleBaseNodeStatusUpdate,
+    setWalletBalance,
+    updateWalletScanningProgress,
+    useSecurityStore,
+} from '@app/store';
 import { deepEqual } from '@app/utils/objectDeepEqual.ts';
 import {
     handleAppLoaded,
@@ -112,9 +111,6 @@ const useTauriEventsListener = () => {
                             break;
                         case 'GpuPoolStatsUpdate':
                             setGpuPoolStats(event.payload);
-                            break;
-                        case 'ConnectedPeersUpdate':
-                            handleConnectedPeersUpdate(event.payload);
                             break;
                         case 'NewBlockHeight': {
                             const current = useBlockchainVisualisationStore.getState().latestBlockPayload?.block_height;

--- a/src/store/actions/index.ts
+++ b/src/store/actions/index.ts
@@ -40,13 +40,7 @@ export {
     setReleaseNotes,
 } from './appStateStoreActions.ts';
 
-export {
-    handleBaseNodeStatusUpdate,
-    handleConnectedPeersUpdate,
-    setCpuMiningStatus,
-    setGpuDevices,
-    setGpuMiningStatus,
-} from './miningMetricsStoreActions.ts';
+export { setCpuMiningStatus, setGpuDevices, setGpuMiningStatus } from './miningMetricsStoreActions.ts';
 
 export {
     getMiningNetwork,
@@ -70,3 +64,5 @@ export {
     refreshTransactions,
     setWalletBalance,
 } from './walletStoreActions';
+
+export { handleBaseNodeStatusUpdate } from './nodeStoreActions.ts';

--- a/src/store/actions/miningMetricsStoreActions.ts
+++ b/src/store/actions/miningMetricsStoreActions.ts
@@ -1,8 +1,6 @@
-import { BaseNodeStatus, CpuMinerStatus, GpuDevice, GpuMinerStatus } from '@app/types/app-status.ts';
+import { CpuMinerStatus, GpuDevice, GpuMinerStatus } from '@app/types/app-status.ts';
 
-import { setAnimationState } from '@tari-project/tari-tower';
 import { useMiningMetricsStore } from '../useMiningMetricsStore.ts';
-import { useMiningStore } from '../useMiningStore.ts';
 
 export const setGpuDevices = (gpu_devices: GpuDevice[]) => {
     useMiningMetricsStore.setState({ gpu_devices });
@@ -12,26 +10,4 @@ export const setGpuMiningStatus = (gpu_mining_status: GpuMinerStatus) => {
 };
 export const setCpuMiningStatus = (cpu_mining_status: CpuMinerStatus) => {
     useMiningMetricsStore.setState((c) => ({ ...c, cpu_mining_status }));
-};
-
-export const handleConnectedPeersUpdate = (connected_peers: string[]) => {
-    const wasNodeConnected = useMiningMetricsStore.getState().isNodeConnected;
-    const isNodeConnected = connected_peers?.length > 0;
-    useMiningMetricsStore.setState((c) => ({ ...c, connected_peers, isNodeConnected }));
-
-    const miningInitiated =
-        useMiningStore.getState().isCpuMiningInitiated || useMiningStore.getState().isGpuMiningInitiated;
-    if (miningInitiated) {
-        if (!isNodeConnected && wasNodeConnected) {
-            // Lost connection
-            setAnimationState('stop');
-        }
-        if (isNodeConnected && !wasNodeConnected) {
-            // Restored connection
-            setAnimationState('start');
-        }
-    }
-};
-export const handleBaseNodeStatusUpdate = (base_node_status: BaseNodeStatus) => {
-    useMiningMetricsStore.setState((c) => ({ ...c, base_node_status }));
 };

--- a/src/store/actions/nodeStoreActions.ts
+++ b/src/store/actions/nodeStoreActions.ts
@@ -1,0 +1,24 @@
+import { BaseNodeStatus } from '@app/types/app-status.ts';
+
+import { setAnimationState } from '@tari-project/tari-tower';
+import { useNodeStore } from '../useNodeStore.ts';
+import { useMiningStore } from '../useMiningStore.ts';
+
+export const handleBaseNodeStatusUpdate = (base_node_status: BaseNodeStatus) => {
+    const wasNodeConnected = useNodeStore.getState().isNodeConnected;
+    const isNodeConnected = base_node_status.num_connections > 0;
+    useNodeStore.setState((c) => ({ ...c, base_node_status, isNodeConnected }));
+
+    const miningInitiated =
+        useMiningStore.getState().isCpuMiningInitiated || useMiningStore.getState().isGpuMiningInitiated;
+    if (miningInitiated) {
+        if (!isNodeConnected && wasNodeConnected) {
+            // Lost connection
+            setAnimationState('stop');
+        }
+        if (isNodeConnected && !wasNodeConnected) {
+            // Restored connection
+            setAnimationState('start');
+        }
+    }
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,3 +14,4 @@ export * from './useShellOfSecretsStore.ts';
 export * from './useSecurityStore.ts';
 export * from './useUIStore.ts';
 export * from './useWalletStore.ts';
+export * from './useNodeStore.ts';

--- a/src/store/useMiningMetricsStore.ts
+++ b/src/store/useMiningMetricsStore.ts
@@ -1,29 +1,13 @@
 import { create } from './create';
-import { BaseNodeStatus, CpuMinerStatus, GpuMinerStatus, GpuDevice } from '@app/types/app-status';
+import { CpuMinerStatus, GpuMinerStatus, GpuDevice } from '@app/types/app-status';
 
 interface MiningMetricsStoreState {
-    isNodeConnected: boolean;
-    base_node_status: BaseNodeStatus;
-    connected_peers: string[];
     gpu_devices: GpuDevice[];
     gpu_mining_status: GpuMinerStatus;
     cpu_mining_status: CpuMinerStatus;
 }
 
 const initialState: MiningMetricsStoreState = {
-    isNodeConnected: false,
-    base_node_status: {
-        sha_network_hashrate: 0,
-        monero_randomx_network_hashrate: 0,
-        tari_randomx_network_hashrate: 0,
-        block_reward: 0,
-        block_height: 0,
-        block_time: 0,
-        is_synced: false,
-        num_connections: 0,
-        readiness_status: '',
-    },
-    connected_peers: [],
     gpu_devices: [],
     gpu_mining_status: {
         is_mining: false,

--- a/src/store/useNodeStore.ts
+++ b/src/store/useNodeStore.ts
@@ -1,6 +1,7 @@
 import { BackgroundNodeSyncUpdatePayload } from '@app/types/events-payloads';
 import { create } from './create';
 import { deepEqual } from '@app/utils/objectDeepEqual.ts';
+import { BaseNodeStatus } from '@app/types/app-status';
 
 export type NodeType = 'Local' | 'Remote' | 'RemoteUntilLocal' | 'LocalAfterRemote';
 export interface NodeIdentity {
@@ -14,6 +15,8 @@ interface NodeStoreState {
     node_connection_address?: string;
     backgroundNodeSyncLastUpdate?: BackgroundNodeSyncUpdatePayload;
     tor_entry_guards: string[];
+    isNodeConnected: boolean;
+    base_node_status: BaseNodeStatus;
 }
 
 const initialState: NodeStoreState = {
@@ -24,6 +27,18 @@ const initialState: NodeStoreState = {
     },
     node_connection_address: '',
     tor_entry_guards: [],
+    isNodeConnected: false,
+    base_node_status: {
+        sha_network_hashrate: 0,
+        monero_randomx_network_hashrate: 0,
+        tari_randomx_network_hashrate: 0,
+        block_reward: 0,
+        block_height: 0,
+        block_time: 0,
+        is_synced: false,
+        num_connections: 0,
+        readiness_status: '',
+    },
 };
 
 export const useNodeStore = create<NodeStoreState>()(() => ({

--- a/src/types/backend-state.ts
+++ b/src/types/backend-state.ts
@@ -1,7 +1,6 @@
 import {
     BackgroundNodeSyncUpdatePayload,
     ConfigPoolsPayload,
-    ConnectedPeersUpdatePayload,
     ConnectionStatusPayload,
     CriticalProblemPayload,
     DetectedAvailableGpuEngines,
@@ -56,10 +55,6 @@ export type BackendStateUpdateEvent =
     | {
           event_type: 'GpuMiningUpdate';
           payload: GpuMinerStatus;
-      }
-    | {
-          event_type: 'ConnectedPeersUpdate';
-          payload: ConnectedPeersUpdatePayload;
       }
     | {
           event_type: 'NewBlockHeight';

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -53,8 +53,6 @@ export interface ShowReleaseNotesPayload {
     should_show_dialog: boolean;
 }
 
-export type ConnectedPeersUpdatePayload = string[];
-
 export interface NodeTypeUpdatePayload {
     node_type?: 'Local' | 'Remote' | 'RemoteUntilLocal' | 'LocalAfterRemote';
     node_identity?: {

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -155,4 +155,5 @@ declare module '@tauri-apps/api/core' {
     function invoke(param: 'reset_gpu_pool_config', payload: { gpuPoolName: string }): Promise<void>;
     function invoke(param: 'reset_cpu_pool_config', payload: { cpuPoolName: string }): Promise<void>;
     function invoke(param: 'restart_phases', payload: { phases: SetupPhase[] }): Promise<void>;
+    function invoke(param: 'list_connected_peers'): Promise<string[]>;
 }


### PR DESCRIPTION
Description
---
#### _get_network_state_
**(+ 80% calls reduction)**

* Remote node's network status fetched once per 45secs instead of once per 10secs
* Orphan check uses global network status instead of fetching it's own once per 30sec(btw increased this to 60secs)

#### _get_blocks_
**(~66% calls reduction)**
- Orphan check changed to be performed once per 60secs instead of once per 30secs
- telemetry service uses already defined flag

#### _list_connected_peers_
**(~ 99% calls reduction)**
- `list_connected_peers` called on demand, not once per 10 sec

Motivation and Context
---
* Remote nodes are overloaded with grpc calls that could be optimize

Frontend updates
---
Move node related properties from `miningMetricsStore` to `nodeStore`