### PR TITLE
fix(ui): status indicators on crew rewards avatars

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
@@ -10,6 +10,7 @@ import {
     InviteFriendsMessage,
     LoadingPlaceholder,
     PhotoWrapper,
+    OnlineIndicator,
 } from './styles';
 
 import { useReferrerProgress } from '@app/hooks/crew/useReferrerProgress';
@@ -67,11 +68,17 @@ export default function StatsRow() {
                                     <AvatarInviteButton />
                                 </PhotoWrapper>
                             ))}
-                        {crewData?.members.map(({ image, displayName }, index) => (
-                            <PhotoWrapper key={`${index}-crewminiavatar`} onClick={handleCrewToggle}>
-                                <Avatar image={image} username={displayName} size={28} />
-                            </PhotoWrapper>
-                        ))}
+                        {crewData?.members.map(({ image, displayName, isCurrentlyMining, lastActivityDate }, index) => {
+                            const lastActivityMoreThan1Hour =
+                                Date.now() - new Date(lastActivityDate).getTime() > 1000 * 60 * 60;
+                            const isOnline = !lastActivityMoreThan1Hour && !!isCurrentlyMining;
+                            return (
+                                <PhotoWrapper key={`${index}-crewminiavatar`} onClick={handleCrewToggle}>
+                                    {isCurrentlyMining && <OnlineIndicator $isOnline={isOnline} />}
+                                    <Avatar image={image} username={displayName} size={28} />
+                                </PhotoWrapper>
+                            );
+                        })}
                     </PhotosRow>
 
                     <TextWrapper>

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/styles.ts
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/styles.ts
@@ -14,12 +14,6 @@ export const ActiveMinersWrapper = styled.div`
     gap: 10px;
 `;
 
-export const PhotosRow = styled.div`
-    display: flex;
-    align-items: center;
-    position: relative;
-`;
-
 export const PhotoWrapper = styled.button<{ $isInviteButton?: boolean }>`
     width: 32px;
     height: 32px;
@@ -30,6 +24,10 @@ export const PhotoWrapper = styled.button<{ $isInviteButton?: boolean }>`
     position: relative;
 
     cursor: pointer;
+    transition:
+        opacity 0.2s ease-in-out,
+        transform 0.2s ease-in-out,
+        filter 0.2s ease-in-out;
 
     &:not(:first-child) {
         margin-left: -17px;
@@ -54,7 +52,9 @@ export const PhotoWrapper = styled.button<{ $isInviteButton?: boolean }>`
 
             transition:
                 color 0.2s ease-in-out,
-                background-color 0.2s ease-in-out;
+                background-color 0.2s ease-in-out,
+                filter 0.2s ease-in-out,
+                transform 0.2s ease-in-out;
 
             &:hover {
                 z-index: 4;
@@ -62,6 +62,27 @@ export const PhotoWrapper = styled.button<{ $isInviteButton?: boolean }>`
                 background-color: #656666;
             }
         `}
+
+    &:hover {
+        z-index: 4;
+
+        transform: scale(1) !important;
+        filter: blur(0px) !important;
+        filter: grayscale(0%) !important;
+    }
+`;
+
+export const PhotosRow = styled.div`
+    display: flex;
+    align-items: center;
+    position: relative;
+
+    &:hover {
+        ${PhotoWrapper} {
+            transform: scale(0.8);
+            filter: blur(2px) grayscale(100%);
+        }
+    }
 `;
 
 export const TextWrapper = styled.div`
@@ -120,4 +141,23 @@ export const InviteFriendsMessage = styled.div`
 export const LoadingPlaceholder = styled.div`
     width: 100%;
     height: 30px;
+`;
+
+export const OnlineIndicator = styled.div<{ $isOnline: boolean }>`
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: #01a405;
+    flex-shrink: 0;
+    border: 2px solid #323333;
+
+    position: absolute;
+    top: -2px;
+    right: -2px;
+
+    ${({ $isOnline }) =>
+        !$isOnline &&
+        css`
+            background-color: #eb3d1e;
+        `}
 `;

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -184,6 +184,8 @@ export interface ReferrerProgressResponse {
         name: string;
         displayName: string;
         image: string;
+        isCurrentlyMining: boolean;
+        lastActivityDate: string;
     }[];
     membersToNudge: {
         id: string;


### PR DESCRIPTION
This PR adds the status indicator to the member avatars in the collapsed state of the crew rewards widget. 

I also added a hover effect that scales and blurs the other circles within this component when one of them is hovered, this is to draw focus to the one being interacted with. I found it was too visually confusing when hovering the middle avatar. 

<img width="822" height="424" alt="CleanShot 2025-09-18 at 17 58 10@2x" src="https://github.com/user-attachments/assets/e812a2aa-a3dc-416a-84d0-7926341fb130" />

<img width="656" height="458" alt="CleanShot 2025-09-18 at 17 58 42@2x" src="https://github.com/user-attachments/assets/fb23bb76-52c2-4b5d-89b8-f6a94cce5a08" />
