### PR TITLE
chore: bump bridge tapplet version in testnet and nextnet to v0.2.2-pre.0

### DIFF
--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.2.0",
+        "bridge": "0.2.2",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.2.2",
+        "bridge": "0.2.2-pre.0",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.2.0",
+        "bridge": "0.2.2",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.2.2",
+        "bridge": "0.2.2-pre.0",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",


### PR DESCRIPTION
Description
---

Bumps `bridge` tapplet version in testnet and nextnet to `v0.2.2-pre.0`

Motivation and Context
---

We built a new release of bridge tapplet - `v0.2.2-pre.0`. It has to be tested.

How Has This Been Tested?
---

Ran locally an the new tapplet version was downloaded and run.

```
14:55:06 INFO  Downloading binary: bridge from url: https://cdn-universe.tari.com/tari-project/wxtm-bridge-frontend/releases/download/v0.2.2-pre.0/bridge-v0.2.2-pre.0.zip                                                                              
14:55:07 INFO  Using archive destination: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive
14:55:07 INFO  Destination directory: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive
14:55:07 INFO  Destination file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive/bridge-v0.2.2-pre.0.zip                                                                                        
14:55:07 INFO  File does not exist, creating new file at /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive/bridge-v0.2.2-pre.0.zip                                                                
14:55:07 INFO  Expected file size: 15093579                                                                                                                                                                                                 
14:55:07 INFO  Current file size: 0
14:55:07 INFO  File is empty, starting download from the beginning.
14:55:07 INFO  Downloaded successfully
14:55:07 INFO  Extracting file to /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0
14:55:07 INFO  Destination directory already exists, removing old entries.
14:55:07 INFO  Archive file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive
14:55:07 INFO  Extracting archive file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive/bridge-v0.2.2-pre.0.zip
14:55:08 INFO  Using archive destination: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0/archive
14:55:08 INFO  Successfully downloaded binary: bridge on retry: 0
14:55:08 INFO  [ Wallet Phase ] Setup completed successfully
14:55:08 INFO  Downloading binary: lolminer from fallback url: https://github.com/Lolliedieb/lolMiner-releases/releases/download/1.98/Not available for this platform
14:55:08 WARN  Failed to download binary: lolminer at retry: 2
14:55:08 INFO  Progress channel completed for binary: "bridge"
14:55:18 INFO  Start tapplet path "/Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.2-pre.0"
14:55:18 INFO  Launch tapplet on port 0
14:55:18 INFO  🚀 The tapplet was launched at the address: "127.0.0.1:51407"
```

<img width="1675" height="620" alt="Screenshot 2025-09-30 at 14 58 02" src="https://github.com/user-attachments/assets/42918d73-f557-46c9-a3a5-31cd511e7c3b" />


What process can a PR reviewer use to test or verify this change?
---

Same as above.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
