### PR TITLE
feat: custom remote node address selection in Settings

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -141,6 +141,8 @@
     "data-subtitle": "Set a custom location to store the base node data",
     "data-title": "Node data settings"
   },
+  "custom-remote-node-address": "Custom remote node address (gRPC)",
+  "custom-remote-node-address-error": "Address must start with http:// or https://",
   "node-configuration": "Node configuration",
   "node-configuration-description": "Connect with Remote, Local or both until your Local is ready to use",
   "node-connection-address": "Connection address",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1683,6 +1683,41 @@ pub async fn set_node_type(
 }
 
 #[tauri::command]
+pub async fn set_remote_base_node_address(address: String) -> Result<(), InvokeError> {
+    let timer = Instant::now();
+    info!(target: LOG_TARGET_APP_LOGIC, "[set_remote_base_node_address] called with address: {address:?}");
+
+    let trimmed = address.trim().to_string();
+    if !trimmed.is_empty() {
+        // Validate the address format by attempting to parse it
+        let has_scheme = trimmed.starts_with("http://") || trimmed.starts_with("https://");
+        if !has_scheme {
+            return Err(InvokeError::from_anyhow(anyhow::anyhow!(
+                "Invalid address: must start with http:// or https://"
+            )));
+        }
+    }
+
+    ConfigCore::update_field_requires_restart(
+        ConfigCoreContent::set_remote_base_node_address,
+        trimmed,
+        vec![SetupPhase::Node, SetupPhase::Wallet, SetupPhase::CpuMining],
+    )
+    .await
+    .map_err(InvokeError::from_anyhow)?;
+
+    SetupManager::get_instance()
+        .restart_phases_from_queue()
+        .await;
+
+    if timer.elapsed() > MAX_ACCEPTABLE_COMMAND_TIME {
+        warn!(target: LOG_TARGET_APP_LOGIC, "set_remote_base_node_address took too long: {:?}", timer.elapsed());
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn change_cpu_pool(cpu_pool: String) -> Result<(), InvokeError> {
     let timer = Instant::now();
     info!(target: LOG_TARGET_APP_LOGIC, "[change_cpu_pool] called with cpu_pool: {cpu_pool:?}");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1687,20 +1687,48 @@ pub async fn set_remote_base_node_address(address: String) -> Result<(), InvokeE
     let timer = Instant::now();
     info!(target: LOG_TARGET_APP_LOGIC, "[set_remote_base_node_address] called with address: {address:?}");
 
-    let trimmed = address.trim().to_string();
-    if !trimmed.is_empty() {
-        // Validate the address format by attempting to parse it
-        let has_scheme = trimmed.starts_with("http://") || trimmed.starts_with("https://");
-        if !has_scheme {
+    // The PR description promises "Clear the field — reverts to default
+    // remote node address". An empty string however is not a valid gRPC
+    // endpoint: persisting it would make the node phase fail to dial on
+    // the next restart and leave the user stuck until they manually
+    // re-enter an address. Substituting the network-appropriate default
+    // from `ConfigCoreContent::default()` preserves the documented
+    // "clear to reset" UX without storing a known-broken value.
+    //
+    // For non-empty input we parse the address with `url::Url` instead of
+    // a raw `starts_with` prefix check: the previous version accepted
+    // `"http://"` on its own, mis-scheme URLs like `"https:foo"`, and any
+    // string that happened to begin with `http://` without a host. Using
+    // the real parser catches those and guarantees the persisted value
+    // actually round-trips through `Url::parse`.
+    let trimmed_address = address.trim();
+    let resolved = if trimmed_address.is_empty() {
+        ConfigCoreContent::default().remote_base_node_address().clone()
+    } else {
+        let parsed = url::Url::parse(trimmed_address).map_err(|e| {
+            InvokeError::from_anyhow(anyhow::anyhow!(
+                "Invalid remote base node address {trimmed_address:?}: {e}"
+            ))
+        })?;
+        match parsed.scheme() {
+            "http" | "https" => {},
+            other => {
+                return Err(InvokeError::from_anyhow(anyhow::anyhow!(
+                    "Invalid remote base node address scheme {other:?}: must be http or https"
+                )));
+            },
+        }
+        if parsed.host_str().is_none_or(str::is_empty) {
             return Err(InvokeError::from_anyhow(anyhow::anyhow!(
-                "Invalid address: must start with http:// or https://"
+                "Invalid remote base node address {trimmed_address:?}: missing host"
             )));
         }
-    }
+        trimmed_address.to_string()
+    };
 
     ConfigCore::update_field_requires_restart(
         ConfigCoreContent::set_remote_base_node_address,
-        trimmed,
+        resolved,
         vec![SetupPhase::Node, SetupPhase::Wallet, SetupPhase::CpuMining],
     )
     .await

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1682,8 +1682,95 @@ pub async fn set_node_type(
     Ok(())
 }
 
+/// Parse and canonicalise a remote base node gRPC address.
+///
+/// On success returns the canonical `{scheme}://{host}:{port}` form that
+/// `RemoteNodeAdapter::set_grpc_address` can safely split on `:`. The
+/// function deliberately rejects a superset of what a raw `url::Url::parse`
+/// would accept:
+///
+/// - Scheme must be `http` or `https` (case-insensitive; normalised to
+///   lowercase in the returned string).
+/// - A port is **required** — the adapter panics on `parts[2]` when the
+///   address has no explicit port, so we refuse to persist one without.
+/// - Host must be present.
+/// - Path, query, fragment, username and password are all rejected to
+///   keep the persisted value a bare gRPC endpoint (no `/v1`, no
+///   `user:pass@`, no `?x=y`).
+///
+/// IPv6 literals are preserved in their bracketed form (`[::1]`) so the
+/// canonical string remains parseable.
+fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::Error> {
+    let parsed = url::Url::parse(input)
+        .map_err(|e| anyhow::anyhow!("Invalid remote base node address {input:?}: {e}"))?;
+
+    let scheme = parsed.scheme().to_ascii_lowercase();
+    if scheme != "http" && scheme != "https" {
+        anyhow::bail!("Invalid remote base node address scheme {scheme:?}: must be http or https");
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        anyhow::bail!(
+            "Invalid remote base node address {input:?}: userinfo (user:pass@) is not permitted"
+        );
+    }
+
+    let host = parsed
+        .host_str()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Invalid remote base node address {input:?}: missing host"))?;
+
+    let port = parsed.port().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Invalid remote base node address {input:?}: an explicit port is required (e.g. :443)"
+        )
+    })?;
+
+    // `url` normalises an empty path to "/" — treat that the same as no path
+    // for the purpose of rejection, but reject anything longer.
+    if !matches!(parsed.path(), "" | "/") {
+        anyhow::bail!(
+            "Invalid remote base node address {input:?}: path segments are not permitted"
+        );
+    }
+    if parsed.query().is_some() {
+        anyhow::bail!(
+            "Invalid remote base node address {input:?}: query strings are not permitted"
+        );
+    }
+    if parsed.fragment().is_some() {
+        anyhow::bail!("Invalid remote base node address {input:?}: fragments are not permitted");
+    }
+
+    // Preserve IPv6 brackets: `url` gives the unbracketed form via `host_str`.
+    let host_for_url = match parsed.host() {
+        Some(url::Host::Ipv6(addr)) => format!("[{addr}]"),
+        _ => host.to_string(),
+    };
+
+    Ok(format!("{scheme}://{host_for_url}:{port}"))
+}
+
+/// Validate a candidate remote base node address without persisting it.
+///
+/// Returns the canonical form the backend would actually store when
+/// `set_remote_base_node_address` is called with the same input. The UI
+/// calls this from the input's blur handler so errors appear inline and
+/// the submitted value matches exactly what the backend will accept.
+///
+/// Empty (or whitespace-only) input resolves to the network-appropriate
+/// default, matching the documented "clear to reset" UX.
 #[tauri::command]
-pub async fn set_remote_base_node_address(address: String) -> Result<(), InvokeError> {
+pub fn validate_remote_base_node_address(address: String) -> Result<String, InvokeError> {
+    let trimmed = address.trim();
+    if trimmed.is_empty() {
+        return Ok(ConfigCoreContent::default().remote_base_node_address().clone());
+    }
+    canonicalise_remote_base_node_address(trimmed).map_err(InvokeError::from_anyhow)
+}
+
+#[tauri::command]
+pub async fn set_remote_base_node_address(address: String) -> Result<String, InvokeError> {
     let timer = Instant::now();
     info!(target: LOG_TARGET_APP_LOGIC, "[set_remote_base_node_address] called with address: {address:?}");
 
@@ -1695,40 +1782,27 @@ pub async fn set_remote_base_node_address(address: String) -> Result<(), InvokeE
     // from `ConfigCoreContent::default()` preserves the documented
     // "clear to reset" UX without storing a known-broken value.
     //
-    // For non-empty input we parse the address with `url::Url` instead of
-    // a raw `starts_with` prefix check: the previous version accepted
-    // `"http://"` on its own, mis-scheme URLs like `"https:foo"`, and any
-    // string that happened to begin with `http://` without a host. Using
-    // the real parser catches those and guarantees the persisted value
-    // actually round-trips through `Url::parse`.
+    // For non-empty input we run the shared canonicaliser, which parses
+    // with `url::Url`, requires a port, rejects path/query/fragment/
+    // userinfo and lower-cases the scheme. The canonical `scheme://host:port`
+    // string is what gets persisted — not the raw user input — so
+    // `RemoteNodeAdapter::set_grpc_address` always sees a well-formed
+    // value that its split-by-colon logic can handle.
+    //
+    // The resolved value is returned to the caller so the frontend store
+    // can mirror the backend without a second round trip: on an empty
+    // input the store needs to end up holding the default address, not
+    // the empty string the user typed.
     let trimmed_address = address.trim();
     let resolved = if trimmed_address.is_empty() {
         ConfigCoreContent::default().remote_base_node_address().clone()
     } else {
-        let parsed = url::Url::parse(trimmed_address).map_err(|e| {
-            InvokeError::from_anyhow(anyhow::anyhow!(
-                "Invalid remote base node address {trimmed_address:?}: {e}"
-            ))
-        })?;
-        match parsed.scheme() {
-            "http" | "https" => {},
-            other => {
-                return Err(InvokeError::from_anyhow(anyhow::anyhow!(
-                    "Invalid remote base node address scheme {other:?}: must be http or https"
-                )));
-            },
-        }
-        if parsed.host_str().is_none_or(str::is_empty) {
-            return Err(InvokeError::from_anyhow(anyhow::anyhow!(
-                "Invalid remote base node address {trimmed_address:?}: missing host"
-            )));
-        }
-        trimmed_address.to_string()
+        canonicalise_remote_base_node_address(trimmed_address).map_err(InvokeError::from_anyhow)?
     };
 
     ConfigCore::update_field_requires_restart(
         ConfigCoreContent::set_remote_base_node_address,
-        resolved,
+        resolved.clone(),
         vec![SetupPhase::Node, SetupPhase::Wallet, SetupPhase::CpuMining],
     )
     .await
@@ -1742,7 +1816,7 @@ pub async fn set_remote_base_node_address(address: String) -> Result<(), InvokeE
         warn!(target: LOG_TARGET_APP_LOGIC, "set_remote_base_node_address took too long: {:?}", timer.elapsed());
     }
 
-    Ok(())
+    Ok(resolved)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -469,6 +469,7 @@ fn main() {
             commands::validate_minotari_amount,
             commands::trigger_phases_restart,
             commands::set_node_type,
+            commands::set_remote_base_node_address,
             commands::set_allow_notifications,
             commands::launch_builtin_tapplet,
             commands::get_bridge_envs,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -470,6 +470,7 @@ fn main() {
             commands::trigger_phases_restart,
             commands::set_node_type,
             commands::set_remote_base_node_address,
+            commands::validate_remote_base_node_address,
             commands::set_allow_notifications,
             commands::launch_builtin_tapplet,
             commands::get_bridge_envs,

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.styles.ts
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { StyledInput as BaseStyledInput } from '@app/components/elements/inputs/Input.styles.ts';
+
+export const AddressFieldWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+`;
+
+export const AddressFieldLabel = styled.label`
+    font-size: 12px;
+    opacity: 0.7;
+`;
+
+export const AddressInput = styled(BaseStyledInput)`
+    font-size: 13px;
+`;
+
+export const AddressErrorMessage = styled.span`
+    font-size: 11px;
+    color: ${({ theme }) => theme.palette.error.main};
+    margin-top: 2px;
+`;

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Typography } from '@app/components/elements/Typography.tsx';
 
@@ -11,19 +11,56 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 import { Select, SelectOption } from '@app/components/elements/inputs/Select.tsx';
+import { StyledInput } from '@app/components/elements/inputs/Input.styles.ts';
 import { Stack } from '@app/components/elements/Stack.tsx';
 import { offset } from '@floating-ui/react';
 import { NodeType } from '@app/types/mining/node.ts';
-import { setNodeType } from '@app/store/actions/config/core.ts';
+import { setNodeType, setRemoteBaseNodeAddress } from '@app/store/actions/config/core.ts';
 import { useConfigCoreStore } from '@app/store/stores/config/useConfigCoreStore.ts';
 
 export default function NodeTypeConfiguration() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const node_type = useConfigCoreStore((s) => s.node_type || 'Local');
+    const remote_base_node_address = useConfigCoreStore((s) => s.remote_base_node_address || '');
+    const [addressInput, setAddressInput] = useState(remote_base_node_address);
+    const [addressError, setAddressError] = useState(false);
+
+    const showAddressInput = node_type === 'Remote' || node_type === 'RemoteUntilLocal';
+
+    useEffect(() => {
+        setAddressInput(remote_base_node_address);
+    }, [remote_base_node_address]);
 
     const handleChange = useCallback(async (nodeType: string) => {
         await setNodeType(nodeType as NodeType);
     }, []);
+
+    const handleAddressBlur = useCallback(async () => {
+        const trimmed = addressInput.trim();
+        if (trimmed === remote_base_node_address) return;
+
+        if (trimmed && !trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+            setAddressError(true);
+            return;
+        }
+
+        setAddressError(false);
+        await setRemoteBaseNodeAddress(trimmed);
+    }, [addressInput, remote_base_node_address]);
+
+    const handleAddressChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setAddressInput(e.target.value);
+        setAddressError(false);
+    }, []);
+
+    const handleAddressKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+                handleAddressBlur();
+            }
+        },
+        [handleAddressBlur]
+    );
 
     const tabOptions: SelectOption[] = useMemo(
         () => [
@@ -58,6 +95,30 @@ export default function NodeTypeConfiguration() {
                     </Stack>
                 </SettingsGroupAction>
             </SettingsGroup>
+            {showAddressInput && (
+                <SettingsGroup style={{ paddingTop: 0 }}>
+                    <SettingsGroupContent style={{ width: '100%' }}>
+                        <Typography variant="span" style={{ fontSize: 12, opacity: 0.7, marginBottom: 4 }}>
+                            {t('custom-remote-node-address')}
+                        </Typography>
+                        <StyledInput
+                            name="remote-node-address"
+                            placeholder="https://grpc.tari.com:443"
+                            value={addressInput}
+                            onChange={handleAddressChange}
+                            onBlur={handleAddressBlur}
+                            onKeyDown={handleAddressKeyDown}
+                            $hasError={addressError}
+                            style={{ width: '100%', fontSize: 13 }}
+                        />
+                        {addressError && (
+                            <Typography variant="span" style={{ fontSize: 11, color: '#ff4444', marginTop: 2 }}>
+                                {t('custom-remote-node-address-error')}
+                            </Typography>
+                        )}
+                    </SettingsGroupContent>
+                </SettingsGroup>
+            )}
         </SettingsGroupWrapper>
     );
 }

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 
 import { Typography } from '@app/components/elements/Typography.tsx';
 
@@ -11,19 +12,27 @@ import {
     SettingsGroupWrapper,
 } from '../../components/SettingsGroup.styles.ts';
 import { Select, SelectOption } from '@app/components/elements/inputs/Select.tsx';
-import { StyledInput } from '@app/components/elements/inputs/Input.styles.ts';
 import { Stack } from '@app/components/elements/Stack.tsx';
 import { offset } from '@floating-ui/react';
 import { NodeType } from '@app/types/mining/node.ts';
 import { setNodeType, setRemoteBaseNodeAddress } from '@app/store/actions/config/core.ts';
 import { useConfigCoreStore } from '@app/store/stores/config/useConfigCoreStore.ts';
+import {
+    AddressErrorMessage,
+    AddressFieldLabel,
+    AddressFieldWrapper,
+    AddressInput,
+} from './NodeTypeConfiguration.styles.ts';
 
 export default function NodeTypeConfiguration() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
     const node_type = useConfigCoreStore((s) => s.node_type || 'Local');
     const remote_base_node_address = useConfigCoreStore((s) => s.remote_base_node_address || '');
     const [addressInput, setAddressInput] = useState(remote_base_node_address);
-    const [addressError, setAddressError] = useState(false);
+    const [addressError, setAddressError] = useState<string | null>(null);
+
+    const addressInputId = useId();
+    const addressErrorId = useId();
 
     const showAddressInput = node_type === 'Remote' || node_type === 'RemoteUntilLocal';
 
@@ -37,20 +46,35 @@ export default function NodeTypeConfiguration() {
 
     const handleAddressBlur = useCallback(async () => {
         const trimmed = addressInput.trim();
-        if (trimmed === remote_base_node_address) return;
-
-        if (trimmed && !trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
-            setAddressError(true);
+        if (trimmed === remote_base_node_address) {
+            setAddressError(null);
             return;
         }
 
-        setAddressError(false);
-        await setRemoteBaseNodeAddress(trimmed);
-    }, [addressInput, remote_base_node_address]);
+        // Validate via the backend so inline errors use the exact same
+        // rules — scheme, explicit port, no path/query/userinfo — that
+        // `set_remote_base_node_address` will apply when it persists.
+        try {
+            await invoke<string>('validate_remote_base_node_address', { address: trimmed });
+        } catch (e) {
+            const message = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
+            console.warn('Remote base node address failed validation:', message);
+            setAddressError(message || t('custom-remote-node-address-error'));
+            return;
+        }
+
+        setAddressError(null);
+        try {
+            await setRemoteBaseNodeAddress(trimmed);
+        } catch (e) {
+            const message = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
+            setAddressError(message || t('custom-remote-node-address-error'));
+        }
+    }, [addressInput, remote_base_node_address, t]);
 
     const handleAddressChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setAddressInput(e.target.value);
-        setAddressError(false);
+        setAddressError(null);
     }, []);
 
     const handleAddressKeyDown = useCallback(
@@ -98,24 +122,32 @@ export default function NodeTypeConfiguration() {
             {showAddressInput && (
                 <SettingsGroup style={{ paddingTop: 0 }}>
                     <SettingsGroupContent style={{ width: '100%' }}>
-                        <Typography variant="span" style={{ fontSize: 12, opacity: 0.7, marginBottom: 4 }}>
-                            {t('custom-remote-node-address')}
-                        </Typography>
-                        <StyledInput
-                            name="remote-node-address"
-                            placeholder="https://grpc.tari.com:443"
-                            value={addressInput}
-                            onChange={handleAddressChange}
-                            onBlur={handleAddressBlur}
-                            onKeyDown={handleAddressKeyDown}
-                            $hasError={addressError}
-                            style={{ width: '100%', fontSize: 13 }}
-                        />
-                        {addressError && (
-                            <Typography variant="span" style={{ fontSize: 11, color: '#ff4444', marginTop: 2 }}>
-                                {t('custom-remote-node-address-error')}
-                            </Typography>
-                        )}
+                        <AddressFieldWrapper>
+                            <AddressFieldLabel htmlFor={addressInputId}>
+                                {t('custom-remote-node-address')}
+                            </AddressFieldLabel>
+                            <AddressInput
+                                id={addressInputId}
+                                name="remote-node-address"
+                                type="url"
+                                inputMode="url"
+                                autoComplete="off"
+                                spellCheck={false}
+                                placeholder="https://grpc.tari.com:443"
+                                value={addressInput}
+                                onChange={handleAddressChange}
+                                onBlur={handleAddressBlur}
+                                onKeyDown={handleAddressKeyDown}
+                                $hasError={Boolean(addressError)}
+                                aria-invalid={Boolean(addressError)}
+                                aria-describedby={addressError ? addressErrorId : undefined}
+                            />
+                            {addressError && (
+                                <AddressErrorMessage id={addressErrorId} role="alert">
+                                    {t('custom-remote-node-address-error')}
+                                </AddressErrorMessage>
+                            )}
+                        </AddressFieldWrapper>
                     </SettingsGroupContent>
                 </SettingsGroup>
             )}

--- a/src/store/actions/config/core.ts
+++ b/src/store/actions/config/core.ts
@@ -88,6 +88,15 @@ export const setMonerodConfig = async (useMoneroFail: boolean, moneroNodes: stri
         }));
     });
 };
+export const setRemoteBaseNodeAddress = async (address: string) => {
+    const previousAddress = store.getState().remote_base_node_address;
+    store.setState((c) => ({ ...c, remote_base_node_address: address }));
+    invoke('set_remote_base_node_address', { address }).catch((e) => {
+        console.error('Could not set remote base node address', e);
+        setError('Could not change remote base node address');
+        store.setState((c) => ({ ...c, remote_base_node_address: previousAddress }));
+    });
+};
 export const setNodeType = async (nodeType: NodeType) => {
     const previousNodeType = store.getState().node_type;
     store.setState((c) => ({ ...c, node_type: nodeType }));

--- a/src/store/actions/config/core.ts
+++ b/src/store/actions/config/core.ts
@@ -90,12 +90,22 @@ export const setMonerodConfig = async (useMoneroFail: boolean, moneroNodes: stri
 };
 export const setRemoteBaseNodeAddress = async (address: string) => {
     const previousAddress = store.getState().remote_base_node_address;
-    store.setState((c) => ({ ...c, remote_base_node_address: address }));
-    invoke('set_remote_base_node_address', { address }).catch((e) => {
+    // Intentionally pessimistic: the backend canonicalises the address
+    // (validates scheme/host/port, trims trailing slashes, substitutes the
+    // network default for an empty string) and returns what it actually
+    // persisted. Writing that value into the store — rather than the raw
+    // input — keeps the store and the persisted config in sync so the
+    // "clear to reset to default" flow actually reflects in the UI on the
+    // next render.
+    try {
+        const resolved = await invoke<string>('set_remote_base_node_address', { address });
+        store.setState((c) => ({ ...c, remote_base_node_address: resolved }));
+    } catch (e) {
         console.error('Could not set remote base node address', e);
         setError('Could not change remote base node address');
         store.setState((c) => ({ ...c, remote_base_node_address: previousAddress }));
-    });
+        throw e;
+    }
 };
 export const setNodeType = async (nodeType: NodeType) => {
     const previousNodeType = store.getState().node_type;


### PR DESCRIPTION
## Summary
- Adds a text input field in Settings > Node Configuration that appears when Remote or Remote & Local mode is selected
- Users can enter a custom gRPC endpoint (e.g. `https://grpc.tari.com:443`) to connect to their own base node
- Implements `set_remote_base_node_address` Tauri command with URL scheme validation and phase restart
- The backend infrastructure (`remote_base_node_address` config field, `RemoteNodeAdapter.set_grpc_address()`) was already in place — this PR exposes it through the UI

## Changes
- `src-tauri/src/commands.rs` — New `set_remote_base_node_address` command with http/https validation
- `src-tauri/src/main.rs` — Register the new command
- `src/store/actions/config/core.ts` — `setRemoteBaseNodeAddress` action with optimistic update + rollback
- `src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx` — Conditional address input with validation
- `public/locales/en/settings.json` — i18n keys for the new input label and error message

## Test plan
- [ ] Select "Remote" or "Remote & Local" node type in Settings — address input should appear
- [ ] Select "Local" — address input should hide
- [ ] Enter a valid `https://` address and blur — config updates, node restarts
- [ ] Enter an invalid address (no scheme) — error message shown, config not updated
- [ ] Clear the field — reverts to default remote node address
- [ ] Verify the entered address persists across app restarts

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bounty-payout-section:start -->
---

## Bounty payout

If this PR is accepted as a bounty submission, please direct funds to the following Tari wallet address:

**`123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb`**
<!-- bounty-payout-section:end -->
