### PR TITLE
fix: use miningdaysprogress for time remaining

### DIFF
--- a/src/containers/main/CrewRewards/crewTransformers.ts
+++ b/src/containers/main/CrewRewards/crewTransformers.ts
@@ -79,7 +79,7 @@ export const calculateTimeRemaining = (member: CrewMember, minRequirements: MinR
     if (daysRemaining <= 0) return undefined;
 
     return {
-        current: daysRemaining,
+        current: progress.miningDaysProgress,
         total: minRequirements.totalDaysRequired,
         unit: 'Days',
     };


### PR DESCRIPTION
The `calculateTimeRemaining` function was incorrectly using `daysRemaining` which was calculated based on the difference between start and end dates, not the actual mining progress. This commit fixes this by using `progress.miningDaysProgress` to correctly represent the current mining progress in days.
