### PR TITLE
chore: update Bridge tapplet version to v0.3.2

### DIFF
--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.3.1",
+        "bridge": "0.3.2",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.3.1",
+        "bridge": "0.3.2",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.3.1",
+        "bridge": "0.3.2",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",


### PR DESCRIPTION
## Description

Updates Bridge tapplet version to `v0.3.2`.

## Motivation and Context

Tapplet adds a new feature to limit Bridge unwrap requests to align with daily limit.

## How Has This Been Tested?


Ran locally. `v0.3.2` was downloaded successfully.

```
2025-12-12 14:53:37.110861000 INFO  Downloading binary: bridge from url: https://cdn-universe.tari.com/tari-project/wxtm-bridge-frontend/releases/download/v0.3.2/bridge-v0.3.2.zip // src/binaries/binaries_manager.rs:386
2025-12-12 14:53:37.357050000 INFO  Using archive destination: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive // src/requests/clients/http_file_client.rs:136
2025-12-12 14:53:37.357115000 INFO  Destination directory: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive // src/requests/clients/http_file_client.rs:212
2025-12-12 14:53:37.357144000 INFO  Destination file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive/bridge-v0.3.2.zip // src/requests/clients/http_file_client.rs:213
2025-12-12 14:53:37.357483000 INFO  File does not exist, creating new file at /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive/bridge-v0.3.2.zip // src/requests/clients/http_file_client.rs:222
2025-12-12 14:53:37.357918000 INFO  Expected file size: 15122564 // src/requests/clients/http_file_client.rs:259
2025-12-12 14:53:37.357954000 INFO  Current file size: 0 // src/requests/clients/http_file_client.rs:260
2025-12-12 14:53:37.357982000 INFO  File is empty, starting download from the beginning. // src/requests/clients/http_file_client.rs:282
2025-12-12 14:53:37.870825000 INFO  Downloaded successfully // src/requests/clients/http_file_client.rs:289
2025-12-12 14:53:37.871602000 INFO  Extracting file to /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2 // src/requests/clients/http_file_client.rs:423
2025-12-12 14:53:37.871711000 INFO  Destination directory already exists, removing old entries. // src/requests/clients/http_file_client.rs:429
2025-12-12 14:53:37.871742000 INFO  Archive file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive // src/requests/clients/http_file_client.rs:430
2025-12-12 14:53:37.871841000 INFO  Extracting archive file: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive/bridge-v0.3.2.zip // src/requests/clients/http_file_client.rs:448
2025-12-12 14:53:38.279798000 INFO  Extraction completed successfully. // src/requests/clients/http_file_client.rs:404
2025-12-12 14:53:38.279848000 INFO  Using archive destination: /Users/martinserts/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.3.2/archive // src/requests/clients/http_file_client.rs:136
2025-12-12 14:53:38.279887000 INFO  Successfully downloaded binary: bridge on retry: 0 // src/binaries/binaries_manager.rs:350
```

## What process can a PR reviewer use to test or verify this change?

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
