### PR TITLE
chore: bump core versions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2510,21 +2510,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "findshlibs"
@@ -3313,7 +3312,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-platform-verifier",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -3338,7 +3337,7 @@ dependencies = [
  "resolv-conf",
  "rustls",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -4332,7 +4331,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thread-id",
  "typemap-ors",
  "unicode-segmentation",
@@ -4636,8 +4635,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -4658,7 +4657,7 @@ dependencies = [
  "tari_sidechain",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tonic-build",
@@ -4667,8 +4666,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -4676,16 +4675,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4703,12 +4702,12 @@ dependencies = [
 [[package]]
 name = "minotari_wallet_grpc_client"
 version = "0.1.0"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "minotari_app_grpc",
  "tari_common",
  "tari_common_types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tonic 0.13.1",
 ]
 
@@ -4809,7 +4808,7 @@ dependencies = [
  "once_cell",
  "png 0.17.16",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -5592,7 +5591,7 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6498,7 +6497,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6519,7 +6518,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6798,7 +6797,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7002,10 +7001,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
+name = "rsqlite-vfs"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -7097,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7134,9 +7143,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7445,7 +7454,7 @@ checksum = "b3b211916a3aed3398125b02b98a5cd4fc530c5626dd28a3c86865fe6cd93935"
 dependencies = [
  "minidumper-child",
  "sentry",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7863,7 +7872,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -8030,14 +8039,13 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
 dependencies = [
  "cc",
- "hashbrown 0.16.1",
  "js-sys",
- "thiserror 2.0.17",
+ "rsqlite-vfs",
  "wasm-bindgen",
 ]
 
@@ -8484,7 +8492,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tiny-keccak",
  "tokio",
  "tokio-tungstenite",
@@ -8524,8 +8532,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -8543,14 +8551,14 @@ dependencies = [
  "structopt",
  "tari_features",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.5.11",
 ]
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -8560,14 +8568,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "tari_common_types"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -8595,15 +8603,15 @@ dependencies = [
  "tari_hashing",
  "tari_max_size",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utoipa",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_comms"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8637,7 +8645,7 @@ dependencies = [
  "tari_shutdown",
  "tari_storage",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -8649,8 +8657,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -8675,7 +8683,7 @@ dependencies = [
  "tari_crypto",
  "tari_shutdown",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
  "zeroize",
@@ -8683,8 +8691,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8693,8 +8701,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8747,7 +8755,7 @@ dependencies = [
  "tari_test_utils",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -8778,13 +8786,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 
 [[package]]
 name = "tari_hashing"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "blake2",
  "borsh",
@@ -8794,8 +8802,8 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "borsh",
  "digest",
@@ -8803,37 +8811,37 @@ dependencies = [
  "serde",
  "tari_crypto",
  "tari_hashing",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_max_size"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "borsh",
  "serde",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_mmr"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "borsh",
  "digest",
  "serde",
  "tari_crypto",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_node_components"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "blake2",
  "borsh",
@@ -8846,13 +8854,13 @@ dependencies = [
  "tari_hashing",
  "tari_transaction_components",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_p2p"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "futures",
@@ -8869,7 +8877,7 @@ dependencies = [
  "tari_service_framework",
  "tari_shutdown",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -8877,8 +8885,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "blake2",
  "borsh",
@@ -8890,36 +8898,36 @@ dependencies = [
  "tari_crypto",
  "tari_max_size",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_service_framework"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
  "log",
  "tari_shutdown",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower-service",
 ]
 
 [[package]]
 name = "tari_shutdown"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "borsh",
  "hex",
@@ -8930,25 +8938,25 @@ dependencies = [
  "tari_hashing",
  "tari_jellyfish",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_storage"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "bincode",
  "lmdb-zero",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_test_utils"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "futures",
  "rand 0.8.5",
@@ -8960,8 +8968,8 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.2.1-pre.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1-pre.1#c22e47742d1ae9aa67360e56cd63b2bae05992e1"
+version = "5.2.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8997,7 +9005,7 @@ dependencies = [
  "tari_script",
  "tari_sidechain",
  "tari_utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "utoipa",
  "uuid",
@@ -9066,7 +9074,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tray-icon",
  "url",
@@ -9120,7 +9128,7 @@ dependencies = [
  "sha2",
  "syn 2.0.114",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -9170,7 +9178,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9185,7 +9193,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9205,7 +9213,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "url",
 ]
@@ -9228,7 +9236,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
  "urlpattern",
@@ -9249,7 +9257,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9275,7 +9283,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9295,7 +9303,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -9308,10 +9316,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus 5.13.1",
+ "zbus 5.13.2",
 ]
 
 [[package]]
@@ -9338,7 +9346,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -9364,7 +9372,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -9431,7 +9439,7 @@ dependencies = [
  "serde_with",
  "serialize-to-javascript",
  "swift-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "url",
  "urlpattern",
@@ -9494,11 +9502,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -9514,9 +9522,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10079,7 +10087,7 @@ dependencies = [
  "once_cell",
  "png 0.17.16",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -10114,7 +10122,7 @@ dependencies = [
  "native-tls",
  "rand 0.9.2",
  "sha1 0.10.6",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -10496,9 +10504,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -10797,7 +10805,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -11469,9 +11477,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -11483,7 +11491,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix 1.1.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -11543,7 +11551,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -11709,9 +11717,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.13.1"
+version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f79257df967b6779afa536788657777a0001f5b42524fcaf5038d4344df40b"
+checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
 dependencies = [
  "async-broadcast 0.7.2",
  "async-executor",
@@ -11737,9 +11745,9 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros 5.13.1",
+ "zbus_macros 5.13.2",
  "zbus_names 4.3.1",
- "zvariant 5.9.1",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -11757,16 +11765,16 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.13.1"
+version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad23e2d2f91cae771c7af7a630a49e755f1eb74f8a46e9f6d5f7a146edf5a37"
+checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
  "zbus_names 4.3.1",
- "zvariant 5.9.1",
+ "zvariant 5.9.2",
  "zvariant_utils",
 ]
 
@@ -11789,7 +11797,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.14",
- "zvariant 5.9.1",
+ "zvariant 5.9.2",
 ]
 
 [[package]]
@@ -11908,7 +11916,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1 0.10.6",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "xz2",
  "zeroize",
@@ -11930,9 +11938,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zopfli"
@@ -12005,15 +12013,15 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.9.1"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326aaed414f04fe839777b4c443d4e94c74e7b3621093bd9c5e649ac8aa96543"
+checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 0.7.14",
- "zvariant_derive 5.9.1",
+ "zvariant_derive 5.9.2",
  "zvariant_utils",
 ]
 
@@ -12031,9 +12039,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.1"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba44e1f8f4da9e6e2d25d2a60b116ef8b9d0be174a7685e55bb12a99866279a7"
+checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,9 +47,9 @@ libsqlite3-sys = { version = "0.25.1", features = [
 ] } # Required for tari_wallet
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
-minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
-minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
+minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
+minotari_wallet_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -76,11 +76,11 @@ sha2 = "0.10.8"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
 tari_crypto = "0.22.1"
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1-pre.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
 tari_utilities = "0.8.0"
 tauri = { version = "2", features = [
   "protocol-asset",

--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -4,11 +4,11 @@
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",
-        "minotari_node": "5.2.1-pre.1 | c22e477",
-        "mmproxy": "5.2.1-pre.1 | c22e477",
+        "minotari_node": "5.2.1 | c79f555",
+        "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "14.5.1",
-        "wallet": "5.2.1-pre.1 | c22e477",
+        "wallet": "5.2.1 | c79f555",
         "xmrig": "6.24.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -4,11 +4,11 @@
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",
-        "minotari_node": "5.2.1-pre.1 | c22e477",
-        "mmproxy": "5.2.1-pre.1 | c22e477",
+        "minotari_node": "5.2.1 | c79f555",
+        "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "14.5.1",
-        "wallet": "5.2.1-pre.1 | c22e477",
+        "wallet": "5.2.1 | c79f555",
         "xmrig": "6.24.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -4,11 +4,11 @@
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",
-        "minotari_node": "5.2.1-pre.1 | c22e477",
-        "mmproxy": "5.2.1-pre.1 | c22e477",
+        "minotari_node": "5.2.1 | c79f555",
+        "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "14.5.1",
-        "wallet": "5.2.1-pre.1 | c22e477",
+        "wallet": "5.2.1 | c79f555",
         "xmrig": "6.24.0"
     }
 }

--- a/src/containers/floating/Settings/sections/connections/Network.tsx
+++ b/src/containers/floating/Settings/sections/connections/Network.tsx
@@ -18,8 +18,6 @@ export default function Network() {
     const { t } = useTranslation('settings');
     const baseNodeStatus = useNodeStore((state) => state?.base_node_status);
 
-    const sha_network_hashrate = baseNodeStatus?.sha_network_hashrate || 0;
-    const tari_randomx_network_hashrate = baseNodeStatus?.tari_randomx_network_hashrate || 0;
     const block_reward = baseNodeStatus?.block_reward || 0;
     const block_height = baseNodeStatus?.block_height || 0;
     const block_time = baseNodeStatus?.block_time || 0;
@@ -27,8 +25,6 @@ export default function Network() {
     const readiness_status = baseNodeStatus?.readiness_status?.['State'] || 0;
 
     // Format values
-    const fmtSHA = formatHashrate(sha_network_hashrate);
-    const fmtTariRX = formatHashrate(tari_randomx_network_hashrate);
     const formattedBlockReward = formatHashrate(block_reward);
 
     // Format block time as a date


### PR DESCRIPTION
## Description

- bumped tari core binaries versions (to `v5.2.1`)
- small lints

## How Has This Been Tested?

- ~~currently testing locally, waiting for wallet scan~~ locally

## Breaking Changes

- [x] None
