### PR TITLE
fix: respect manual mining stop state on sleep/wake resume

### DIFF
--- a/src/store/actions/miningStoreActions.ts
+++ b/src/store/actions/miningStoreActions.ts
@@ -144,6 +144,7 @@ function handleEcoAlertCheck(diffSeconds?: number) {
 
 export const startMining = async () => {
     console.info('Mining starting....');
+    useMiningStore.setState({ userManuallyStopped: false });
     handleEcoAlertCheck();
     try {
         await startCpuMining();
@@ -157,6 +158,7 @@ export const startMining = async () => {
 
 export const stopMining = async () => {
     console.info('Mining stopping...');
+    useMiningStore.setState({ userManuallyStopped: true });
     try {
         await stopCpuMining();
         await stopGpuMining();
@@ -235,7 +237,7 @@ export const handleCpuMinerControlsStateChanged = (state: MinerControlsState) =>
             useMiningStore.setState({ isCpuMiningInitiated: false });
             break;
         case MinerControlsState.Started: {
-            useMiningStore.setState({ isCpuMiningInitiated: true });
+            useMiningStore.setState({ isCpuMiningInitiated: true, userManuallyStopped: false });
             handleStartSideEffects();
             break;
         }
@@ -252,7 +254,7 @@ export const handleGpuMinerControlsStateChanged = (state: MinerControlsState) =>
             useMiningStore.setState({ isGpuMiningInitiated: false });
             break;
         case MinerControlsState.Started:
-            useMiningStore.setState({ isGpuMiningInitiated: true });
+            useMiningStore.setState({ isGpuMiningInitiated: true, userManuallyStopped: false });
             handleStartSideEffects();
             break;
         case MinerControlsState.Stopped:

--- a/src/store/actions/miningStoreActions.ts
+++ b/src/store/actions/miningStoreActions.ts
@@ -144,7 +144,12 @@ function handleEcoAlertCheck(diffSeconds?: number) {
 
 export const startMining = async () => {
     console.info('Mining starting....');
-    useMiningStore.setState({ userManuallyStopped: false });
+    // Note: the `userManuallyStopped` flag is cleared centrally by the
+    // `handleCpuMinerControlsStateChanged` / `handleGpuMinerControlsStateChanged`
+    // handlers when the `MinerControlsState.Started` event arrives from the
+    // backend, so no setState is needed here. Keeping the clear in a single
+    // place guarantees that the scheduler `ResumeMining` path and any other
+    // non-user-triggered starts also reset the flag consistently.
     handleEcoAlertCheck();
     try {
         await startCpuMining();

--- a/src/store/actions/setupStoreActions.ts
+++ b/src/store/actions/setupStoreActions.ts
@@ -128,6 +128,11 @@ const handleCpuMiningModuleUpdateSideEffects = async (state: AppModuleState) => 
             const gpuMiningInitiated = useMiningStore.getState().isGpuMiningInitiated;
             const wasMineOnAppStartExecuted = useMiningStore.getState().wasMineOnAppStartExecuted;
             const resumeAfterRestart = useMiningStore.getState().resumeAfterRestart;
+            const userManuallyStopped = useMiningStore.getState().userManuallyStopped;
+
+            if (userManuallyStopped) {
+                break;
+            }
 
             if (resumeAfterRestart.cpu) {
                 useMiningStore.setState((c) => ({ ...c, resumeAfterRestart: { ...c.resumeAfterRestart, cpu: false } }));
@@ -166,6 +171,11 @@ const handleGpuMiningModuleUpdateSideEffects = async (state: AppModuleState) => 
             const cpuMiningInitiated = useMiningStore.getState().isCpuMiningInitiated;
             const wasMineOnAppStartExecuted = useMiningStore.getState().wasMineOnAppStartExecuted;
             const resumeAfterRestart = useMiningStore.getState().resumeAfterRestart;
+            const userManuallyStopped = useMiningStore.getState().userManuallyStopped;
+
+            if (userManuallyStopped) {
+                break;
+            }
 
             if (resumeAfterRestart.gpu) {
                 useMiningStore.setState((c) => ({ ...c, resumeAfterRestart: { ...c.resumeAfterRestart, gpu: false } }));

--- a/src/store/useMiningStore.ts
+++ b/src/store/useMiningStore.ts
@@ -30,6 +30,7 @@ export interface MiningStoreState {
     sessionMiningTime: SessionMiningTime;
     showEcoAlert: boolean;
     selectedResumeDuration?: ResumeMiningTime;
+    userManuallyStopped: boolean;
     eventSchedulerLastSelectedMiningModeName?: string; // Mining mode selector handles some modes in external dialogs and cannot pass callbacks to them, so we store the last selected mode name here temporarily
     // Its needed in Scheduler component, we pass callback to trigger updating this value when mode is selected instead of the main mining mode value
 }
@@ -46,6 +47,7 @@ const initialState: MiningStoreState = {
     isChangingMode: false,
     isExcludingGpuDevices: false,
     miningControlsEnabled: true,
+    userManuallyStopped: false,
     network: undefined,
     availableMiners: undefined,
     selectedMiner: undefined,


### PR DESCRIPTION
## Summary
- Adds an in-memory `userManuallyStopped` flag to the mining store that tracks when the user explicitly stops mining
- When system resumes from sleep and setup phases re-initialize, the CPU/GPU mining side effects check this flag and skip auto-starting mining if the user had manually stopped it
- The flag is automatically cleared when mining starts by any means (user click, scheduler ResumeMining event, mode change restart)

## How it works
1. User clicks Stop → `stopMining()` sets `userManuallyStopped = true`
2. System goes to sleep → backend calls `shutdown_phases()` → frontend receives `NotInitialized` and stops miners
3. System wakes → backend calls `resume_phases()` → frontend receives `Initialized`
4. `handleCpuMiningModuleUpdateSideEffects` / `handleGpuMiningModuleUpdateSideEffects` check `userManuallyStopped` — if `true`, they skip auto-starting
5. If user manually starts mining again (or scheduler fires), the flag clears via `MinerControlsState::Started` handler

## Test plan
- [ ] Start mining, then manually stop it. Put system to sleep, then wake — mining should NOT auto-restart
- [ ] Start mining (leave it running). Put system to sleep, then wake — mining SHOULD auto-restart
- [ ] Start mining, manually stop, then manually start again. Sleep/wake — mining SHOULD auto-restart (flag was cleared)
- [ ] Pause mining with timer (e.g. 1 hour). When timer fires and ResumeMining event starts mining, then sleep/wake — mining SHOULD auto-restart (flag cleared by Started event)

Closes #2657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bounty-payout-section:start -->
---

## Bounty payout

If this PR is accepted as a bounty submission, please direct funds to the following Tari wallet address:

**`123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb`**
<!-- bounty-payout-section:end -->
