### PR TITLE
fix(ui): full width manage your crew button

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/RewardsWidget.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/RewardsWidget.tsx
@@ -5,7 +5,7 @@ import CrewSection from './sections/CrewSection/CrewSection';
 import MainSection from './sections/MainSection/MainSection';
 import StreakProgress from './sections/StreakProgress/StreakProgress';
 
-import { ExpandButton, Holder, PositionWrapper, WidgetWrapper } from './styles';
+import { ExpandButton, ExpandButtonWrapper, Holder, PositionWrapper, WidgetWrapper } from './styles';
 import { useCrewRewardsStore } from '../../../../store/useCrewRewardsStore';
 import { AnimatePresence } from 'motion/react';
 import { useAirdropStore } from '@app/store';
@@ -65,9 +65,11 @@ export default function RewardsWidget() {
                     <AnimatePresence>{isOpen && <CrewSection />}</AnimatePresence>
                     <AnimatePresence>
                         {isHovering && !isOpen && (
-                            <ExpandButton onClick={() => setIsOpen(true)} {...buttonAnimation}>
-                                {t('airdrop:crewRewards.manageYourCrew')}
-                            </ExpandButton>
+                            <ExpandButtonWrapper {...buttonAnimation}>
+                                <ExpandButton onClick={() => setIsOpen(true)}>
+                                    {t('airdrop:crewRewards.manageYourCrew')}
+                                </ExpandButton>
+                            </ExpandButtonWrapper>
                         )}
                     </AnimatePresence>
                 </WidgetWrapper>

--- a/src/containers/main/CrewRewards/RewardsWidget/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/styles.ts
@@ -74,8 +74,22 @@ export const WidgetWrapper = styled('div')<{ $isOpen: boolean; $isLogin?: boolea
         `}
 `;
 
-export const ExpandButton = styled(m.button)`
-    width: 200px;
+export const ExpandButtonWrapper = styled(m.div)`
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 20px;
+
+    position: absolute;
+    top: 115px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+`;
+
+export const ExpandButton = styled.button`
+    width: 100%;
     height: 33px;
     background: rgba(255, 255, 255, 0.05);
     border-radius: 10px;
@@ -89,12 +103,6 @@ export const ExpandButton = styled(m.button)`
     line-height: 190%;
 
     white-space: nowrap;
-
-    position: absolute;
-    top: 115px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 2;
 
     cursor: pointer;
     transition: background 0.2s ease-in-out;


### PR DESCRIPTION
This PR mades the "Manage your crew" expand button in the Crew Rewards widget full width. This was a request for product/design. 

<img width="1190" height="586" alt="CleanShot 2025-09-10 at 19 27 41@2x" src="https://github.com/user-attachments/assets/ecb0740f-2a35-49d4-b466-12a19f087100" />
