### PR TITLE
chore: sentry cleanups pt2 | PID file

### DIFF
--- a/public/locales/af/setup-progresses.json
+++ b/public/locales/af/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Alle modules het misluk om te inisialiseer. App kan nie in huidige toestand werk nie. Herbegin asseblief die app of kontak ondersteuning.",
   "any_moment_now": "Enige oomblik nou",
+  "app-modules": {
+    "cpu-mining": "CPU Mynbou",
+    "gpu-mining": "GPU Mynbou",
+    "wallet": "Beursie"
+  },
   "awaiting-exchange-selection": "Wag op gebruiker se uitruilkeuse",
   "block-sync": "Blokke sinkroniseer",
   "calculating_time": "Bereken oorblywende tyd...",
   "calculating_time-compact": "Bereken tyd...",
+  "critical-initialization-failure": "Kritieke inisialisering mislukking",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Misluk om stap te voltooi",
   "header-sync": "Koptekste sinkroniseer",
   "local-node-sync": "Tari Universe sinkroniseer steeds. Dit sal nie jou mynervaring beïnvloed nie.",
+  "module-initialization-issues": "Sommige modules het misluk om te inisialiseer",
   "network-peers": "Koppel aan netwerkmaats",
   "phase-title": {
     "setup-core": "Stel die Tari Toep op",
     "setup-core-compact": "Sinchroniseer app",
     "setup-hardware": "Stel die Hardeware op",
     "setup-hardware-compact": "Stel hardeware op",
-    "setup-node": "Stel die Tari Node op",
-    "setup-node-compact": "Sinchroniseer node",
     "setup-mining": "Stel ekstra nutsmiddels op",
     "setup-mining-compact": "Stel nutsgoed op",
+    "setup-node": "Stel die Tari Node op",
+    "setup-node-compact": "Sinchroniseer node",
     "setup-wallet": "Stel die Beursie op",
     "setup-wallet-compact": "Sinchroniseer beursie"
-  },
-  "critical-initialization-failure": "Kritieke inisialisering mislukking",
-  "failed-to-complete-step": "Misluk om stap te voltooi",
-  "all-modules-failed-description": "Alle modules het misluk om te inisialiseer. App kan nie in huidige toestand werk nie. Herbegin asseblief die app of kontak ondersteuning.",
-  "module-initialization-issues": "Sommige modules het misluk om te inisialiseer",
-  "some-modules-failed-description": "App kan voortgaan om te werk, maar sommige funksies mag nie beskikbaar wees nie. Herbegin asseblief mislukte modules, of kontak ondersteuning as die probleem voortduur.",
-  "app-modules": {
-    "cpu-mining": "CPU Mynbou",
-    "gpu-mining": "GPU Mynbou",
-    "wallet": "Beursie"
   },
   "remaining": "oorblywend",
   "second_remaining": "sekonde oor",
   "seconds_remaining": "sekondes oor",
+  "some-modules-failed-description": "App kan voortgaan om te werk, maar sommige funksies mag nie beskikbaar wees nie. Herbegin asseblief mislukte modules, of kontak ondersteuning as die probleem voortduur.",
   "title": {
     "binaries-cpu-miner": "Bereiding van CPU Mynwerker Binêr",
     "binaries-cpu-miner-download": "Bereiding van CPU Mynwerker Binêr | Laai af: {{ progress }}%",

--- a/public/locales/cn/setup-progresses.json
+++ b/public/locales/cn/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "所有模块初始化失败。应用程序无法在当前状态下工作。请重新启动应用程序或联系支持。",
   "any_moment_now": "随时",
+  "app-modules": {
+    "cpu-mining": "CPU 挖矿",
+    "gpu-mining": "GPU 挖矿",
+    "wallet": "钱包"
+  },
   "awaiting-exchange-selection": "等待用户选择交易所",
   "block-sync": "同步区块",
   "calculating_time": "计算剩余时间...",
   "calculating_time-compact": "计算时间...",
+  "critical-initialization-failure": "关键初始化失败",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "未能完成步骤",
   "header-sync": "同步头部",
   "local-node-sync": "Tari Universe仍在同步。这不会影响您的挖矿体验。",
+  "module-initialization-issues": "某些模块初始化失败",
   "network-peers": "连接到网络节点",
   "phase-title": {
     "setup-core": "设置 Tari 应用程序",
     "setup-core-compact": "同步应用程序",
     "setup-hardware": "设置硬件",
     "setup-hardware-compact": "设置硬件",
-    "setup-node": "设置 Tari 节点",
-    "setup-node-compact": "同步节点",
     "setup-mining": "设置额外工具",
     "setup-mining-compact": "设置工具",
+    "setup-node": "设置 Tari 节点",
+    "setup-node-compact": "同步节点",
     "setup-wallet": "设置钱包",
     "setup-wallet-compact": "同步钱包"
-  },
-  "critical-initialization-failure": "关键初始化失败",
-  "failed-to-complete-step": "未能完成步骤",
-  "all-modules-failed-description": "所有模块初始化失败。应用程序无法在当前状态下工作。请重新启动应用程序或联系支持。",
-  "module-initialization-issues": "某些模块初始化失败",
-  "some-modules-failed-description": "应用程序可以继续工作，但某些功能可能不可用。请重新启动失败的模块，或在问题持续时联系支持。",
-  "app-modules": {
-    "cpu-mining": "CPU 挖矿",
-    "gpu-mining": "GPU 挖矿",
-    "wallet": "钱包"
   },
   "remaining": "剩余",
   "second_remaining": "剩余秒数",
   "seconds_remaining": "剩余秒数",
+  "some-modules-failed-description": "应用程序可以继续工作，但某些功能可能不可用。请重新启动失败的模块，或在问题持续时联系支持。",
   "title": {
     "binaries-cpu-miner": "准备 CPU 挖矿二进制文件",
     "binaries-cpu-miner-download": "准备 CPU 矿工二进制文件 | 下载中：{{ progress }}%",

--- a/public/locales/de/setup-progresses.json
+++ b/public/locales/de/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Alle Module konnten nicht initialisiert werden. Die App kann im aktuellen Zustand nicht arbeiten. Bitte starten Sie die App neu oder kontaktieren Sie den Support.",
   "any_moment_now": "Jeden Moment",
+  "app-modules": {
+    "cpu-mining": "CPU-Mining",
+    "gpu-mining": "GPU-Mining",
+    "wallet": "Wallet"
+  },
   "awaiting-exchange-selection": "Warten auf die Auswahl der Börse durch den Benutzer",
   "block-sync": "Blöcke synchronisieren",
   "calculating_time": "Verbleibende Zeit berechnen...",
   "calculating_time-compact": "Zeit berechnen...",
+  "critical-initialization-failure": "Kritischer Initialisierungsfehler",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Schritt konnte nicht abgeschlossen werden",
   "header-sync": "Header synchronisieren",
   "local-node-sync": "Tari Universe synchronisiert noch. Dies wird Ihr Mining-Erlebnis nicht beeinträchtigen.",
+  "module-initialization-issues": "Einige Module konnten nicht initialisiert werden",
   "network-peers": "Verbindung zu Netzwerk-Peers herstellen",
   "phase-title": {
     "setup-core": "Tari-App wird eingerichtet",
     "setup-core-compact": "App synchronisieren",
     "setup-hardware": "Hardware wird eingerichtet",
     "setup-hardware-compact": "Hardware einrichten",
-    "setup-node": "Tari-Knoten wird eingerichtet",
-    "setup-node-compact": "Knoten synchronisieren",
     "setup-mining": "Zusätzliche Dienstprogramme werden eingerichtet",
     "setup-mining-compact": "Einrichten von Dienstprogrammen",
+    "setup-node": "Tari-Knoten wird eingerichtet",
+    "setup-node-compact": "Knoten synchronisieren",
     "setup-wallet": "Wallet wird eingerichtet",
     "setup-wallet-compact": "Wallet synchronisieren"
-  },
-  "critical-initialization-failure": "Kritischer Initialisierungsfehler",
-  "failed-to-complete-step": "Schritt konnte nicht abgeschlossen werden",
-  "all-modules-failed-description": "Alle Module konnten nicht initialisiert werden. Die App kann im aktuellen Zustand nicht arbeiten. Bitte starten Sie die App neu oder kontaktieren Sie den Support.",
-  "module-initialization-issues": "Einige Module konnten nicht initialisiert werden",
-  "some-modules-failed-description": "Die App kann weiterarbeiten, aber einige Funktionen sind möglicherweise nicht verfügbar. Bitte starten Sie fehlgeschlagene Module neu oder kontaktieren Sie den Support, wenn das Problem weiterhin besteht.",
-  "app-modules": {
-    "cpu-mining": "CPU-Mining",
-    "gpu-mining": "GPU-Mining",
-    "wallet": "Wallet"
   },
   "remaining": "verbleibend",
   "second_remaining": "verbleibende Sekunde",
   "seconds_remaining": "verbleibende Sekunden",
+  "some-modules-failed-description": "Die App kann weiterarbeiten, aber einige Funktionen sind möglicherweise nicht verfügbar. Bitte starten Sie fehlgeschlagene Module neu oder kontaktieren Sie den Support, wenn das Problem weiterhin besteht.",
   "title": {
     "binaries-cpu-miner": "CPU-Miner-Binärdatei wird vorbereitet",
     "binaries-cpu-miner-download": "CPU-Miner-Binärdatei vorbereiten | Herunterladen: {{ progress }}%",

--- a/public/locales/en/setup-progresses.json
+++ b/public/locales/en/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
   "any_moment_now": "Any moment now",
+  "app-modules": {
+    "cpu-mining": "CPU Mining",
+    "gpu-mining": "GPU Mining",
+    "wallet": "Wallet"
+  },
   "awaiting-exchange-selection": "Awaiting user exchange selection",
   "block-sync": "Syncing blocks",
   "calculating_time": "Calculating time remaining...",
   "calculating_time-compact": "Calculating time...",
+  "critical-initialization-failure": "Critical initialization failure",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Failed to complete step",
   "header-sync": "Syncing headers",
   "local-node-sync": "Tari Universe is still syncing. This won’t affect your mining experience.",
+  "module-initialization-issues": "Some Modules failed to initialize",
   "network-peers": "Connecting to network peers",
   "phase-title": {
     "setup-core": "Setting up the Tari App",
     "setup-core-compact": "Syncing app",
     "setup-hardware": "Setting up the Hardware",
     "setup-hardware-compact": "Setting up hardware",
-    "setup-node": "Setting up the Tari Node",
-    "setup-node-compact": "Syncing node",
     "setup-mining": "Setting up extra utilities",
     "setup-mining-compact": "Setting up utilities",
+    "setup-node": "Setting up the Tari Node",
+    "setup-node-compact": "Syncing node",
     "setup-wallet": "Setting up the Wallet",
     "setup-wallet-compact": "Syncing wallet"
-  },
-  "critical-initialization-failure": "Critical initialization failure",
-  "failed-to-complete-step": "Failed to complete step",
-  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
-  "module-initialization-issues": "Some Modules failed to initialize",
-  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
-  "app-modules": {
-    "cpu-mining": "CPU Mining",
-    "gpu-mining": "GPU Mining",
-    "wallet": "Wallet"
   },
   "remaining": "remaining",
   "second_remaining": "second remaining",
   "seconds_remaining": "seconds remaining",
+  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
   "title": {
     "binaries-cpu-miner": "Preparing CPU Miner Binary",
     "binaries-cpu-miner-download": "Preparing CPU Miner Binary | Downloading: {{ progress }}%",

--- a/public/locales/fr/setup-progresses.json
+++ b/public/locales/fr/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Tous les modules ont échoué à s\"initialiser. L\"application ne peut pas fonctionner dans l\"état actuel. Veuillez redémarrer l\"application ou contacter le support.",
   "any_moment_now": "D\"un moment à l\"autre",
+  "app-modules": {
+    "cpu-mining": "Minage CPU",
+    "gpu-mining": "Minage GPU",
+    "wallet": "Portefeuille"
+  },
   "awaiting-exchange-selection": "En attente de la sélection de la plateforme d\"échange par l\"utilisateur",
   "block-sync": "Synchronisation des blocs",
   "calculating_time": "Calcul du temps restant...",
   "calculating_time-compact": "Calcul du temps...",
+  "critical-initialization-failure": "Échec critique de l\"initialisation",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Échec de l\"étape",
   "header-sync": "Synchronisation des en-têtes",
   "local-node-sync": "Tari Universe est toujours en cours de synchronisation. Cela n\"affectera pas votre expérience de minage.",
+  "module-initialization-issues": "Certains modules n\"ont pas pu s\"initialiser",
   "network-peers": "Connexion aux pairs du réseau",
   "phase-title": {
     "setup-core": "Configuration de l\"application Tari",
     "setup-core-compact": "Synchronisation de l\"application",
     "setup-hardware": "Configuration du matériel",
     "setup-hardware-compact": "Configuration du matériel",
-    "setup-node": "Configuration du nœud Tari",
-    "setup-node-compact": "Synchronisation du nœud",
     "setup-mining": "Configuration des utilitaires supplémentaires",
     "setup-mining-compact": "Configuration des utilitaires",
+    "setup-node": "Configuration du nœud Tari",
+    "setup-node-compact": "Synchronisation du nœud",
     "setup-wallet": "Configuration du portefeuille",
     "setup-wallet-compact": "Synchronisation du portefeuille"
-  },
-  "critical-initialization-failure": "Échec critique de l\"initialisation",
-  "failed-to-complete-step": "Échec de l\"étape",
-  "all-modules-failed-description": "Tous les modules ont échoué à s\"initialiser. L\"application ne peut pas fonctionner dans l\"état actuel. Veuillez redémarrer l\"application ou contacter le support.",
-  "module-initialization-issues": "Certains modules n\"ont pas pu s\"initialiser",
-  "some-modules-failed-description": "L\"application peut continuer à fonctionner, mais certaines fonctionnalités peuvent ne pas être disponibles. Veuillez redémarrer les modules échoués ou contacter le support si le problème persiste.",
-  "app-modules": {
-    "cpu-mining": "Minage CPU",
-    "gpu-mining": "Minage GPU",
-    "wallet": "Portefeuille"
   },
   "remaining": "restant",
   "second_remaining": "seconde restante",
   "seconds_remaining": "secondes restantes",
+  "some-modules-failed-description": "L\"application peut continuer à fonctionner, mais certaines fonctionnalités peuvent ne pas être disponibles. Veuillez redémarrer les modules échoués ou contacter le support si le problème persiste.",
   "title": {
     "binaries-cpu-miner": "Préparation du binaire du mineur CPU",
     "binaries-cpu-miner-download": "Préparation du binaire du mineur CPU | Téléchargement : {{ progress }}%",

--- a/public/locales/hi/setup-progresses.json
+++ b/public/locales/hi/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
   "any_moment_now": "किसी भी क्षण",
+  "app-modules": {
+    "cpu-mining": "CPU Mining",
+    "gpu-mining": "GPU Mining",
+    "wallet": "Wallet"
+  },
   "awaiting-exchange-selection": "Awaiting user exchange selection",
   "block-sync": "ब्लॉक्स सिंक कर रहा है",
   "calculating_time": "शेष समय की गणना कर रहा है...",
   "calculating_time-compact": "Calculating time...",
+  "critical-initialization-failure": "Critical initialization failure",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Failed to complete step",
   "header-sync": "हेडर सिंक कर रहा है",
   "local-node-sync": "तारी यूनिवर्स अभी भी सिंक कर रहा है। यह आपके खनन अनुभव को प्रभावित नहीं करेगा।",
+  "module-initialization-issues": "Some Modules failed to initialize",
   "network-peers": "नेटवर्क साथियों से कनेक्ट हो रहा है",
   "phase-title": {
     "setup-core": "तारी ऐप सेट कर रहे हैं",
     "setup-core-compact": "Syncing app",
     "setup-hardware": "हार्डवेयर सेट कर रहे हैं",
     "setup-hardware-compact": "Setting up hardware",
-    "setup-node": "तारी नोड सेट कर रहे हैं",
-    "setup-node-compact": "Syncing node",
     "setup-mining": "अतिरिक्त उपयोगिताएँ सेट कर रहे हैं",
     "setup-mining-compact": "Setting up utilities",
+    "setup-node": "तारी नोड सेट कर रहे हैं",
+    "setup-node-compact": "Syncing node",
     "setup-wallet": "वॉलेट सेट कर रहे हैं",
     "setup-wallet-compact": "Syncing wallet"
-  },
-  "critical-initialization-failure": "Critical initialization failure",
-  "failed-to-complete-step": "Failed to complete step",
-  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
-  "module-initialization-issues": "Some Modules failed to initialize",
-  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
-  "app-modules": {
-    "cpu-mining": "CPU Mining",
-    "gpu-mining": "GPU Mining",
-    "wallet": "Wallet"
   },
   "remaining": "शेष",
   "second_remaining": "सेकंड शेष",
   "seconds_remaining": "सेकंड शेष",
+  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
   "title": {
     "binaries-cpu-miner": "सीपीयू माइनर बाइनरी तैयार कर रहे हैं",
     "binaries-cpu-miner-download": "Preparing CPU Miner Binary | Downloading: {{ progress }}%",

--- a/public/locales/id/setup-progresses.json
+++ b/public/locales/id/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Semua modul gagal diinisialisasi. Aplikasi tidak dapat berfungsi dalam keadaan saat ini. Silakan mulai ulang aplikasi atau hubungi dukungan.",
   "any_moment_now": "Sebentar lagi",
+  "app-modules": {
+    "cpu-mining": "Penambangan CPU",
+    "gpu-mining": "Penambangan GPU",
+    "wallet": "Dompet"
+  },
   "awaiting-exchange-selection": "Menunggu pemilihan bursa pengguna",
   "block-sync": "Menyinkronkan blok",
   "calculating_time": "Menghitung waktu yang tersisa...",
   "calculating_time-compact": "Menghitung waktu...",
+  "critical-initialization-failure": "Kegagalan inisialisasi kritis",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Gagal menyelesaikan langkah",
   "header-sync": "Menyinkronkan header",
   "local-node-sync": "Tari Universe masih menyinkronkan. Ini tidak akan mempengaruhi pengalaman menambang Anda.",
+  "module-initialization-issues": "Beberapa Modul gagal diinisialisasi",
   "network-peers": "Menghubungkan ke rekan jaringan",
   "phase-title": {
     "setup-core": "Menyiapkan Aplikasi Tari",
     "setup-core-compact": "Sinkronisasi aplikasi",
     "setup-hardware": "Menyiapkan Perangkat Keras",
     "setup-hardware-compact": "Menyiapkan perangkat keras",
-    "setup-node": "Menyiapkan Node Tari",
-    "setup-node-compact": "Sinkronisasi node",
     "setup-mining": "Menyiapkan utilitas tambahan",
     "setup-mining-compact": "Menyiapkan utilitas",
+    "setup-node": "Menyiapkan Node Tari",
+    "setup-node-compact": "Sinkronisasi node",
     "setup-wallet": "Menyiapkan Dompet",
     "setup-wallet-compact": "Sinkronisasi dompet"
-  },
-  "critical-initialization-failure": "Kegagalan inisialisasi kritis",
-  "failed-to-complete-step": "Gagal menyelesaikan langkah",
-  "all-modules-failed-description": "Semua modul gagal diinisialisasi. Aplikasi tidak dapat berfungsi dalam keadaan saat ini. Silakan mulai ulang aplikasi atau hubungi dukungan.",
-  "module-initialization-issues": "Beberapa Modul gagal diinisialisasi",
-  "some-modules-failed-description": "Aplikasi dapat terus berfungsi, tetapi beberapa fitur mungkin tidak tersedia. Silakan mulai ulang modul yang gagal, atau hubungi dukungan jika masalah berlanjut.",
-  "app-modules": {
-    "cpu-mining": "Penambangan CPU",
-    "gpu-mining": "Penambangan GPU",
-    "wallet": "Dompet"
   },
   "remaining": "tersisa",
   "second_remaining": "detik tersisa",
   "seconds_remaining": "detik tersisa",
+  "some-modules-failed-description": "Aplikasi dapat terus berfungsi, tetapi beberapa fitur mungkin tidak tersedia. Silakan mulai ulang modul yang gagal, atau hubungi dukungan jika masalah berlanjut.",
   "title": {
     "binaries-cpu-miner": "Menyiapkan Binary Penambang CPU",
     "binaries-cpu-miner-download": "Mempersiapkan Biner Penambang CPU | Mengunduh: {{ progress }}%",

--- a/public/locales/ja/setup-progresses.json
+++ b/public/locales/ja/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "すべてのモジュールの初期化に失敗しました。アプリは現在の状態では動作できません。アプリを再起動するか、サポートに連絡してください。",
   "any_moment_now": "今すぐにでも",
+  "app-modules": {
+    "cpu-mining": "CPUマイニング",
+    "gpu-mining": "GPUマイニング",
+    "wallet": "ウォレット"
+  },
   "awaiting-exchange-selection": "ユーザーの取引所選択を待っています",
   "block-sync": "ブロックを同期中",
   "calculating_time": "残り時間を計算中...",
   "calculating_time-compact": "時間を計算中...",
+  "critical-initialization-failure": "重大な初期化エラー",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "ステップの完了に失敗しました",
   "header-sync": "ヘッダーを同期中",
   "local-node-sync": "Tari Universeはまだ同期中です。これはマイニング体験に影響しません。",
+  "module-initialization-issues": "一部のモジュールの初期化に失敗しました",
   "network-peers": "ネットワークピアに接続中",
   "phase-title": {
     "setup-core": "Tariアプリを設定中",
     "setup-core-compact": "アプリを同期中",
     "setup-hardware": "ハードウェアを設定中",
     "setup-hardware-compact": "ハードウェアの設定中",
-    "setup-node": "Tariノードを設定中",
-    "setup-node-compact": "ノードを同期中",
     "setup-mining": "追加ユーティリティを設定中",
     "setup-mining-compact": "ユーティリティの設定中",
+    "setup-node": "Tariノードを設定中",
+    "setup-node-compact": "ノードを同期中",
     "setup-wallet": "ウォレットを設定中",
     "setup-wallet-compact": "ウォレットを同期中"
-  },
-  "critical-initialization-failure": "重大な初期化エラー",
-  "failed-to-complete-step": "ステップの完了に失敗しました",
-  "all-modules-failed-description": "すべてのモジュールの初期化に失敗しました。アプリは現在の状態では動作できません。アプリを再起動するか、サポートに連絡してください。",
-  "module-initialization-issues": "一部のモジュールの初期化に失敗しました",
-  "some-modules-failed-description": "アプリは動作を続けることができますが、一部の機能が利用できない場合があります。失敗したモジュールを再起動するか、問題が続く場合はサポートに連絡してください。",
-  "app-modules": {
-    "cpu-mining": "CPUマイニング",
-    "gpu-mining": "GPUマイニング",
-    "wallet": "ウォレット"
   },
   "remaining": "残り",
   "second_remaining": "残り秒数",
   "seconds_remaining": "残り秒数",
+  "some-modules-failed-description": "アプリは動作を続けることができますが、一部の機能が利用できない場合があります。失敗したモジュールを再起動するか、問題が続く場合はサポートに連絡してください。",
   "title": {
     "binaries-cpu-miner": "CPUマイナーバイナリを準備中",
     "binaries-cpu-miner-download": "CPUマイナーバイナリの準備中 | ダウンロード中: {{ progress }}%",

--- a/public/locales/ko/setup-progresses.json
+++ b/public/locales/ko/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "모든 모듈이 초기화에 실패했습니다. 현재 상태에서는 앱이 작동할 수 없습니다. 앱을 다시 시작하거나 지원팀에 문의하세요.",
   "any_moment_now": "곧",
+  "app-modules": {
+    "cpu-mining": "CPU 채굴",
+    "gpu-mining": "GPU 채굴",
+    "wallet": "지갑"
+  },
   "awaiting-exchange-selection": "사용자 거래소 선택 대기 중",
   "block-sync": "블록 동기화 중",
   "calculating_time": "남은 시간 계산 중...",
   "calculating_time-compact": "시간 계산 중...",
+  "critical-initialization-failure": "중대한 초기화 실패",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "단계를 완료하지 못했습니다",
   "header-sync": "헤더 동기화 중",
   "local-node-sync": "타리 유니버스가 여전히 동기화 중입니다. 이는 채굴 경험에 영향을 미치지 않습니다.",
+  "module-initialization-issues": "일부 모듈이 초기화에 실패했습니다",
   "network-peers": "네트워크 피어에 연결 중",
   "phase-title": {
     "setup-core": "Tari 앱 설정 중",
     "setup-core-compact": "앱 동기화 중",
     "setup-hardware": "하드웨어 설정 중",
     "setup-hardware-compact": "하드웨어 설정 중",
-    "setup-node": "Tari 노드 설정 중",
-    "setup-node-compact": "노드 동기화 중",
     "setup-mining": "추가 유틸리티 설정 중",
     "setup-mining-compact": "유틸리티 설정 중",
+    "setup-node": "Tari 노드 설정 중",
+    "setup-node-compact": "노드 동기화 중",
     "setup-wallet": "지갑 설정 중",
     "setup-wallet-compact": "지갑 동기화 중"
-  },
-  "critical-initialization-failure": "중대한 초기화 실패",
-  "failed-to-complete-step": "단계를 완료하지 못했습니다",
-  "all-modules-failed-description": "모든 모듈이 초기화에 실패했습니다. 현재 상태에서는 앱이 작동할 수 없습니다. 앱을 다시 시작하거나 지원팀에 문의하세요.",
-  "module-initialization-issues": "일부 모듈이 초기화에 실패했습니다",
-  "some-modules-failed-description": "앱은 계속 작동할 수 있지만 일부 기능은 사용할 수 없습니다. 실패한 모듈을 다시 시작하거나 문제가 지속되면 지원팀에 문의하세요.",
-  "app-modules": {
-    "cpu-mining": "CPU 채굴",
-    "gpu-mining": "GPU 채굴",
-    "wallet": "지갑"
   },
   "remaining": "남음",
   "second_remaining": "남은 초",
   "seconds_remaining": "남은 초",
+  "some-modules-failed-description": "앱은 계속 작동할 수 있지만 일부 기능은 사용할 수 없습니다. 실패한 모듈을 다시 시작하거나 문제가 지속되면 지원팀에 문의하세요.",
   "title": {
     "binaries-cpu-miner": "CPU 채굴기 바이너리 준비 중",
     "binaries-cpu-miner-download": "CPU 채굴기 바이너리 준비 중 | 다운로드 중: {{ progress }}%",

--- a/public/locales/pl/setup-progresses.json
+++ b/public/locales/pl/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Wszystkie moduły nie zainicjowały się. Aplikacja nie może działać w obecnym stanie. Proszę zrestartować aplikację lub skontaktować się z pomocą techniczną.",
   "any_moment_now": "W każdej chwili",
+  "app-modules": {
+    "cpu-mining": "Kopanie CPU",
+    "gpu-mining": "Kopanie GPU",
+    "wallet": "Portfel"
+  },
   "awaiting-exchange-selection": "Oczekiwanie na wybór giełdy przez użytkownika",
   "block-sync": "Synchronizacja bloków",
   "calculating_time": "Obliczanie pozostałego czasu...",
   "calculating_time-compact": "Obliczanie czasu...",
+  "critical-initialization-failure": "Krytyczny błąd inicjalizacji",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Nie udało się ukończyć kroku",
   "header-sync": "Synchronizacja nagłówków",
   "local-node-sync": "Tari Universe nadal się synchronizuje. To nie wpłynie na Twoje doświadczenie w kopaniu.",
+  "module-initialization-issues": "Niektóre moduły nie zainicjowały się",
   "network-peers": "Łączenie z węzłami sieci",
   "phase-title": {
     "setup-core": "Konfiguracja Aplikacji Tari",
     "setup-core-compact": "Synchronizowanie aplikacji",
     "setup-hardware": "Konfiguracja Sprzętu",
     "setup-hardware-compact": "Konfigurowanie sprzętu",
-    "setup-node": "Konfiguracja Węzła Tari",
-    "setup-node-compact": "Synchronizowanie węzła",
     "setup-mining": "Konfiguracja dodatkowych narzędzi",
     "setup-mining-compact": "Konfigurowanie narzędzi",
+    "setup-node": "Konfiguracja Węzła Tari",
+    "setup-node-compact": "Synchronizowanie węzła",
     "setup-wallet": "Konfiguracja Portfela",
     "setup-wallet-compact": "Synchronizowanie portfela"
-  },
-  "critical-initialization-failure": "Krytyczny błąd inicjalizacji",
-  "failed-to-complete-step": "Nie udało się ukończyć kroku",
-  "all-modules-failed-description": "Wszystkie moduły nie zainicjowały się. Aplikacja nie może działać w obecnym stanie. Proszę zrestartować aplikację lub skontaktować się z pomocą techniczną.",
-  "module-initialization-issues": "Niektóre moduły nie zainicjowały się",
-  "some-modules-failed-description": "Aplikacja może nadal działać, ale niektóre funkcje mogą być niedostępne. Proszę zrestartować nieudane moduły lub skontaktować się z pomocą techniczną, jeśli problem będzie się powtarzał.",
-  "app-modules": {
-    "cpu-mining": "Kopanie CPU",
-    "gpu-mining": "Kopanie GPU",
-    "wallet": "Portfel"
   },
   "remaining": "pozostało",
   "second_remaining": "pozostała sekunda",
   "seconds_remaining": "pozostało sekund",
+  "some-modules-failed-description": "Aplikacja może nadal działać, ale niektóre funkcje mogą być niedostępne. Proszę zrestartować nieudane moduły lub skontaktować się z pomocą techniczną, jeśli problem będzie się powtarzał.",
   "title": {
     "binaries-cpu-miner": "Przygotowywanie Pliku Wykonywalnego Koparki CPU",
     "binaries-cpu-miner-download": "Przygotowywanie binariów kopacza CPU | Pobieranie: {{ progress }}%",

--- a/public/locales/pt-BR/setup-progresses.json
+++ b/public/locales/pt-BR/setup-progresses.json
@@ -1,11 +1,28 @@
 {
+  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
   "any_moment_now": "A qualquer momento",
+  "app-modules": {
+    "cpu-mining": "CPU Mining",
+    "gpu-mining": "GPU Mining",
+    "wallet": "Wallet"
+  },
   "awaiting-exchange-selection": "Aguardando seleção de exchange do usuário",
   "block-sync": "Sincronizando blocos",
   "calculating_time": "Calculando tempo restante...",
   "calculating_time-compact": "Calculando tempo...",
+  "critical-initialization-failure": "Critical initialization failure",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Failed to complete step",
   "header-sync": "Sincronizando cabeçalhos",
   "local-node-sync": "O Tari Universe ainda está sincronizando. Isso não afetará sua experiência de mineração.",
+  "module-initialization-issues": "Some Modules failed to initialize",
   "network-peers": "Conectando-se a pares da rede",
   "phase-core-critical-problem-description": "A configuração principal é crítica para o aplicativo. Tente reiniciar o aplicativo. Se o problema persistir, entre em contato com o suporte.",
   "phase-core-critical-problem-title": "Falha na Configuração Principal",
@@ -24,6 +41,8 @@
     "setup-local-node-compact": "Sincronizando nó",
     "setup-mining": "Configurando utilitários extras",
     "setup-mining-compact": "Configurando utilitários",
+    "setup-node": "Setting up the Tari Node",
+    "setup-node-compact": "Syncing node",
     "setup-wallet": "Configurando a Carteira",
     "setup-wallet-compact": "Sincronizando carteira"
   },
@@ -32,6 +51,7 @@
   "remaining": "restante",
   "second_remaining": "segundo restante",
   "seconds_remaining": "segundos restantes",
+  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
   "title": {
     "binaries-cpu-miner": "Preparando Binário do Minerador de CPU",
     "binaries-cpu-miner-download": "Preparando Binário do Minerador de CPU | Baixando: {{ progress }}%",
@@ -50,6 +70,8 @@
     "detect-gpu": "Detectando GPUs",
     "done": "Concluído",
     "initialize-application-modules": "Inicializando Pré-requisitos da Plataforma",
+    "initialize-cpu-hardware": "Initialize CPU Hardware",
+    "initialize-gpu-hardware": "Initialize GPU Hardware",
     "initialize-spending-wallet": "Inicializando Carteira de Gastos",
     "migrating-database": "Migrando Banco de Dados da versão {{current_db_version}} para {{target_db_version}} progresso: {{current_block}}/{{total_blocks}}",
     "mm-proxy": "Iniciando Proxy de Mineração de Fusão",

--- a/public/locales/ru/setup-progresses.json
+++ b/public/locales/ru/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Все модули не удалось инициализировать. Приложение не может работать в текущем состоянии. Пожалуйста, перезапустите приложение или свяжитесь с поддержкой.",
   "any_moment_now": "В любой момент",
+  "app-modules": {
+    "cpu-mining": "Майнинг на CPU",
+    "gpu-mining": "Майнинг на GPU",
+    "wallet": "Кошелек"
+  },
   "awaiting-exchange-selection": "Ожидание выбора биржи пользователем",
   "block-sync": "Синхронизация блоков",
   "calculating_time": "Расчет оставшегося времени...",
   "calculating_time-compact": "Расчет времени...",
+  "critical-initialization-failure": "Критическая ошибка инициализации",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Не удалось завершить шаг",
   "header-sync": "Синхронизация заголовков",
   "local-node-sync": "Tari Universe все еще синхронизируется. Это не повлияет на Ваш процесс майнинга.",
+  "module-initialization-issues": "Некоторые модули не удалось инициализировать",
   "network-peers": "Подключение к сетевым пирам",
   "phase-title": {
     "setup-core": "Настройка приложения Tari",
     "setup-core-compact": "Синхронизация приложения",
     "setup-hardware": "Настройка оборудования",
     "setup-hardware-compact": "Настройка оборудования",
-    "setup-node": "Настройка узла Tari",
-    "setup-node-compact": "Синхронизация узла",
     "setup-mining": "Настройка дополнительных утилит",
     "setup-mining-compact": "Настройка утилит",
+    "setup-node": "Настройка узла Tari",
+    "setup-node-compact": "Синхронизация узла",
     "setup-wallet": "Настройка кошелька",
     "setup-wallet-compact": "Синхронизация кошелька"
-  },
-  "critical-initialization-failure": "Критическая ошибка инициализации",
-  "failed-to-complete-step": "Не удалось завершить шаг",
-  "all-modules-failed-description": "Все модули не удалось инициализировать. Приложение не может работать в текущем состоянии. Пожалуйста, перезапустите приложение или свяжитесь с поддержкой.",
-  "module-initialization-issues": "Некоторые модули не удалось инициализировать",
-  "some-modules-failed-description": "Приложение может продолжать работать, но некоторые функции могут быть недоступны. Пожалуйста, перезапустите неудачные модули или свяжитесь с поддержкой, если проблема сохраняется.",
-  "app-modules": {
-    "cpu-mining": "Майнинг на CPU",
-    "gpu-mining": "Майнинг на GPU",
-    "wallet": "Кошелек"
   },
   "remaining": "осталось",
   "second_remaining": "осталась секунда",
   "seconds_remaining": "осталось секунд",
+  "some-modules-failed-description": "Приложение может продолжать работать, но некоторые функции могут быть недоступны. Пожалуйста, перезапустите неудачные модули или свяжитесь с поддержкой, если проблема сохраняется.",
   "title": {
     "binaries-cpu-miner": "Подготовка бинарного файла майнера для CPU",
     "binaries-cpu-miner-download": "Подготовка бинарного файла майнера на CPU | Загрузка: {{ progress }}%",

--- a/public/locales/tr/setup-progresses.json
+++ b/public/locales/tr/setup-progresses.json
@@ -1,37 +1,45 @@
 {
+  "all-modules-failed-description": "Tüm modüller başlatılamadı. Uygulama mevcut durumda çalışamaz. Lütfen uygulamayı yeniden başlatın veya destekle iletişime geçin.",
   "any_moment_now": "Her an şimdi",
+  "app-modules": {
+    "cpu-mining": "CPU Madenciliği",
+    "gpu-mining": "GPU Madenciliği",
+    "wallet": "Cüzdan"
+  },
   "awaiting-exchange-selection": "Kullanıcı borsa seçimi bekleniyor",
   "block-sync": "Bloklar senkronize ediliyor",
   "calculating_time": "Kalan süre hesaplanıyor...",
   "calculating_time-compact": "Zaman hesaplanıyor...",
+  "critical-initialization-failure": "Kritik başlatma hatası",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Adım tamamlanamadı",
   "header-sync": "Başlıklar senkronize ediliyor",
   "local-node-sync": "Tari Universe hala senkronize ediliyor. Bu, madencilik deneyiminizi etkilemeyecek.",
+  "module-initialization-issues": "Bazı modüller başlatılamadı",
   "network-peers": "Ağ eşlerine bağlanılıyor",
   "phase-title": {
     "setup-core": "Tari Uygulaması Kuruluyor",
     "setup-core-compact": "Uygulama senkronize ediliyor",
     "setup-hardware": "Donanım Kuruluyor",
     "setup-hardware-compact": "Donanım ayarlanıyor",
-    "setup-node": "Tari Düğümü Kuruluyor",
-    "setup-node-compact": "Düğüm senkronize ediliyor",
     "setup-mining": "Ekstra araçlar kuruluyor",
     "setup-mining-compact": "Araçlar ayarlanıyor",
+    "setup-node": "Tari Düğümü Kuruluyor",
+    "setup-node-compact": "Düğüm senkronize ediliyor",
     "setup-wallet": "Cüzdan Kuruluyor",
     "setup-wallet-compact": "Cüzdan senkronize ediliyor"
-  },
-  "critical-initialization-failure": "Kritik başlatma hatası",
-  "failed-to-complete-step": "Adım tamamlanamadı",
-  "all-modules-failed-description": "Tüm modüller başlatılamadı. Uygulama mevcut durumda çalışamaz. Lütfen uygulamayı yeniden başlatın veya destekle iletişime geçin.",
-  "module-initialization-issues": "Bazı modüller başlatılamadı",
-  "some-modules-failed-description": "Uygulama çalışmaya devam edebilir, ancak bazı özellikler kullanılamayabilir. Lütfen başarısız modülleri yeniden başlatın veya sorun devam ederse destekle iletişime geçin.",
-  "app-modules": {
-    "cpu-mining": "CPU Madenciliği",
-    "gpu-mining": "GPU Madenciliği",
-    "wallet": "Cüzdan"
   },
   "remaining": "kalan",
   "second_remaining": "kalan saniye",
   "seconds_remaining": "kalan saniye",
+  "some-modules-failed-description": "Uygulama çalışmaya devam edebilir, ancak bazı özellikler kullanılamayabilir. Lütfen başarısız modülleri yeniden başlatın veya sorun devam ederse destekle iletişime geçin.",
   "title": {
     "binaries-cpu-miner": "CPU Madenci İkili Dosyası Hazırlanıyor",
     "binaries-cpu-miner-download": "CPU Madenci İkili Dosyası Hazırlanıyor | İndiriliyor: {{ progress }}%",

--- a/public/locales/vi/setup-progresses.json
+++ b/public/locales/vi/setup-progresses.json
@@ -1,38 +1,46 @@
 {
+  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
   "any_moment_now": "Sắp xong rồi",
+  "app-modules": {
+    "cpu-mining": "CPU Mining",
+    "gpu-mining": "GPU Mining",
+    "wallet": "Wallet"
+  },
   "awaiting-exchange-selection": "Đang chờ bạn chọn sàn giao dịch",
   "block-sync": "Đang đồng bộ block",
   "calculating_time": "Đang tính toán thời gian còn lại...",
   "calculating_time-compact": "Calculating time...",
+  "critical-initialization-failure": "Critical initialization failure",
+  "error": {
+    "description": {
+      "space": "Please clear out space on your device. Tari Universe cannot create the needed PID files due to space limitations."
+    },
+    "title": {
+      "space": "No space left on device"
+    }
+  },
+  "failed-to-complete-step": "Failed to complete step",
   "header-sync": "Đang đồng bộ header",
   "local-node-sync": "Tari Universe vẫn đang đồng bộ. Điều này không ảnh hưởng đến quá trình đào.",
+  "module-initialization-issues": "Some Modules failed to initialize",
   "network-peers": "Đang kết nối với các node mạng",
   "phase-title": {
     "setup-core": "Đang thiết lập ứng dụng Tari",
     "setup-core-compact": "Syncing app",
     "setup-hardware": "Đang thiết lập phần cứng",
     "setup-hardware-compact": "Setting up hardware",
-    "setup-node": "Đang thiết lập node Tari",
-    "setup-node-compact": "Syncing node",
     "setup-mining": "Setting up extra utilities",
     "setup-mining-compact": "Setting up utilities",
+    "setup-node": "Đang thiết lập node Tari",
+    "setup-node-compact": "Syncing node",
     "setup-unknown": "Đang thiết lập tiện ích bổ sung",
     "setup-wallet": "Đang thiết lập ví",
     "setup-wallet-compact": "Syncing wallet"
   },
-  "critical-initialization-failure": "Critical initialization failure",
-  "failed-to-complete-step": "Failed to complete step",
-  "all-modules-failed-description": "All modules failed to initialize. App can't work in current state. Please restart the app or contact support.",
-  "module-initialization-issues": "Some Modules failed to initialize",
-  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
-  "app-modules": {
-    "cpu-mining": "CPU Mining",
-    "gpu-mining": "GPU Mining",
-    "wallet": "Wallet"
-  },
   "remaining": "còn lại",
   "second_remaining": "giây còn lại",
   "seconds_remaining": "giây còn lại",
+  "some-modules-failed-description": "App can continue to work, but some features may not be available. Please restart failed modules, or contact support if the issue persists.",
   "title": {
     "binaries-cpu-miner": "Đang chuẩn bị file nhị phân CPU Miner",
     "binaries-cpu-miner-download": "Preparing CPU Miner Binary | Downloading: {{ progress }}%",

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -255,8 +255,8 @@ impl ProcessInstanceTrait for ProcessInstance {
 
                     if should_emit_critial_error {
                         EventsEmitter::emit_critical_problem(CriticalProblemPayload {
-                            title: Some("No space left on device".to_string()),
-                            description: Some("Please clear out old files".to_string()),
+                            title: Some("error.title.space".to_string()),
+                            description: Some("error.description.space".to_string()),
                             error_message: Some(error_msg),
                         }).await;
                     }


### PR DESCRIPTION
Description
---

- remove the sentry logging for `os error 28` (no more space) in favour of emitting a critical problem message

Motivation and Context
---
- point 2 on #3033 
- **thousands** of these logs coming up in sentry, and the users should be informed so they can clear out some space
