### PR TITLE
feat(ui): Dialogue modal Vignette shadow background

### DIFF
--- a/src/components/elements/dialog/Dialog.styles.ts
+++ b/src/components/elements/dialog/Dialog.styles.ts
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 import { FloatingOverlay } from '@floating-ui/react';
 import { convertHexToRGBA } from '@app/utils';
 import { ContentWrapperStyleProps } from './types.ts';
+import { m } from 'motion/react';
 
 export const Overlay = styled(FloatingOverlay)`
     display: flex;
@@ -11,7 +12,7 @@ export const Overlay = styled(FloatingOverlay)`
 `;
 
 export const ContentWrapper = styled.div<ContentWrapperStyleProps>`
-    box-shadow: 0 4px 45px 0 rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 45px 0 rgba(0, 0, 0, 0.35);
     border-radius: clamp(20px, 5vh, 35px);
     overflow: ${({ $allowOverflow }) => ($allowOverflow ? 'unset' : 'hidden')};
     max-height: 90%;
@@ -37,6 +38,15 @@ export const ContentWrapper = styled.div<ContentWrapperStyleProps>`
         }
     }};
 `;
+
+export const Vignette = styled(m.div)`
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    background: radial-gradient(50% 50% at 50% 50%, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%);
+    pointer-events: none;
+`;
+
 export const ContentScrollContainer = styled.div<ContentWrapperStyleProps>`
     overflow: ${({ $allowOverflow }) => ($allowOverflow ? 'unset' : 'hidden')};
     position: relative;

--- a/src/components/elements/dialog/Dialog.tsx
+++ b/src/components/elements/dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import {
     Content,
     ContentScrollContainer,
     ContentWrapper,
+    Vignette,
     Overlay,
     WrapperContent,
 } from './Dialog.styles.ts';
@@ -75,6 +76,7 @@ export function DialogContent({ variant = 'primary', closeButton, ...props }: Di
                                 {markup}
                             </MotionOverlay>
                         </FloatingFocusManager>
+                        <Vignette initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} />
                     </FloatingPortal>
                 ) : null}
             </AnimatePresence>


### PR DESCRIPTION
I feel like there isnt enough contrast between the background and the foreground with the Dialogue component, so I added a `Vignette` layer. This adds a cool `highlight` effect to the modal, and increases contrast between the foreground modal and background elements ( without needing blur ).

Before:

<img width="2670" height="1532" alt="CleanShot 2025-09-10 at 19 40 35@2x" src="https://github.com/user-attachments/assets/b3c8f929-f6c0-425d-a798-4b96131eee4d" />

After:

<img width="2670" height="1518" alt="CleanShot 2025-09-10 at 19 40 05@2x" src="https://github.com/user-attachments/assets/47007b15-62b5-4310-86d7-98adfa04e93c" />
