### PR TITLE
fix: When GPU is disabled, Universe should not say "Rewards in Progress."

### DIFF
--- a/public/locales/af/p2p.json
+++ b/public/locales/af/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Belonings in Proses",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Swembad is besig om op te warm",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Beloningsdrempel"

--- a/public/locales/cn/p2p.json
+++ b/public/locales/cn/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "奖励进行中",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "矿池正在热身",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "奖励门槛"

--- a/public/locales/de/p2p.json
+++ b/public/locales/de/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Belohnungen in Bearbeitung",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Pool wird aufgewärmt",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Belohnungsschwelle"

--- a/public/locales/en/p2p.json
+++ b/public/locales/en/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Rewards in Progress",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Pool is warming up",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Rewards threshold"

--- a/public/locales/fr/p2p.json
+++ b/public/locales/fr/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Récompenses en cours",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Le pool se réchauffe",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Seuil de récompenses"

--- a/public/locales/hi/p2p.json
+++ b/public/locales/hi/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "इनाम प्रगति पर",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "पूल गर्म हो रहा है",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "इनाम सीमा"

--- a/public/locales/id/p2p.json
+++ b/public/locales/id/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Hadiah Sedang Berlangsung",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Pool sedang memanas",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Ambang Hadiah"

--- a/public/locales/ja/p2p.json
+++ b/public/locales/ja/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "進行中の報酬",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "プールが準備中です",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "報酬のしきい値"

--- a/public/locales/ko/p2p.json
+++ b/public/locales/ko/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "진행 중인 보상",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "풀 준비 중",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "보상 기준"

--- a/public/locales/pl/p2p.json
+++ b/public/locales/pl/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Nagrody w toku",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Pula się rozgrzewa",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Próg nagród"

--- a/public/locales/ru/p2p.json
+++ b/public/locales/ru/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Вознаграждение в процессе",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} задизейблен",
     "tile-loading": "Пул разогревается",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Порог вознаграждения"

--- a/public/locales/tr/p2p.json
+++ b/public/locales/tr/p2p.json
@@ -18,6 +18,7 @@
     "earned": "You earned",
     "tile-heading": "Devam Eden Ödüller",
     "tile-heading-zero": "Rewards start in ~30 mins",
+    "tile-disabled-heading": "{{unit}} is disabled",
     "tile-loading": "Havuz ısınıyor",
     "tooltip-copy": "“In Progress” until you earn a minimum of <strong>{{amount}}</strong>. There may be a delay between sending your payout and it displaying in your wallet txs and balance.",
     "tooltip-tile-heading": "Ödül Eşiği"

--- a/src/containers/navigation/components/MiningTiles/Miner.tsx
+++ b/src/containers/navigation/components/MiningTiles/Miner.tsx
@@ -62,9 +62,16 @@ export default function MinerTile({
 
     const mainNumber = isPoolEnabled ? currentUnpaid : formattedHashRate.value;
     const mainUnit = isPoolEnabled ? 'XTM' : formattedHashRate.unit;
-    const mainLabel = isPoolEnabled
-        ? t('stats.tile-heading', { context: isMining && currentUnpaid === 0 && 'zero', ns: 'p2p' })
-        : t(mainLabelKey);
+
+    let mainLabel: string;
+    if (enabled && isPoolEnabled) {
+        const context = isMining && currentUnpaid === 0 && 'zero';
+        mainLabel = t('stats.tile-heading', { context, ns: 'p2p' });
+    } else if (enabled) {
+        mainLabel = t(mainLabelKey);
+    } else {
+        mainLabel = t('stats.tile-disabled-heading', { unit: title, ns: 'p2p' });
+    }
 
     const [isOpen, setIsOpen] = useState(false);
     const { refs, context, floatingStyles } = useFloating({
@@ -108,7 +115,7 @@ export default function MinerTile({
                 minerModuleState={minerModuleState}
             />
             <AnimatePresence>
-                {isOpen && showTooltip && !hasMinerModuleCrashed && (
+                {enabled && isOpen && showTooltip && !hasMinerModuleCrashed && (
                     <Tooltip ref={refs.setFloating} {...getFloatingProps()} style={floatingStyles}>
                         <ExpandedBox
                             initial={{ opacity: 0, y: 10 }}


### PR DESCRIPTION
## Description

- Added "(CPU|GPU) is disabled" texts to tiles;

## Motivation and Context

* [When GPU is disabled, Universe should not say "Rewards in Progress." #2828](https://github.com/tari-project/universe/issues/2828)

## How Has This Been Tested?

- locally

https://github.com/user-attachments/assets/37686c2d-1361-4363-9a13-cb5da08ed4f4

## Steps for PR Reviewers to Verify

- Toggle mining units state;
- Toggle pool/solo mining settings;

## Breaking Changes

- [x] None  
- [ ] Requires the data directory on the base node to be deleted  
- [ ] Requires a hard fork  
- [ ] Other (please specify):  
