### PR TITLE
fix(ui): query checks for exchanges

### DIFF
--- a/src/containers/navigation/components/MiningTiles/components/exchange-button/ExchangeButton.tsx
+++ b/src/containers/navigation/components/MiningTiles/components/exchange-button/ExchangeButton.tsx
@@ -7,7 +7,6 @@ import { Button, LogosWrapper } from './styles.ts';
 export default function ExchangeButton() {
     const { t } = useTranslation('wallet');
     const { data: exchanges } = useFetchExchangeList();
-
     function handleClick() {
         setShowUniversalModal(true);
     }

--- a/src/hooks/exchanges/fetchExchanges.ts
+++ b/src/hooks/exchanges/fetchExchanges.ts
@@ -20,10 +20,8 @@ function handleRewardData(list: ExchangeBranding[]) {
     setRewardData({ reward_earn_cap_percentage: highestAmt, reward_end_date: latestDate });
 }
 
-export const queryFn = async () => {
-    const apiUrl = useConfigBEInMemoryStore.getState().airdrop_api_url;
+const queryFn = async (apiUrl: string) => {
     const path = `/miner/exchanges?include_wXTM=true`;
-
     if (!apiUrl.length) return [];
     try {
         const res = await handleAirdropRequest<{ exchanges: ExchangeBranding[] }>({
@@ -49,16 +47,16 @@ export const queryFn = async () => {
 
 export function useFetchExchangeList() {
     const isWalletUIExchangeSpecific = useConfigUIStore((s) => s.wallet_ui_mode === WalletUIMode.ExchangeSpecificMiner);
-
+    const apiUrl = useConfigBEInMemoryStore((s) => s.airdrop_api_url);
     return useQuery({
         queryKey: [KEY_XC_LIST],
-        enabled: !isWalletUIExchangeSpecific,
-        queryFn: () => queryFn(),
+        enabled: Boolean(apiUrl.length && !isWalletUIExchangeSpecific),
+        queryFn: async () => await queryFn(apiUrl),
         refetchOnWindowFocus: true,
         refetchInterval: 60 * 1000 * 60 * 3, // every three hours
     });
 }
 
 export async function fetchExchangeList() {
-    return await queryClient.fetchQuery({ queryKey: [KEY_XC_LIST], queryFn: () => queryFn() });
+    return await queryClient.fetchQuery({ queryKey: [KEY_XC_LIST] });
 }


### PR DESCRIPTION
Description
---

`apiUrl` was empty when the query was initially fired, and being in a normal function there was no update once it was set, so just moved getting it to the query hook & used the value for `enabled`

Motivation and Context
---

- fixes https://github.com/tari-project/universe/issues/2790 😬 

How Has This Been Tested?
---

- dlocally: 

<img width="2180" height="1386" alt="optimised_29-08_14-54_1135" src="https://github.com/user-attachments/assets/22829f13-8344-4612-8181-e9e72a9aab8a" />

<img width="1056" height="284" alt="optimised_29-08_14-54_1136" src="https://github.com/user-attachments/assets/2da7570e-efb6-44b3-815c-b8df9b6c04c1" />

<img width="856" height="326" alt="optimised_29-08_14-55_1137" src="https://github.com/user-attachments/assets/03a6568f-7566-4704-b23a-c39cadabc86b" />

<img width="860" height="422" alt="optimised_29-08_14-55_1138" src="https://github.com/user-attachments/assets/4eac28c9-94d2-4d3d-a1ec-e28116277841" />
