### PR TITLE
fix(ui): add toast error for incorrect PIN on sync flow

### DIFF
--- a/src/containers/floating/PaperWalletModal/sections/ConnectSection/ConnectSection.tsx
+++ b/src/containers/floating/PaperWalletModal/sections/ConnectSection/ConnectSection.tsx
@@ -12,6 +12,7 @@ import { usePaperWalletStore } from '@app/store/usePaperWalletStore';
 import { invoke } from '@tauri-apps/api/core';
 import LoadingSvg from '@app/components/svgs/LoadingSvg';
 import { useAirdropSetTokenToUuid } from '@app/hooks/airdrop/stateHelpers/useAirdropSetTokens';
+import { setError } from '@app/store';
 
 interface Props {
     setSection: (section: PaperWalletModalSectionType) => void;
@@ -43,6 +44,13 @@ export default function ConnectSection({ setSection }: Props) {
                     setSection('QRCode');
                 }
             } catch (e) {
+                const errorMessage = e as unknown as string;
+                if (
+                    !errorMessage.includes('User canceled the operation') &&
+                    !errorMessage.includes('PIN entry cancelled')
+                ) {
+                    setError(errorMessage);
+                }
                 console.error('Failed to get paper wallet details', e);
             }
         });


### PR DESCRIPTION
Description
---

- just called the `setError` action for incorrect PIN in the Sync with Phone flow 

Motivation and Context
---
- closes https://github.com/tari-project/universe/issues/3018


How Has This Been Tested?
---

- locally:

https://github.com/user-attachments/assets/33806416-4fbc-49ea-8013-1b4b7fbbfdb2

