### PR TITLE
fix(node): reject network-mounted directories for node data location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8962,6 +8962,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "whoami",
+ "windows-sys 0.52.0",
  "winreg 0.52.0",
  "wiremock",
  "zip 2.4.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -131,6 +131,9 @@ openssl = { version = "0.10", features = [
 ] } # temporary fix for openssl
 planif = "1.0.0"
 whoami = "1.5.2"
+windows-sys = { version = "0.52", features = [
+  "Win32_Storage_FileSystem",
+] } # GetDriveTypeW for SMB-mapped drive-letter detection in data_location
 winreg = "0.52.0"
 
 

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -62,6 +62,24 @@ pub fn detect_network_filesystem(path: &Path) -> Option<String> {
     // user-facing caller has already validated existence.
     let canonical: PathBuf = canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
+    // On Windows, a UNC path such as `\\server\share\folder` is a network
+    // location that is NOT mapped to a drive letter, so `sysinfo::Disks`
+    // (which iterates drive-letter mounts) will not report it. Detect the
+    // `\\?\UNC\...` (verbatim) and `\\server\share` prefixes directly from
+    // the canonical path before falling through to the disk enumeration.
+    #[cfg(windows)]
+    {
+        use std::path::{Component, Prefix};
+        if let Some(Component::Prefix(prefix_component)) = canonical.components().next() {
+            match prefix_component.kind() {
+                Prefix::UNC(_, _) | Prefix::VerbatimUNC(_, _) => {
+                    return Some("unc".to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+
     let disks = Disks::new_with_refreshed_list();
     let mut best: Option<(usize, String)> = None;
 

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -41,23 +41,39 @@ use tauri::ipc::InvokeError;
 /// Values are matched case-insensitively against the filesystem string
 /// reported by sysinfo (see `is_network_fs`). Covers the common remote
 /// filesystem names across platforms:
-/// - macOS:   `smbfs`, `nfs`, `afpfs`, `webdav`
-/// - Linux:   `cifs`, `smb3`, `nfs`, `nfs4`, `fuse.sshfs`, `sshfs`, `9p`,
-///            `ceph`, `glusterfs`, `beegfs`, `lustre`
+/// - macOS: `smbfs`, `nfs`, `afpfs`, `webdav`
+/// - Linux: `cifs`, `smb3`, `nfs`, `nfs4`, `fuse.sshfs`, `sshfs`, `9p`, `ceph`,
+///   `glusterfs`, `beegfs`, `lustre`
 /// - Windows: sysinfo reports remote drives with a filesystem string that
-///            frequently contains `remote` or the underlying SMB/NFS name,
-///            but for SMB drive-letter mappings `GetVolumeInformationW`
-///            typically returns `NTFS` — so the `cfg(windows)` branch in
-///            `detect_network_filesystem` additionally calls
-///            `GetDriveTypeW` to catch that case.
+///   frequently contains `remote` or the underlying SMB/NFS name, but for SMB
+///   drive-letter mappings `GetVolumeInformationW` typically returns `NTFS` —
+///   so the `cfg(windows)` branch in `detect_network_filesystem` additionally
+///   calls `GetDriveTypeW` to catch that case.
 ///
 /// `"ftp"` is intentionally *not* in this list: on modern macOS (post Big
 /// Sur) Finder's FTP mount was removed; on Linux, `curlftpfs` reports as
 /// `fuse` / `fuse.curlftpfs`; Windows doesn't expose FTP as a drive. There
 /// is no current OS where sysinfo's `file_system()` returns `"ftp"`.
 const NETWORK_FILESYSTEMS: &[&str] = &[
-    "smbfs", "cifs", "smb", "smb2", "smb3", "nfs", "nfs3", "nfs4", "afpfs", "webdav", "davfs",
-    "sshfs", "fuse.sshfs", "9p", "ceph", "glusterfs", "beegfs", "lustre", "remote",
+    "smbfs",
+    "cifs",
+    "smb",
+    "smb2",
+    "smb3",
+    "nfs",
+    "nfs3",
+    "nfs4",
+    "afpfs",
+    "webdav",
+    "davfs",
+    "sshfs",
+    "fuse.sshfs",
+    "9p",
+    "ceph",
+    "glusterfs",
+    "beegfs",
+    "lustre",
+    "remote",
 ];
 
 /// True if `fs_name` (already lowercased) indicates a network / remote
@@ -149,6 +165,106 @@ fn is_windows_remote_drive(letter: u8) -> bool {
     drive_type == DRIVE_REMOTE
 }
 
+pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
+    let move_options = DirectoryMoveOptions {
+        destination_directory_rule: DestinationDirectoryRule::AllowNonEmpty {
+            colliding_file_behaviour: CollidingFileBehaviour::Abort,
+            colliding_subdirectory_behaviour: CollidingSubDirectoryBehaviour::Continue,
+        },
+        allowed_strategies: DirectoryMoveAllowedStrategies::Either {
+            copy_and_delete_options: DirectoryMoveByCopyOptions {
+                broken_symlink_behaviour: BrokenSymlinkBehaviour::Abort,
+                symlink_behaviour: SymlinkBehaviour::Keep,
+            },
+        },
+    };
+    match canonicalize(to_path) {
+        Ok(new_dir) => {
+            // Refuse network-mounted destinations up front. fs_more's
+            // move_directory has historically failed with confusing errors
+            // on SMB / NFS / AFP mounts (see issue #3178 — macOS with a NAS
+            // SMB mount) because those filesystems don't support all the
+            // metadata operations (rename-across-volume, fsync on
+            // directories, extended attributes) the node LMDB database
+            // relies on. Detect this before we shut down the node phase and
+            // return a clear, actionable error instead of a cryptic fs_more
+            // failure.
+            if let Some(fs_name) = detect_network_filesystem(&new_dir) {
+                let message = format!(
+                    "Selected directory is on a network filesystem ({fs_name}), which is not \
+                     supported for the node data location. The node database requires a local \
+                     disk (HDD/SSD) because network filesystems such as SMB, NFS, AFP and WebDAV \
+                     do not reliably support the operations LMDB needs. Please choose a local \
+                     directory instead."
+                );
+                error!(target: LOG_TARGET_APP_LOGIC, "{message}");
+                return Err(InvokeError::from(message));
+            }
+
+            match ConfigCore::update_node_data_directory(new_dir.clone()).await {
+                Ok(previous) => {
+                    if let Some(previous) = previous {
+                        SetupManager::get_instance()
+                            .shutdown_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                            .await;
+
+                        let network = Network::get_current().to_string().to_lowercase();
+                        let source_dir = previous.join("node").join(&network);
+                        let destination_dir = new_dir.join("node").join(&network);
+
+                        if let Some(parent) = destination_dir.parent() {
+                            fs::create_dir_all(parent)
+                                .map_err(|e| InvokeError::from(e.to_string()))?;
+                        }
+
+                        let dest_existed = destination_dir.exists();
+
+                        match move_directory(source_dir, destination_dir.clone(), move_options) {
+                            Ok(res) => {
+                                info!(target: LOG_TARGET_APP_LOGIC, "Successfully moved items - Total bytes: {}, Directories: {:?}", res.total_bytes_moved, res.directories_moved);
+                            }
+                            Err(e) => {
+                                error!(target: LOG_TARGET_APP_LOGIC, "Could not move items, reverting config change: {e}");
+
+                                if !dest_existed
+                                    && destination_dir.exists()
+                                    && let Err(cleanup_err) = fs::remove_dir_all(&destination_dir)
+                                {
+                                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to clean up destination after failed move: {cleanup_err}");
+                                }
+
+                                ConfigCore::update_node_data_directory(previous)
+                                    .await
+                                    .map_err(|e| InvokeError::from(e.to_string()))?;
+
+                                SetupManager::get_instance()
+                                    .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                                    .await;
+
+                                return Err(InvokeError::from(e.to_string()));
+                            }
+                        };
+
+                        info!(target: LOG_TARGET_APP_LOGIC, "[ set_custom_node_directory ] restarting phases");
+                        SetupManager::get_instance()
+                            .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                            .await;
+                    }
+                }
+                Err(e) => {
+                    error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
+                    return Err(InvokeError::from(e.to_string()));
+                }
+            }
+        }
+        Err(e) => {
+            error!(target: LOG_TARGET_APP_LOGIC, "New node directory does not exist: {e}");
+            return Err(InvokeError::from(e.to_string()));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::is_network_fs;
@@ -217,103 +333,4 @@ mod tests {
         // rustdoc: no current OS reports "ftp" via sysinfo.
         assert!(!is_network_fs("ftp"));
     }
-}
-
-pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
-    let move_options = DirectoryMoveOptions {
-        destination_directory_rule: DestinationDirectoryRule::AllowNonEmpty {
-            colliding_file_behaviour: CollidingFileBehaviour::Abort,
-            colliding_subdirectory_behaviour: CollidingSubDirectoryBehaviour::Continue,
-        },
-        allowed_strategies: DirectoryMoveAllowedStrategies::Either {
-            copy_and_delete_options: DirectoryMoveByCopyOptions {
-                broken_symlink_behaviour: BrokenSymlinkBehaviour::Abort,
-                symlink_behaviour: SymlinkBehaviour::Keep,
-            },
-        },
-    };
-    match canonicalize(to_path) {
-        Ok(new_dir) => {
-            // Refuse network-mounted destinations up front. fs_more's
-            // move_directory has historically failed with confusing errors
-            // on SMB / NFS / AFP mounts (see issue #3178 — macOS with a NAS
-            // SMB mount) because those filesystems don't support all the
-            // metadata operations (rename-across-volume, fsync on
-            // directories, extended attributes) the node LMDB database
-            // relies on. Detect this before we shut down the node phase and
-            // return a clear, actionable error instead of a cryptic fs_more
-            // failure.
-            if let Some(fs_name) = detect_network_filesystem(&new_dir) {
-                let message = format!(
-                    "Selected directory is on a network filesystem ({fs_name}), which is not \
-                     supported for the node data location. The node database requires a local \
-                     disk (HDD/SSD) because network filesystems such as SMB, NFS, AFP and WebDAV \
-                     do not reliably support the operations LMDB needs. Please choose a local \
-                     directory instead."
-                );
-                error!(target: LOG_TARGET_APP_LOGIC, "{message}");
-                return Err(InvokeError::from(message));
-            }
-
-            match ConfigCore::update_node_data_directory(new_dir.clone()).await {
-            Ok(previous) => {
-                if let Some(previous) = previous {
-                    SetupManager::get_instance()
-                        .shutdown_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                        .await;
-
-                    let network = Network::get_current().to_string().to_lowercase();
-                    let source_dir = previous.join("node").join(&network);
-                    let destination_dir = new_dir.join("node").join(&network);
-
-                    if let Some(parent) = destination_dir.parent() {
-                        fs::create_dir_all(parent).map_err(|e| InvokeError::from(e.to_string()))?;
-                    }
-
-                    let dest_existed = destination_dir.exists();
-
-                    match move_directory(source_dir, destination_dir.clone(), move_options) {
-                        Ok(res) => {
-                            info!(target: LOG_TARGET_APP_LOGIC, "Successfully moved items - Total bytes: {}, Directories: {:?}", res.total_bytes_moved, res.directories_moved);
-                        }
-                        Err(e) => {
-                            error!(target: LOG_TARGET_APP_LOGIC, "Could not move items, reverting config change: {e}");
-
-                            if !dest_existed
-                                && destination_dir.exists()
-                                && let Err(cleanup_err) = fs::remove_dir_all(&destination_dir)
-                            {
-                                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to clean up destination after failed move: {cleanup_err}");
-                            }
-
-                            ConfigCore::update_node_data_directory(previous)
-                                .await
-                                .map_err(|e| InvokeError::from(e.to_string()))?;
-
-                            SetupManager::get_instance()
-                                .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                                .await;
-
-                            return Err(InvokeError::from(e.to_string()));
-                        }
-                    };
-
-                    info!(target: LOG_TARGET_APP_LOGIC, "[ set_custom_node_directory ] restarting phases");
-                    SetupManager::get_instance()
-                        .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                        .await;
-                }
-            }
-            Err(e) => {
-                error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
-                return Err(InvokeError::from(e.to_string()));
-            }
-            }
-        }
-        Err(e) => {
-            error!(target: LOG_TARGET_APP_LOGIC, "New node directory does not exist: {e}");
-            return Err(InvokeError::from(e.to_string()));
-        }
-    }
-    Ok(())
 }

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -31,8 +31,64 @@ use fs_more::directory::{
 use fs_more::file::CollidingFileBehaviour;
 use log::{error, info, warn};
 use std::fs;
+use std::path::{Path, PathBuf};
+use sysinfo::Disks;
 use tari_common::configuration::Network;
 use tauri::ipc::InvokeError;
+
+/// Filesystem type names that indicate a network / remote volume.
+///
+/// These values are normalised to lowercase and covers the common remote
+/// filesystem names reported by sysinfo across platforms:
+/// - macOS:   `smbfs`, `nfs`, `afpfs`, `webdav`, `ftp`
+/// - Linux:   `cifs`, `smb3`, `nfs`, `nfs4`, `fuse.sshfs`, `sshfs`, `9p`,
+///            `ceph`, `glusterfs`, `beegfs`, `lustre`
+/// - Windows: sysinfo reports remote drives with a filesystem string that
+///            frequently contains `remote` or the underlying SMB/NFS name.
+const NETWORK_FILESYSTEMS: &[&str] = &[
+    "smbfs", "cifs", "smb", "smb2", "smb3", "nfs", "nfs3", "nfs4", "afpfs", "webdav", "davfs",
+    "ftp", "sshfs", "fuse.sshfs", "9p", "ceph", "glusterfs", "beegfs", "lustre", "remote",
+];
+
+/// Returns `Some(fs_name)` if `path` resolves to a location on a network /
+/// remote filesystem, or `None` if it's on a local volume (or we can't tell).
+///
+/// We pick the mount point whose path is the longest prefix of `path`, then
+/// check whether its filesystem type is one of the known remote types. This
+/// is how GNU `df`, `findmnt`, and similar tools resolve a path to its mount.
+pub fn detect_network_filesystem(path: &Path) -> Option<String> {
+    // Canonicalise so symlinks and `..` components don't confuse the prefix
+    // match. Fall back to the original path if canonicalisation fails — the
+    // user-facing caller has already validated existence.
+    let canonical: PathBuf = canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    let disks = Disks::new_with_refreshed_list();
+    let mut best: Option<(usize, String)> = None;
+
+    for disk in disks.list() {
+        let mount = disk.mount_point();
+        if !canonical.starts_with(mount) {
+            continue;
+        }
+        let mount_len = mount.as_os_str().len();
+        let fs_name = disk.file_system().to_string_lossy().to_ascii_lowercase();
+
+        match &best {
+            Some((len, _)) if *len >= mount_len => {}
+            _ => best = Some((mount_len, fs_name)),
+        }
+    }
+
+    let (_, fs_name) = best?;
+    if NETWORK_FILESYSTEMS
+        .iter()
+        .any(|known| fs_name == *known || fs_name.contains(known))
+    {
+        Some(fs_name)
+    } else {
+        None
+    }
+}
 
 pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
     let move_options = DirectoryMoveOptions {
@@ -48,7 +104,29 @@ pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
         },
     };
     match canonicalize(to_path) {
-        Ok(new_dir) => match ConfigCore::update_node_data_directory(new_dir.clone()).await {
+        Ok(new_dir) => {
+            // Refuse network-mounted destinations up front. fs_more's
+            // move_directory has historically failed with confusing errors
+            // on SMB / NFS / AFP mounts (see issue #3178 — macOS with a NAS
+            // SMB mount) because those filesystems don't support all the
+            // metadata operations (rename-across-volume, fsync on
+            // directories, extended attributes) the node LMDB database
+            // relies on. Detect this before we shut down the node phase and
+            // return a clear, actionable error instead of a cryptic fs_more
+            // failure.
+            if let Some(fs_name) = detect_network_filesystem(&new_dir) {
+                let message = format!(
+                    "Selected directory is on a network filesystem ({fs_name}), which is not \
+                     supported for the node data location. The node database requires a local \
+                     disk (HDD/SSD) because network filesystems such as SMB, NFS, AFP and WebDAV \
+                     do not reliably support the operations LMDB needs. Please choose a local \
+                     directory instead."
+                );
+                error!(target: LOG_TARGET_APP_LOGIC, "{message}");
+                return Err(InvokeError::from(message));
+            }
+
+            match ConfigCore::update_node_data_directory(new_dir.clone()).await {
             Ok(previous) => {
                 if let Some(previous) = previous {
                     SetupManager::get_instance()
@@ -101,7 +179,8 @@ pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
                 error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
                 return Err(InvokeError::from(e.to_string()));
             }
-        },
+            }
+        }
         Err(e) => {
             error!(target: LOG_TARGET_APP_LOGIC, "New node directory does not exist: {e}");
             return Err(InvokeError::from(e.to_string()));

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -38,17 +38,36 @@ use tauri::ipc::InvokeError;
 
 /// Filesystem type names that indicate a network / remote volume.
 ///
-/// These values are normalised to lowercase and covers the common remote
-/// filesystem names reported by sysinfo across platforms:
-/// - macOS:   `smbfs`, `nfs`, `afpfs`, `webdav`, `ftp`
+/// Values are matched case-insensitively against the filesystem string
+/// reported by sysinfo (see `is_network_fs`). Covers the common remote
+/// filesystem names across platforms:
+/// - macOS:   `smbfs`, `nfs`, `afpfs`, `webdav`
 /// - Linux:   `cifs`, `smb3`, `nfs`, `nfs4`, `fuse.sshfs`, `sshfs`, `9p`,
 ///            `ceph`, `glusterfs`, `beegfs`, `lustre`
 /// - Windows: sysinfo reports remote drives with a filesystem string that
-///            frequently contains `remote` or the underlying SMB/NFS name.
+///            frequently contains `remote` or the underlying SMB/NFS name,
+///            but for SMB drive-letter mappings `GetVolumeInformationW`
+///            typically returns `NTFS` — so the `cfg(windows)` branch in
+///            `detect_network_filesystem` additionally calls
+///            `GetDriveTypeW` to catch that case.
+///
+/// `"ftp"` is intentionally *not* in this list: on modern macOS (post Big
+/// Sur) Finder's FTP mount was removed; on Linux, `curlftpfs` reports as
+/// `fuse` / `fuse.curlftpfs`; Windows doesn't expose FTP as a drive. There
+/// is no current OS where sysinfo's `file_system()` returns `"ftp"`.
 const NETWORK_FILESYSTEMS: &[&str] = &[
     "smbfs", "cifs", "smb", "smb2", "smb3", "nfs", "nfs3", "nfs4", "afpfs", "webdav", "davfs",
-    "ftp", "sshfs", "fuse.sshfs", "9p", "ceph", "glusterfs", "beegfs", "lustre", "remote",
+    "sshfs", "fuse.sshfs", "9p", "ceph", "glusterfs", "beegfs", "lustre", "remote",
 ];
+
+/// True if `fs_name` (already lowercased) indicates a network / remote
+/// filesystem. Extracted so the match can be unit-tested without touching
+/// real disks.
+fn is_network_fs(fs_name: &str) -> bool {
+    NETWORK_FILESYSTEMS
+        .iter()
+        .any(|known| fs_name == *known || fs_name.contains(known))
+}
 
 /// Returns `Some(fs_name)` if `path` resolves to a location on a network /
 /// remote filesystem, or `None` if it's on a local volume (or we can't tell).
@@ -75,6 +94,17 @@ pub fn detect_network_filesystem(path: &Path) -> Option<String> {
                 Prefix::UNC(_, _) | Prefix::VerbatimUNC(_, _) => {
                     return Some("unc".to_string());
                 }
+                // For drive-letter prefixes (e.g. `Z:\`), sysinfo reports
+                // `GetVolumeInformationW`'s filesystem string which for an
+                // SMB-mapped drive is usually `NTFS` (the share's backing
+                // FS) rather than anything matching `NETWORK_FILESYSTEMS`.
+                // Check `GetDriveTypeW` directly so we catch `DRIVE_REMOTE`
+                // regardless of the volume's reported filesystem.
+                Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => {
+                    if is_windows_remote_drive(letter) {
+                        return Some("remote".to_string());
+                    }
+                }
                 _ => {}
             }
         }
@@ -98,13 +128,94 @@ pub fn detect_network_filesystem(path: &Path) -> Option<String> {
     }
 
     let (_, fs_name) = best?;
-    if NETWORK_FILESYSTEMS
-        .iter()
-        .any(|known| fs_name == *known || fs_name.contains(known))
-    {
+    if is_network_fs(&fs_name) {
         Some(fs_name)
     } else {
         None
+    }
+}
+
+/// Windows helper: returns true if the drive letter maps to a remote
+/// (network) volume per `GetDriveTypeW`. `letter` is the ASCII byte for
+/// the drive (e.g. `b'Z'`).
+#[cfg(windows)]
+fn is_windows_remote_drive(letter: u8) -> bool {
+    use windows_sys::Win32::Storage::FileSystem::{DRIVE_REMOTE, GetDriveTypeW};
+    // Build `"X:\0"` as a UTF-16 null-terminated string.
+    let root: [u16; 4] = [u16::from(letter), u16::from(b':'), u16::from(b'\\'), 0];
+    // Safety: `root` is a valid null-terminated wide string; the Win32
+    // API reads it and returns a small integer code.
+    let drive_type = unsafe { GetDriveTypeW(root.as_ptr()) };
+    drive_type == DRIVE_REMOTE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_network_fs;
+
+    // Cases brianp called out in code review; extended with a few more so
+    // regressions in NETWORK_FILESYSTEMS show up in `cargo test` without
+    // needing a real mounted volume.
+    #[test]
+    fn local_filesystems_are_not_flagged() {
+        assert!(!is_network_fs("ntfs"));
+        assert!(!is_network_fs("apfs"));
+        assert!(!is_network_fs("hfs+"));
+        assert!(!is_network_fs("ext4"));
+        assert!(!is_network_fs("btrfs"));
+        assert!(!is_network_fs("xfs"));
+        assert!(!is_network_fs("exfat"));
+        assert!(!is_network_fs("zfs"));
+    }
+
+    #[test]
+    fn smb_family_is_flagged() {
+        // Note the matcher is invoked post-lowercase; sysinfo reports e.g.
+        // `"SMB3"` on some Linux kernels — callers must lowercase first.
+        assert!(is_network_fs("smbfs"));
+        assert!(is_network_fs("smb"));
+        assert!(is_network_fs("smb2"));
+        assert!(is_network_fs("smb3"));
+        assert!(is_network_fs("cifs"));
+    }
+
+    #[test]
+    fn nfs_family_is_flagged() {
+        assert!(is_network_fs("nfs"));
+        assert!(is_network_fs("nfs3"));
+        assert!(is_network_fs("nfs4"));
+    }
+
+    #[test]
+    fn macos_network_mounts_are_flagged() {
+        assert!(is_network_fs("afpfs"));
+        assert!(is_network_fs("webdav"));
+    }
+
+    #[test]
+    fn linux_clustered_mounts_are_flagged() {
+        assert!(is_network_fs("ceph"));
+        assert!(is_network_fs("glusterfs"));
+        assert!(is_network_fs("beegfs"));
+        assert!(is_network_fs("lustre"));
+        assert!(is_network_fs("9p"));
+        assert!(is_network_fs("fuse.sshfs"));
+        assert!(is_network_fs("sshfs"));
+    }
+
+    #[test]
+    fn generic_remote_token_is_flagged() {
+        // sysinfo sometimes reports network drives on Windows with a FS
+        // string that embeds `remote` — the contains() branch catches that.
+        assert!(is_network_fs("remote"));
+        assert!(is_network_fs("something-remote"));
+    }
+
+    #[test]
+    fn ftp_is_deliberately_not_flagged() {
+        // Kept as an explicit regression guard. See NETWORK_FILESYSTEMS
+        // rustdoc: no current OS reports "ftp" via sysinfo.
+        assert!(!is_network_fs("ftp"));
     }
 }
 


### PR DESCRIPTION
## Summary
The custom node data location feature from #3068 fails on macOS when the target directory is a NAS via SMB mount (#3178). This PR takes the second option allowed by the acceptance criteria: **detect network-mounted paths up front and show a clear error message** explaining that a local disk is required.

### Root cause
\`fs_more::directory::move_directory\` does not reliably complete on network filesystems (SMB / NFS / AFP / WebDAV etc.) because:
- Cross-volume rename semantics differ per protocol
- \`fsync\` on directories is often a no-op or fails outright
- Extended attributes / file locks used by LMDB may not be supported

Worse, the original code caught the failure only *after* shutting down the Node + Wallet phases and mutating \`ConfigCore::update_node_data_directory\`, leaving users with a cryptic \`fs_more\` error and a half-moved wallet state.

### Changes
**\`src-tauri/src/node/data_location.rs\`**
- New \`detect_network_filesystem(path: &Path) -> Option<String>\` helper that uses \`sysinfo::Disks\` (already a dependency) to find the longest-matching mount for the target path and checks its filesystem type against a list of known remote filesystems:
  - \`smbfs\`, \`cifs\`, \`smb\`, \`smb2\`, \`smb3\` (SMB / CIFS)
  - \`nfs\`, \`nfs3\`, \`nfs4\` (NFS)
  - \`afpfs\` (AFP, legacy macOS)
  - \`webdav\`, \`davfs\` (WebDAV)
  - \`sshfs\`, \`fuse.sshfs\`, \`9p\` (FUSE-based remotes)
  - \`ceph\`, \`glusterfs\`, \`beegfs\`, \`lustre\` (distributed)
  - \`remote\` (generic Windows remote)
- \`update_data_location\` calls the helper **immediately after canonicalisation** and returns an \`InvokeError\` with a clear message before touching any app state:
  > Selected directory is on a network filesystem (smbfs), which is not supported for the node data location. The node database requires a local disk (HDD/SSD) because network filesystems such as SMB, NFS, AFP and WebDAV do not reliably support the operations LMDB needs. Please choose a local directory instead.

### Why detect instead of fix?
Making LMDB work over SMB would require either switching the node's storage backend or disabling features (journaling, fsync) that compromise data integrity. The accepted option in the bounty is *\"Either: the fix allows SMB-mounted volumes to work end-to-end, or: the UI detects network-mounted paths and shows a clear error message before attempting the move\"* — this PR implements the second, safer option.

Closes #3178

## Test plan
- [ ] On macOS, mount an SMB share under \`/Volumes/NAS\` and try to select it as the node data location → a toast shows the new clear error, phases stay up, config is unchanged
- [ ] On Linux, mount a CIFS share and repeat → same behaviour
- [ ] On Windows, map a network drive (e.g. \`Z:\`) and repeat → same behaviour
- [ ] Selecting a normal local directory continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bounty-payout-section:start -->
---

## Bounty payout

If this PR is accepted as a bounty submission, please direct funds to the following Tari wallet address:

**`123JbAxCZ4Vrh4jCjFLXTu4z8sLeggUR87fejwNunsB55NMBSH9RpkjNiw1WL2GkKr8JhqRZhbrsSREchGanchw2Nhb`**
<!-- bounty-payout-section:end -->
