### PR TITLE
fix: possible malformed node config files

### DIFF
--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -392,6 +392,7 @@ impl StatusMonitor for NodeStatusMonitor {
                     .join("peer_db"),
             )
             .await;
+
             let _unused = fs::remove_dir_all(
                 base_path
                     .join("node")
@@ -399,7 +400,15 @@ impl StatusMonitor for NodeStatusMonitor {
                     .join("libtor"),
             )
             .await;
+
             let _unused = fs::remove_dir_all(base_path.join("tor-data")).await;
+            let _unused = fs::remove_dir_all(
+                base_path
+                    .join("node")
+                    .join(Network::get_current().to_string().to_lowercase())
+                    .join("config"),
+            )
+            .await;
         }
 
         Ok(HandleUnhealthyResult::Continue)


### PR DESCRIPTION
Probably will fix: https://nomatter.tari.com/tari/pl/gorbc5eyuj8qxq6ecepnuo6eba

From what I've investigated in core repo, some config is malformed which throws error on serialization which in returns throws 101 error in TU, to try and fix this I've added deletion of config folder on `handle_unhealthy` 

Tested by changing config.toml file and running TU app, I can see the same error as in error report and then deletion happen which looks like it fixing the issue, node running properly after