### PR TITLE
fix: clamp cpu cores to use between 1 and max available cores

### DIFF
--- a/src-tauri/src/cpu_miner.rs
+++ b/src-tauri/src/cpu_miner.rs
@@ -253,7 +253,8 @@ impl CpuMiner {
 
         let cpu_cores_to_use = max_cpu_available
             .saturating_mul(cpu_usage_percentage)
-            .saturating_div(100);
+            .saturating_div(100)
+            .clamp(1, max_cpu_available);
 
         info!(target: LOG_TARGET, "Using {cpu_cores_to_use} CPU cores for mining");
 


### PR DESCRIPTION
### [ Summary ]
- Prevent passing to xmrig threads arg values below 1 and bigger then available threads