### PR TITLE
chore: rm err logging for release notes dir

### DIFF
--- a/src-tauri/src/release_notes.rs
+++ b/src-tauri/src/release_notes.rs
@@ -98,10 +98,7 @@ impl ReleaseNotes {
         debug!(target: LOG_TARGET, "[read_release_notes_file]");
         let release_notes_path = ReleaseNotes::get_release_notes_path();
         debug!(target: LOG_TARGET, "[read_release_notes_file] Reading release notes from {release_notes_path}");
-        let content = std::fs::read_to_string(release_notes_path).map_err(|e| {
-            error!(target: LOG_TARGET, "Failed to read release notes file: {e}");
-            anyhow!("Failed to read release notes file")
-        })?;
+        let content = std::fs::read_to_string(release_notes_path)?;
 
         Ok(serde_json::from_str(&content)?)
     }


### PR DESCRIPTION
Description
---

- just removed the error logging from `read_release_notes_file` when directory isn't there 

Motivation and Context
---

- closes https://github.com/tari-project/universe/issues/2807
