### PR TITLE
fix(ui): remove the zoom out animation when exiting the app

### DIFF
--- a/src/App/App.styles.ts
+++ b/src/App/App.styles.ts
@@ -27,18 +27,11 @@ const variants = {
             ease,
         },
     },
-    exit: {
-        opacity: 0,
-        transition: {
-            duration: 0,
-        },
-    },
 };
 
 export const AppContentContainer = styled(m.div).attrs({
     variants,
     animate: 'visible',
-    exit: 'exit',
 })`
     width: 100vw;
     height: 100vh;

--- a/src/App/App.styles.ts
+++ b/src/App/App.styles.ts
@@ -29,10 +29,8 @@ const variants = {
     },
     exit: {
         opacity: 0,
-        scale: 1.5,
         transition: {
-            duration: 0.8,
-            ease,
+            duration: 0,
         },
     },
 };

--- a/src/containers/main/CrewRewards/CrewRewards.tsx
+++ b/src/containers/main/CrewRewards/CrewRewards.tsx
@@ -10,6 +10,7 @@ const CrewRewards = memo(function CrewRewards() {
     const setShowWidget = useCrewRewardsStore((s) => s.setShowWidget);
     const crewRewardsEnabled = useAirdropStore((s) => s.features?.includes(FEATURE_FLAGS.FE_CREW_UI));
     const showTapplet = useUIStore((s) => s.showTapplet);
+    const isShuttingDown = useUIStore((s) => s.isShuttingDown);
 
     useEffect(() => {
         if (crewRewardsEnabled) {
@@ -18,6 +19,8 @@ const CrewRewards = memo(function CrewRewards() {
             setShowWidget(false);
         }
     }, [crewRewardsEnabled, setShowWidget]);
+
+    if (isShuttingDown) return null;
 
     return <AnimatePresence>{showWidget && !showTapplet && <RewardsWidget />}</AnimatePresence>;
 });


### PR DESCRIPTION
The exit animation on the app is strange when closing. It also prevents the "Shutting down" ui from displaying. This PR removes the exit animation. Much cleaner exit experience. 

Bug:
https://www.loom.com/share/9c0a90191f3f43a69108ed5d003f5e8f

Fix:
https://www.loom.com/share/b60eefa1c9084d578e3eb17ff1300783

I also disabled the Crew Rewards widget when shutting down, it was appearing over it. 

Bug:

<img width="2702" height="1558" alt="CleanShot 2025-09-25 at 16 42 22@2x" src="https://github.com/user-attachments/assets/819c18f9-beef-457c-b4b9-ae12842cb5bb" />

Fix:
<img width="2688" height="1576" alt="CleanShot 2025-09-25 at 16 11 41@2x" src="https://github.com/user-attachments/assets/9559ce3f-3443-4170-a28d-b00909282989" />

