### PR TITLE
fix(ui): crew rewards logout while expanded ui bug

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/styles.ts
@@ -41,7 +41,7 @@ export const WidgetWrapper = styled('div')<{ $isOpen: boolean; $isLogin?: boolea
     padding: 20px;
     padding-bottom: 0px;
 
-    max-height: ${({ $isLogin }) => ($isLogin ? '274px' : '115px')};
+    max-height: 115px;
 
     transition: max-height 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -55,5 +55,11 @@ export const WidgetWrapper = styled('div')<{ $isOpen: boolean; $isLogin?: boolea
         $isOpen &&
         css`
             max-height: 830px;
+        `}
+
+    ${({ $isLogin }) =>
+        $isLogin &&
+        css`
+            max-height: 274px;
         `}
 `;


### PR DESCRIPTION
I found this UI bug where if you `expand` the crew rewards then log out of your account, the UI remains expanded. So the UI for the Login CTA gets broken. 

<img width="2658" height="1512" alt="CleanShot 2025-09-03 at 20 57 21@2x" src="https://github.com/user-attachments/assets/939eec85-593b-48fa-9cc1-0bbd8ae8c811" />

Fixed:

<img width="2636" height="1498" alt="CleanShot 2025-09-03 at 21 01 09@2x" src="https://github.com/user-attachments/assets/3a562bc4-cddf-439a-9b88-2b448e2c2abb" />
