### PR TITLE
fix: miners sometimes not properly marked as unhealthy

### DIFF
--- a/src-tauri/src/mining/gpu/miners/graxil.rs
+++ b/src-tauri/src/mining/gpu/miners/graxil.rs
@@ -346,10 +346,13 @@ impl StatusMonitor for GraxilGpuMinerStatusMonitor {
                     }
                     HealthStatus::Healthy
                 } else {
-                    HealthStatus::Warning
+                    HealthStatus::Unhealthy
                 }
             }
-            Err(_) => HealthStatus::Unhealthy,
+            Err(_) => {
+                let _ = self.gpu_status_sender.send(GpuMinerStatus::default());
+                HealthStatus::Unhealthy
+            }
         }
     }
 }

--- a/src-tauri/src/mining/gpu/miners/lolminer.rs
+++ b/src-tauri/src/mining/gpu/miners/lolminer.rs
@@ -292,28 +292,27 @@ impl StatusMonitor for LolMinerGpuMinerStatusMonitor {
         }
     }
 
-    async fn check_health(&self, uptime: Duration, timeout_duration: Duration) -> HealthStatus {
+    async fn check_health(&self, _uptime: Duration, timeout_duration: Duration) -> HealthStatus {
         let status = match tokio::time::timeout(timeout_duration, self.status()).await {
             Ok(inner) => inner,
             Err(_) => {
                 warn!(target: LOG_TARGET, "Timeout error in GpuMinerAdapter check_health");
                 let _ = self.gpu_status_sender.send(GpuMinerStatus::default());
-                return HealthStatus::Warning;
+                return HealthStatus::Unhealthy;
             }
         };
 
         match status {
             Ok(status) => {
                 let _ = self.gpu_status_sender.send(status.clone());
-                // GPU returns 0 for first 10 seconds until it has an average
-                if status.hash_rate > 0.0 || uptime.as_secs() < 11 {
+                if status.hash_rate > 0.0 {
                     if !GpuManager::read().await.is_current_miner_healthy().await {
                         info!(target: LOG_TARGET, "Marking current miner as healthy again");
                         let _unused = GpuManager::write().await.handle_healthy_miner().await;
                     }
                     HealthStatus::Healthy
                 } else {
-                    HealthStatus::Warning
+                    HealthStatus::Unhealthy
                 }
             }
             Err(_) => {

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -334,7 +334,6 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
             warn!(target: LOG_TARGET, "Restarting {name} after health check failure");
             *uptime = Instant::now();
             stats.num_restarts += 1;
-            stats.current_uptime = uptime.elapsed();
             match status_monitor3
                 .handle_unhealthy(*duration_since_last_healthy_status)
                 .await
@@ -361,11 +360,14 @@ async fn do_health_check<TStatusMonitor: StatusMonitor, TProcessInstance: Proces
             // unhealthy_timer.elapsed() resolves to around 10 seconds
             *duration_since_last_healthy_status += unhealthy_timer.elapsed();
         }
-    } else {
-        stats.current_uptime = uptime.elapsed();
+    }
+
+    if is_healthy {
         // Reset the duration once we have a healthy status
         *duration_since_last_healthy_status = Duration::from_secs(0);
     }
+
+    stats.current_uptime = uptime.elapsed();
 
     Ok(None)
 }


### PR DESCRIPTION
### [ Summary ]
- Remove warnings for healthstatus from gpu miners | Its either healthy or unhealthy
- If we cannot fetch or send gpu status => mark it as unhealthy instead warning
- If hashrate is 0.0 => It should be marked as unhealthy
- Removed 10 seconds grace period for hash rate check to prevent producing false positive results