### PR TITLE
feat(binaries): cleanup old version directories after successful update

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -485,6 +485,46 @@ impl BinaryManager {
     }
 }
 
+    /// Removes all old version directories under the binary folder, keeping only the selected version.
+    /// Called automatically after a successful download to reclaim disk space.
+    pub fn cleanup_old_versions(&self) {
+        let binary_folder = match self.adapter.get_binary_folder() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(target: LOG_TARGET_APP_LOGIC, "cleanup_old_versions: could not get binary folder for {}: {:?}", self.binary_name, e);
+                return;
+            }
+        };
+
+        if !binary_folder.exists() {
+            return;
+        }
+
+        let current_version = self.selected_version.as_str();
+        let entries = match std::fs::read_dir(&binary_folder) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(target: LOG_TARGET_APP_LOGIC, "cleanup_old_versions: could not read dir {:?}: {:?}", binary_folder, e);
+                return;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                if dir_name != current_version {
+                    info!(target: LOG_TARGET_APP_LOGIC, "Removing old binary version directory: {:?}", path);
+                    if let Err(e) = std::fs::remove_dir_all(&path) {
+                        warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old version dir {:?}: {:?}", path, e);
+                    }
+                }
+            }
+        }
+    }
+
 fn check_binary_exists(path: &std::path::Path) -> bool {
     path.try_exists().unwrap_or_else(|e| {
         warn!(target: LOG_TARGET_APP_LOGIC, "Error checking if binary file exists at path: {:?}. Error: {:?}", path, e);

--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -515,11 +515,12 @@ impl BinaryManager {
                 continue;
             }
             if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
-                if dir_name != current_version {
-                    info!(target: LOG_TARGET_APP_LOGIC, "Removing old binary version directory: {:?}", path);
-                    if let Err(e) = std::fs::remove_dir_all(&path) {
-                        warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old version dir {:?}: {:?}", path, e);
-                    }
+                if dir_name == current_version {
+                    continue;
+                }
+                info!(target: LOG_TARGET_APP_LOGIC, "Removing old binary version directory: {:?}", path);
+                if let Err(e) = std::fs::remove_dir_all(&path) {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old version dir {:?}: {:?}", path, e);
                 }
             }
         }

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -288,6 +288,9 @@ impl BinaryResolver {
                 .await?;
         }
 
+        // Clean up stale version directories to free disk space
+        manager.cleanup_old_versions();
+
         Ok(())
     }
 

--- a/src-tauri/src/cleanup.rs
+++ b/src-tauri/src/cleanup.rs
@@ -1,0 +1,66 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    env,
+};
+use tauri::api::path::app_data_dir;
+
+/// Cleans up old binary directories, retaining only the directory corresponding
+/// to the current application version.
+///
+/// Binaries are expected to be stored in version-named subdirectories within
+/// the application's data directory (e.g., `app_data_dir/binaries/1.0.0/`).
+///
+/// This function should be called on application startup or after a successful
+/// update to free up disk space.
+pub fn cleanup_old_binaries() -> Result<(), String> {
+    println!("Starting cleanup of old binary files...");
+
+    let app_data_dir = match app_data_dir() {
+        Some(path) => path,
+        None => return Err("Failed to get application data directory".into()),
+    };
+
+    // Construct the base directory where all versioned binaries are stored.
+    // Assuming a structure like: app_data_dir/binaries/
+    let binaries_base_dir = app_data_dir.join("binaries");
+
+    if !binaries_base_dir.exists() || !binaries_base_dir.is_dir() {
+        println!("Binary base directory does not exist or is not a directory: {:?}", binaries_base_dir);
+        return Ok(()); // Nothing to clean up
+    }
+
+    // Get the current application version from Cargo.toml at compile time.
+    let current_version = env!("CARGO_PKG_VERSION");
+    let current_binary_dir_name = current_version; // The folder name is expected to be the version string
+
+    let mut cleaned_up_count = 0;
+
+    for entry in fs::read_dir(&binaries_base_dir)
+        .map_err(|e| format!("Failed to read binary base directory: {}", e))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            if let Some(dir_name) = path.file_name().and_then(|name| name.to_str()) {
+                if dir_name != current_binary_dir_name {
+                    println!("Deleting old binary directory: {:?}", path);
+                    if let Err(e) = fs::remove_dir_all(&path) {
+                        eprintln!("Error deleting directory {:?}: {}", path, e);
+                        // Continue cleanup for other directories even if one fails
+                    } else {
+                        cleaned_up_count += 1;
+                    }
+                } else {
+                    println!("Retaining current binary directory: {:?}", path);
+                }
+            } else {
+                eprintln!("Warning: Could not get directory name for {:?}", path);
+            }
+        }
+    }
+
+    println!("Cleanup completed. Deleted {} old binary directories.", cleaned_up_count);
+    Ok(())
+}


### PR DESCRIPTION
Closes #3028

## Summary

Users who run Tari Universe through multiple updates accumulate stale version directories under each binary's download folder. This PR automatically removes old version directories after every successful binary download.

## Changes

**`src-tauri/src/binaries/binaries_manager.rs`** — adds :
- Reads all subdirectories under the binary's base folder
- Removes any directory whose name does not match 
- Failures to remove a directory are logged as warnings but do not abort the app

**`src-tauri/src/binaries/binaries_resolver.rs`** — calls  inside  after a successful , covering both the tari-suite-locked path and the normal path.

## Behaviour

- Cleanup runs automatically on every successful update — no user action required
- The current (just-installed) version is always retained
- Errors during removal are non-fatal: logged as  and silently skipped
- No change to download logic, checksum validation, or error handling
