### PR TITLE
fix(ui): user feedback - check for survey data

### DIFF
--- a/src/hooks/user/surveys/useFetchSurveyContent.ts
+++ b/src/hooks/user/surveys/useFetchSurveyContent.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const KEY_SURVEYS = 'surveys';
 
-async function fetchSurvey(slug: string): Promise<Survey> {
+export async function fetchSurvey(slug: string): Promise<Survey> {
     try {
         const res = await handleAirdropRequest<Survey>({
             path: `/survey/${slug}`,


### PR DESCRIPTION
Description
---

- checking for survey content in the shutdown handler using `ensureQueryData` before showing the Close Survey modal

Motivation and Context
---
- modal would pop up and stay on loading if no internet (still closes if you dismiss or close again, but bad UX)

How Has This Been Tested?
---
- locally

**no connection (no content):**

https://github.com/user-attachments/assets/ae539948-efda-49f8-85c1-6242ad707cdb

**wifi back on:**

https://github.com/user-attachments/assets/587424a3-0130-4e7b-ba90-e27f83cfa225


What process can a PR reviewer use to test or verify this change?
---
- test closing with no internet