### PR TITLE
fix: duplicate transactions

### DIFF
--- a/src/store/actions/walletStoreActions.ts
+++ b/src/store/actions/walletStoreActions.ts
@@ -247,10 +247,16 @@ const mergeTransactions = (
 export const handleWalletTransactionsFound = async (payload: DisplayedTransaction[]) => {
     const processedTransactions = await solveBridgeTransactionDetails(payload);
 
-    useWalletStore.setState((state) => ({
-        ...state,
-        wallet_transactions: mergeTransactions(state.wallet_transactions, processedTransactions, true),
-    }));
+    useWalletStore.setState((state) => {
+        const newTransactions = mergeTransactions(state.wallet_transactions, processedTransactions, true);
+        if (newTransactions === state.wallet_transactions) {
+            return state;
+        }
+        return {
+            ...state,
+            wallet_transactions: newTransactions,
+        };
+    });
 };
 
 export const handleWalletTransactionsCleared = () => {
@@ -265,11 +271,9 @@ export const handleWalletTransactionUpdated = async (payload: DisplayedTransacti
 
     useWalletStore.setState((state) => {
         const newTransactions = mergeTransactions(state.wallet_transactions, processedTransactions, false);
-
         if (newTransactions === state.wallet_transactions) {
             return state;
         }
-
         return {
             ...state,
             wallet_transactions: newTransactions,


### PR DESCRIPTION
## Description

This PR fixes a bug where outgoing transactions would appear twice in the transaction history: once as a "pending" transaction (created locally) and again as a "mined" transaction (received from the backend). 

<img width="363" height="431" alt="Screenshot 2026-01-26 at 16 36 06" src="https://github.com/user-attachments/assets/11e81a33-bdac-42c5-8bdf-6a25ac9100b4" />

Closes #3116

## Motivation and Context

Previously, the frontend attempted to match pending and mined transactions using `sent_output_hashes`. However, the backend sometimes returns empty output hashes for mined transactions, causing the match to fail. This resulted in the pending transaction remaining in the list alongside the new mined transaction.

## How Has This Been Tested?

- Manually tested by sending a one-sided transaction.
- Verified that the "fake" pending transaction appears immediately.
- Verified that when the transaction is mined and the backend emits the update, the pending transaction is **replaced** in-place rather than a new one being appended.

## What process can a PR reviewer use to test or verify this change?

1.  Launch TU.
2.  Send a one-sided transaction to another address.
3.  Observe the transaction list. You should see the pending transaction immediately.
4.  Wait for the transaction to be mined (confirmed on chain).
5.  **Verify:** The transaction in the list updates itself (`Block Height`) without creating a second duplicate entry.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
