### PR TITLE
fix(ui): xspace banner z-index issue fix

### DIFF
--- a/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
+++ b/src/containers/floating/XSpaceBanner/XSpaceBanner.style.ts
@@ -10,7 +10,7 @@ export const BannerContent = styled(m.div)<{
     top: 16px;
     right: 20px;
 
-    z-index: 99;
+    z-index: 2;
     display: flex;
     align-items: center;
     padding: 8px 10px;


### PR DESCRIPTION
The x-space banner had a z-index that put it above the crew rewards ui. So when you expand the crew rewards it covers it. This PR fixes that. 

Bug:
<img width="2700" height="1558" alt="CleanShot 2025-09-22 at 10 45 22@2x" src="https://github.com/user-attachments/assets/caf22db6-102d-4a7c-88fd-4f8e1d650ad8" />

Fix:
<img width="2730" height="1592" alt="CleanShot 2025-09-22 at 10 47 45@2x" src="https://github.com/user-attachments/assets/0302dcd7-74a9-4e2f-8df3-2e74a0bea440" />

Tested:

- [x]  Make sure XSpace banner is still clickable
- [x]  Make sure XSpace banner does not overlap crew rewards
- [x]  Make sure Banner is below all modals / dialog ui

