### PR TITLE
feat(ui): crew rewards invite avatar placeholder buttons

### DIFF
--- a/src/components/elements/Avatar/styles.ts
+++ b/src/components/elements/Avatar/styles.ts
@@ -19,5 +19,4 @@ export const AvatarWrapper = styled.div<{ $image: string; $size: number }>`
     font-size: ${({ $size }) => $size / 2}px;
     font-weight: 600;
     color: #fff;
-    cursor: default;
 `;

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/AvatarInviteButton.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/AvatarInviteButton.tsx
@@ -1,5 +1,35 @@
-import { Wrapper } from './styles';
+import { useCopyToClipboard } from '@app/hooks/helpers';
+import { Copied, Wrapper } from './styles';
+import { useAirdropStore } from '@app/store';
+import { AnimatePresence } from 'motion/react';
+import { useTranslation } from 'react-i18next';
 
 export default function AvatarInviteButton() {
-    return <Wrapper>+</Wrapper>;
+    const { t } = useTranslation();
+    const { copyToClipboard, isCopied } = useCopyToClipboard();
+    const airdropUrl = useAirdropStore((state) => state.backendInMemoryConfig?.airdrop_url || '');
+    const referralCode = useAirdropStore((state) => state.userDetails?.user?.referral_code || '');
+
+    const handleInviteButtonClick = () => {
+        if (referralCode && airdropUrl && !isCopied) {
+            copyToClipboard(`${airdropUrl}/download/${referralCode}`);
+        }
+    };
+
+    return (
+        <Wrapper onClick={handleInviteButtonClick}>
+            <AnimatePresence>
+                {isCopied && (
+                    <Copied
+                        initial={{ opacity: 0, y: 0, x: '-50%' }}
+                        animate={{ opacity: 1, y: -4, x: '-50%' }}
+                        exit={{ opacity: 0, x: '-50%' }}
+                    >
+                        {t('airdrop:crewRewards.copied')}
+                    </Copied>
+                )}
+            </AnimatePresence>
+            +
+        </Wrapper>
+    );
 }

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/AvatarInviteButton.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/AvatarInviteButton.tsx
@@ -1,0 +1,5 @@
+import { Wrapper } from './styles';
+
+export default function AvatarInviteButton() {
+    return <Wrapper>+</Wrapper>;
+}

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/AvatarInviteButton/styles.ts
@@ -1,7 +1,36 @@
 import styled from 'styled-components';
+import * as m from 'motion/react-m';
 
 export const Wrapper = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
+
+    width: 100%;
+    height: 100%;
+
+    border-radius: 100%;
+    flex-shrink: 0;
+    position: relative;
+`;
+
+export const Copied = styled(m.div)`
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+
+    background-color: #16d92f;
+    color: #fff;
+    padding: 2px 8px 1px 8px;
+    border-radius: 100px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 12px;
+    text-align: center;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    margin-bottom: 0px;
 `;

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
@@ -16,6 +16,7 @@ import { useReferrerProgress } from '@app/hooks/crew/useReferrerProgress';
 import { formatNumber, FormatPreset } from '@app/utils';
 import { useTranslation, Trans } from 'react-i18next';
 import AvatarInviteButton from './AvatarInviteButton/AvatarInviteButton';
+import { useCrewRewardsStore } from '@app/store/useCrewRewardsStore';
 
 export default function StatsRow() {
     const { t } = useTranslation();
@@ -30,6 +31,12 @@ export default function StatsRow() {
     const isLoading = crewLoading || crewLoading;
     const hasError = !!crewError;
     const hasFriends = totalFriends > 0;
+
+    const { setIsOpen } = useCrewRewardsStore();
+
+    const handleCrewToggle = () => {
+        setIsOpen(true);
+    };
 
     if (isLoading) {
         return (
@@ -54,8 +61,14 @@ export default function StatsRow() {
             {hasFriends ? (
                 <ActiveMinersWrapper>
                     <PhotosRow>
-                        {crewData?.members.map(({ image, displayName }) => (
-                            <PhotoWrapper>
+                        <PhotoWrapper $isInviteButton={true}>
+                            <AvatarInviteButton />
+                        </PhotoWrapper>
+                        <PhotoWrapper $isInviteButton={true}>
+                            <AvatarInviteButton />
+                        </PhotoWrapper>
+                        {crewData?.members.map(({ image, displayName }, index) => (
+                            <PhotoWrapper key={`${index}-crewminiavatar`} onClick={handleCrewToggle}>
                                 <Avatar image={image} username={displayName} key={image} size={28} />
                             </PhotoWrapper>
                         ))}

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
@@ -15,6 +15,7 @@ import {
 import { useReferrerProgress } from '@app/hooks/crew/useReferrerProgress';
 import { formatNumber, FormatPreset } from '@app/utils';
 import { useTranslation, Trans } from 'react-i18next';
+import AvatarInviteButton from './AvatarInviteButton/AvatarInviteButton';
 
 export default function StatsRow() {
     const { t } = useTranslation();
@@ -53,11 +54,11 @@ export default function StatsRow() {
             {hasFriends ? (
                 <ActiveMinersWrapper>
                     <PhotosRow>
-                        <PhotoWrapper>
-                            {crewData?.members.map(({ image, displayName }) => (
+                        {crewData?.members.map(({ image, displayName }) => (
+                            <PhotoWrapper>
                                 <Avatar image={image} username={displayName} key={image} size={28} />
-                            ))}
-                        </PhotoWrapper>
+                            </PhotoWrapper>
+                        ))}
                     </PhotosRow>
 
                     <TextWrapper>

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
@@ -61,12 +61,12 @@ export default function StatsRow() {
             {hasFriends ? (
                 <ActiveMinersWrapper>
                     <PhotosRow>
-                        <PhotoWrapper $isInviteButton={true}>
-                            <AvatarInviteButton />
-                        </PhotoWrapper>
-                        <PhotoWrapper $isInviteButton={true}>
-                            <AvatarInviteButton />
-                        </PhotoWrapper>
+                        {totalFriends < 3 &&
+                            Array.from({ length: 3 - totalFriends }).map((_, index) => (
+                                <PhotoWrapper key={`${index}-invitebutton`} $isInviteButton={true}>
+                                    <AvatarInviteButton />
+                                </PhotoWrapper>
+                            ))}
                         {crewData?.members.map(({ image, displayName }, index) => (
                             <PhotoWrapper key={`${index}-crewminiavatar`} onClick={handleCrewToggle}>
                                 <Avatar image={image} username={displayName} key={image} size={28} />

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.div`
     display: flex;
@@ -20,21 +20,23 @@ export const PhotosRow = styled.div`
     position: relative;
 `;
 
-export const PhotoWrapper = styled.div`
+export const PhotoWrapper = styled.button<{ $isInviteButton?: boolean }>`
     width: 32px;
     height: 32px;
     border-radius: 100%;
 
-    background-color: #d9d9d9;
+    background-color: #404141;
     border: 2px solid #323333;
     position: relative;
+
+    cursor: pointer;
 
     &:not(:first-child) {
         margin-left: -17px;
     }
 
     &:nth-child(1) {
-        z-index: 3;
+        z-index: 1;
     }
 
     &:nth-child(2) {
@@ -42,8 +44,24 @@ export const PhotoWrapper = styled.div`
     }
 
     &:nth-child(3) {
-        z-index: 1;
+        z-index: 3;
     }
+
+    ${({ $isInviteButton }) =>
+        $isInviteButton &&
+        css`
+            color: #404141;
+
+            transition:
+                color 0.2s ease-in-out,
+                background-color 0.2s ease-in-out;
+
+            &:hover {
+                z-index: 4;
+                color: #fff;
+                background-color: #656666;
+            }
+        `}
 `;
 
 export const TextWrapper = styled.div`


### PR DESCRIPTION
When there was less than 3 crew members, the UI looks a little strange. This PR adds placeholder avatars that work as invite buttons when clicked. 

I also made it so when you click on a real avatar it opens the full crew rewards list view. 

<img width="1010" height="544" alt="CleanShot 2025-09-09 at 16 11 26@2x" src="https://github.com/user-attachments/assets/e9068ccf-1b44-4704-af87-71a29a664572" />

<img width="1100" height="678" alt="CleanShot 2025-09-09 at 16 12 10@2x" src="https://github.com/user-attachments/assets/dd8166ec-3036-48fe-abd6-f7fe6e62ef13" />

<img width="1058" height="544" alt="CleanShot 2025-09-09 at 16 12 49@2x" src="https://github.com/user-attachments/assets/7ae78de7-7e74-4186-9e6b-29f0b6ceb5eb" />


