### PR TITLE
fix: handle wallet initialization dead end when no config record exists

### DIFF
--- a/src-tauri/src/internal_wallet.rs
+++ b/src-tauri/src/internal_wallet.rs
@@ -173,7 +173,8 @@ impl InternalWallet {
             && wallet_config.selected_external_tari_address().is_none()
         {
             log::error!(target: LOG_TARGET, "No Tari wallets found");
-            return Err(anyhow!("No Tari wallets found"));
+            // In case of no wallets found, return falls to trigger migration or new wallet creation
+            return Ok(false);
         }
         // An owned tari wallet id found
 
@@ -218,6 +219,7 @@ impl InternalWallet {
         )
         .await?;
         let wallet_config = ConfigWallet::content().await;
+
         let internal_wallet =
             if InternalWallet::validate_wallet_config_for_seed(app_handle, &wallet_config).await? {
                 InternalWallet::load_latest_version(app_handle, wallet_config).await?


### PR DESCRIPTION
### [ Summary ]
- When initializing wallet with seed, in case there is no wallet records in config ( which means there is no references to record in keyring ), mark validation as failed instead of throwing error, which should trigger migration attempt if available and if not create new wallet 

#### Should fix #2917
