### PR TITLE
fix(ui): fix crew rewards hover bug when logged out

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/RewardsWidget.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/RewardsWidget.tsx
@@ -44,7 +44,7 @@ export default function RewardsWidget() {
         return (
             <PositionWrapper {...introAnimation}>
                 <Holder>
-                    <WidgetWrapper $isOpen={isOpen} $isLogin={true}>
+                    <WidgetWrapper $isOpen={false} $isLogin={true}>
                         <LoginSection />
                     </WidgetWrapper>
                 </Holder>


### PR DESCRIPTION
Here's a bug where the Logged Out UI for the Crew Rewards widget can expand on hover when the user logs out. 

Steps to reproduce: Log out of your airdrop account, hover the Crew Rewards widget. 

Result: The widget expands to full height when it shouldn't. 

Loom Video: https://www.loom.com/share/9f2d2c8f25d64db09da43d2a76ebf53e?sid=48456aff-0d13-4ecf-aff8-f5c97cbfaeda

<img width="2716" height="1580" alt="CleanShot 2025-09-12 at 18 11 29@2x" src="https://github.com/user-attachments/assets/acbe1782-f8f9-4fb6-a10b-46ddb1e6edf0" />


