### PR TITLE
fix: re detect gpu devices when switching miner 

### DIFF
--- a/src-tauri/src/mining/gpu/manager.rs
+++ b/src-tauri/src/mining/gpu/manager.rs
@@ -389,7 +389,8 @@ impl GpuManager {
         if let Some(miner) = self.available_miners.get(&new_miner) {
             info!(target: LOG_TARGET, "Found selected gpu miner in available miners");
             let miner_type = miner.miner_type.clone();
-            let adapter = self.resolve_miner_interface(&miner_type);
+            let mut adapter = self.resolve_miner_interface(&miner_type);
+            adapter.detect_devices().await?;
             let miner_cloned = miner.clone();
             info!(target: LOG_TARGET, "Resolved selected gpu miner interface");
             self.selected_miner = miner_type.clone();


### PR DESCRIPTION
### [ Summary ]
- Detected devices from initial detection are not cached, so we are always displaying detected devices from first used miner. In case when lolminer didn't detected any devices, switching to graxil will keep displaying 0 devices even if graxil is able to detect some
- Created temporary fix for re detecting devices when switching miners