### PR TITLE
fix: daily limit alert - updated to patched bridge binary version

### DIFF
--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.0",
+        "bridge": "0.4.1",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.0",
+        "bridge": "0.4.1",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.0",
+        "bridge": "0.4.1",
         "glytex": "0.2.32 | ad20e05",
         "graxil": "1.0.13 | 16af6ba",
         "lolminer": "1.98",


### PR DESCRIPTION
# IMPORTANT

~~don't merge until https://github.com/tari-project/wxtm-bridge-frontend/pull/101 is merged and deployed with `0.4.1` as the tag~~ merged :D 

## Description

see https://github.com/tari-project/wxtm-bridge-frontend/pull/101 for full context

- updated bridge binary version (to the version where the limit alert display is fixed)

## Motivation and Context

- daily limit notification wasn't working

## How Has This Been Tested?

- locally:

https://github.com/user-attachments/assets/ae33e601-ef46-4b0f-8364-ba2f66226ea8


