### PR TITLE
feat: display dynamic reward values

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/sections/CrewSection/CrewSection.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/CrewSection/CrewSection.tsx
@@ -41,22 +41,26 @@ export default function CrewSection() {
         setCrewQueryParams({ status, page: 1 }); // Reset to page 1 when filter changes
     };
 
+    const rewardsConfig = progressData?.rewardsConfig;
+
     return (
         <Wrapper initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
             <StreakProgress isInline={true} />
 
             <IntroTextWrapper>
                 <Title>{t('airdrop:crewRewards.myCrew')}</Title>
-                <Text>
-                    <Trans
-                        i18nKey="airdrop:crewRewards.earnDescription"
-                        values={{
-                            userReward: 100,
-                            daysRequired: 7,
-                            friendReward: 50,
-                        }}
-                    />
-                </Text>
+                {rewardsConfig && (
+                    <Text>
+                        <Trans
+                            i18nKey="airdrop:crewRewards.earnDescription"
+                            values={{
+                                userReward: rewardsConfig.referrerRewards,
+                                daysRequired: rewardsConfig.requirement,
+                                friendReward: rewardsConfig.referralRewards,
+                            }}
+                        />
+                    </Text>
+                )}
             </IntroTextWrapper>
 
             <Filters totals={progressData?.totals} activeFilter={activeFilter} onFilterChange={handleFilterChange} />

--- a/src/store/useAirdropStore.ts
+++ b/src/store/useAirdropStore.ts
@@ -193,6 +193,11 @@ export interface ReferrerProgressResponse {
         displayName?: string;
         imageUrl?: string;
     }[];
+    rewardsConfig: {
+        referrerRewards: number;
+        referralRewards: number;
+        requirement: number;
+    };
 }
 
 export interface Reward {


### PR DESCRIPTION
Updates the Crew Rewards widget to display dynamic reward values fetched from the `rewardsConfig` in the `progressData`. This ensures that the values for user rewards, days required, and friend rewards are configurable and not hardcoded. The `rewardsConfig` interface has been added to the store.
