### PR TITLE
fix(ui): set dialog z-index to a higher number to fix modal stacking

### DIFF
--- a/src/components/elements/dialog/Dialog.styles.ts
+++ b/src/components/elements/dialog/Dialog.styles.ts
@@ -7,7 +7,7 @@ export const Overlay = styled(FloatingOverlay)`
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1;
+    z-index: 9;
 `;
 
 export const ContentWrapper = styled.div<ContentWrapperStyleProps>`

--- a/src/components/elements/dialog/Dialog.styles.ts
+++ b/src/components/elements/dialog/Dialog.styles.ts
@@ -7,7 +7,7 @@ export const Overlay = styled(FloatingOverlay)`
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 9;
+    z-index: 99;
 `;
 
 export const ContentWrapper = styled.div<ContentWrapperStyleProps>`


### PR DESCRIPTION
The z-index on the `Dialog` component being set to `1` is too low and causing issues with the stacking order. Modals should always be above everything ( except other more important modals like critical errors ).   

This PR sets the `z-index: 99` which should be high enough to prevent issues. 

<img width="2674" height="1522" alt="CleanShot 2025-09-04 at 18 40 41@2x" src="https://github.com/user-attachments/assets/dacc906b-9576-4535-bb9e-9680130c8b8d" />

<img width="1010" height="830" alt="CleanShot 2025-09-04 at 18 46 44@2x" src="https://github.com/user-attachments/assets/4f0b24df-c9ce-4dd1-97ff-5f9d1fa03fad" />

