### PR TITLE
fix: add version counter to each config file

### DIFF
--- a/src-tauri/src/configs/config_core.rs
+++ b/src-tauri/src/configs/config_core.rs
@@ -50,7 +50,6 @@ static INSTANCE: LazyLock<RwLock<ConfigCore>> = LazyLock::new(|| RwLock::new(Con
 #[getset(get = "pub", set = "pub")]
 pub struct ConfigCoreContent {
     version: u32,
-    was_config_migrated: bool,
     created_at: SystemTime,
     use_tor: bool,
     allow_telemetry: bool,
@@ -103,7 +102,6 @@ impl Default for ConfigCoreContent {
 
         Self {
             version: 0,
-            was_config_migrated: false,
             created_at: SystemTime::now(),
             use_tor: true,
             allow_telemetry: true,

--- a/src-tauri/src/configs/config_core.rs
+++ b/src-tauri/src/configs/config_core.rs
@@ -41,6 +41,7 @@ pub struct AirdropTokens {
     pub refresh_token: String,
 }
 
+pub const CORE_CONFIG_VERSION: u32 = 0;
 static INSTANCE: LazyLock<RwLock<ConfigCore>> = LazyLock::new(|| RwLock::new(ConfigCore::new()));
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, Clone)]
@@ -49,7 +50,7 @@ static INSTANCE: LazyLock<RwLock<ConfigCore>> = LazyLock::new(|| RwLock::new(Con
 #[derive(Getters, Setters)]
 #[getset(get = "pub", set = "pub")]
 pub struct ConfigCoreContent {
-    version: u32,
+    version_counter: u32,
     created_at: SystemTime,
     use_tor: bool,
     allow_telemetry: bool,
@@ -101,7 +102,7 @@ impl Default for ConfigCoreContent {
             .unwrap_or(ABTestSelector::GroupA);
 
         Self {
-            version: 0,
+            version_counter: CORE_CONFIG_VERSION,
             created_at: SystemTime::now(),
             use_tor: true,
             allow_telemetry: true,
@@ -139,9 +140,9 @@ impl ConfigCore {
         let mut config = Self::current().write().await;
         config.load_app_handle(app_handle.clone()).await;
 
-        if config.content.version.eq(&0) && config.content.node_type.eq(&NodeType::Local) {
+        if config.content.version_counter.eq(&0) && config.content.node_type.eq(&NodeType::Local) {
             config.content.node_type = NodeType::RemoteUntilLocal;
-            config.content.version = 1;
+            config.content.version_counter = 1;
             let _unused = Self::_save_config(config._get_content().clone());
         };
     }

--- a/src-tauri/src/configs/config_mining.rs
+++ b/src-tauri/src/configs/config_mining.rs
@@ -84,7 +84,7 @@ impl GpuDevicesSettings {
 #[getset(get = "pub", set = "pub")]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ConfigMiningContent {
-    was_config_migrated: bool,
+    version: i32,
     created_at: SystemTime,
     selected_mining_mode: String,
     mining_modes: HashMap<String, MiningMode>,
@@ -96,14 +96,12 @@ pub struct ConfigMiningContent {
     squad_override: Option<String>,
     gpu_miner_type: GpuMinerType,
     is_lolminer_tested: bool,
-    version: i32,
 }
 
 impl Default for ConfigMiningContent {
     fn default() -> Self {
         Self {
             version: 0,
-            was_config_migrated: false,
             created_at: SystemTime::now(),
             selected_mining_mode: "Eco".to_string(),
             mine_on_app_start: true,

--- a/src-tauri/src/configs/config_pools.rs
+++ b/src-tauri/src/configs/config_pools.rs
@@ -47,7 +47,7 @@ static INSTANCE: LazyLock<RwLock<ConfigPools>> = LazyLock::new(|| RwLock::new(Co
 pub struct ConfigPoolsContent {
     // ======= Config internals =======
     #[getset(get = "pub", set = "pub")]
-    was_config_migrated: bool,
+    version: u32,
     #[getset(get = "pub", set = "pub")]
     created_at: SystemTime,
     // ======= Gpu Pool =======
@@ -70,7 +70,7 @@ impl Default for ConfigPoolsContent {
     fn default() -> Self {
         Self {
             // ======= Config internals =======
-            was_config_migrated: false,
+            version: 0,
             created_at: SystemTime::now(),
             // ======= Gpu Pool =======
             gpu_pool_enabled: true,

--- a/src-tauri/src/configs/config_pools.rs
+++ b/src-tauri/src/configs/config_pools.rs
@@ -37,6 +37,7 @@ use crate::{
 
 use super::trait_config::{ConfigContentImpl, ConfigImpl};
 
+pub const POOLS_CONFIG_VERSION: u32 = 0;
 static INSTANCE: LazyLock<RwLock<ConfigPools>> = LazyLock::new(|| RwLock::new(ConfigPools::new()));
 
 #[allow(clippy::struct_excessive_bools)]
@@ -47,7 +48,7 @@ static INSTANCE: LazyLock<RwLock<ConfigPools>> = LazyLock::new(|| RwLock::new(Co
 pub struct ConfigPoolsContent {
     // ======= Config internals =======
     #[getset(get = "pub", set = "pub")]
-    version: u32,
+    version_counter: u32,
     #[getset(get = "pub", set = "pub")]
     created_at: SystemTime,
     // ======= Gpu Pool =======
@@ -70,7 +71,7 @@ impl Default for ConfigPoolsContent {
     fn default() -> Self {
         Self {
             // ======= Config internals =======
-            version: 0,
+            version_counter: POOLS_CONFIG_VERSION,
             created_at: SystemTime::now(),
             // ======= Gpu Pool =======
             gpu_pool_enabled: true,

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -76,7 +76,7 @@ impl DisplayMode {
 #[derive(Getters, Setters)]
 #[getset(get = "pub", set = "pub")]
 pub struct ConfigUIContent {
-    was_config_migrated: bool,
+    version: u32,
     created_at: SystemTime,
     display_mode: DisplayMode,
     has_system_language_been_proposed: bool,
@@ -93,7 +93,7 @@ pub struct ConfigUIContent {
 impl Default for ConfigUIContent {
     fn default() -> Self {
         Self {
-            was_config_migrated: false,
+            version: 0,
             created_at: SystemTime::now(),
             display_mode: DisplayMode::System,
             has_system_language_been_proposed: false,

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -35,6 +35,7 @@ use tokio::sync::RwLock;
 
 use super::trait_config::{ConfigContentImpl, ConfigImpl};
 
+pub const UI_CONFIG_VERSION: u32 = 0;
 static INSTANCE: LazyLock<RwLock<ConfigUI>> = LazyLock::new(|| RwLock::new(ConfigUI::new()));
 
 #[derive(Serialize, Deserialize, Clone, Copy)]
@@ -76,7 +77,7 @@ impl DisplayMode {
 #[derive(Getters, Setters)]
 #[getset(get = "pub", set = "pub")]
 pub struct ConfigUIContent {
-    version: u32,
+    version_counter: u32,
     created_at: SystemTime,
     display_mode: DisplayMode,
     has_system_language_been_proposed: bool,
@@ -93,7 +94,7 @@ pub struct ConfigUIContent {
 impl Default for ConfigUIContent {
     fn default() -> Self {
         Self {
-            version: 0,
+            version_counter: UI_CONFIG_VERSION,
             created_at: SystemTime::now(),
             display_mode: DisplayMode::System,
             has_system_language_been_proposed: false,

--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -163,7 +163,7 @@ impl InternalWallet {
         app_handle: &AppHandle,
         wallet_config: &ConfigWalletContent,
     ) -> Result<bool, anyhow::Error> {
-        if *wallet_config.version() < WALLET_VERSION {
+        if *wallet_config.version_counter() < WALLET_VERSION {
             log::info!(target: LOG_TARGET, "Wallet config version is outdated, migration needed");
             return Ok(false);
         }
@@ -621,13 +621,13 @@ impl InternalWallet {
         if monero_address.is_empty() {
             panic!(
                 "Unexpected! Monero address should be accessible for v{:?}",
-                *wallet_config.version()
+                *wallet_config.version_counter()
             );
         }
         if (*wallet_config.tari_wallets()).is_empty() {
             panic!(
                 "Unexpected! Tari wallets field should be defined in the config for v{:?}",
-                *wallet_config.version()
+                *wallet_config.version_counter()
             );
         }
 


### PR DESCRIPTION
### [ Summary ]
- Added `version_counter` to each config
- If there was `version` ( i32 ) present replaced it with `version_counter` ( u32 ) | config version cannot be negative, replacement was needed as I cannot change type of that field because then the deserialization would fail 
- Added pub const's to each config representing it current expected version 
- Set `version_counter` default value as that mentioned pub const so fresh configs will not require any migration 
- Removed `was_config_migrated` field