### PR TITLE
fix: mark bridge as not required for wallet phase

### DIFF
--- a/src-tauri/src/setup/phase_wallet.rs
+++ b/src-tauri/src/setup/phase_wallet.rs
@@ -139,7 +139,7 @@ impl SetupPhaseImpl for WalletSetupPhase {
         ProgressStepperBuilder::new()
             .add_incremental_step(SetupStep::BinariesWallet, true)
             .add_step(SetupStep::StartWallet, true)
-            .add_incremental_step(SetupStep::SetupBridge, true)
+            .add_incremental_step(SetupStep::SetupBridge, false)
             .build(
                 app_handle,
                 timeout_watcher_sender,


### PR DESCRIPTION
### [ Summary ]
- Change bridge to not be required for wallet phases, because otherwise failing to download bridge tapplet marks wallet as broken event if wallets is working fine