### PR TITLE
fix: accept newline-separated seed words in import (fixes #3128)

### DIFF
--- a/src/components/wallet/seedwords/SeedWords.tsx
+++ b/src/components/wallet/seedwords/SeedWords.tsx
@@ -77,7 +77,8 @@ export default function SeedWords({ isMonero = false }: SeedWordsProps) {
     }, [isValid, newSeedWords]);
 
     const handleApply = (data: { seedWords: string }) => {
-        setNewSeedWords(data.seedWords.split(' '));
+        // Split by any whitespace (spaces, newlines, tabs) to support multiple input formats
+        setNewSeedWords(data.seedWords.trim().split(/\s+/));
         setShowConfirm(true);
     };
 

--- a/src/components/wallet/seedwords/components/Edit.tsx
+++ b/src/components/wallet/seedwords/components/Edit.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import { EditWrapper, StyledTextArea } from './edit.styles.ts';
 
-const SEEDWORD_REGEX = /^(([a-zA-Z]+)\s){23}([a-zA-Z]+)$/;
+// Allow multiple whitespace (spaces, newlines, tabs) between words, and trim input
+const SEEDWORD_REGEX = /^\s*(([a-zA-Z]+)\s+){23}([a-zA-Z]+)\s*$/;
 
 export const Edit = () => {
     const { t } = useTranslation('settings', { useSuspense: false });


### PR DESCRIPTION
## Summary

Fixed the seed word import to accept both newline-separated and space-separated input formats.

## Changes

### 1. src/components/wallet/seedwords/components/Edit.tsx
Updated the SEEDWORD_REGEX to:
- Accept multiple whitespace characters (spaces, newlines, tabs) between words: \s+ instead of \s
- Allow leading and trailing whitespace: ^\s* and \s*$

Before: /^(([a-zA-Z]+)\s){23}([a-zA-Z]+)$/
After: /^\s*(([a-zA-Z]+)\s+){23}([a-zA-Z]+)\s*$/

### 2. src/components/wallet/seedwords/SeedWords.tsx
Changed handleApply to split by any whitespace instead of just spaces:

Before: data.seedWords.split(' ')
After: data.seedWords.trim().split(/\s+/)

This correctly handles:
- Space-separated: word1 word2 word3 ...
- Newline-separated: word1\nword2\nword3...
- Copy-pasted text with mixed whitespace
- Text with leading/trailing whitespace

## Root Cause

1. The original regex \s only matched single whitespace characters. Multi-line input with newlines between words could cause the pattern to fail in edge cases.
2. The split(' ') only split on space characters, not on newlines or tabs, so newline-separated input would produce an incorrect word array.

## Acceptance Criteria (from issue)

- [x] Seed word import handles words entered one per line (newline-separated) in addition to space-separated
- [x] Seed word import works correctly when copy-pasting the full phrase  
- [x] The confirmation tick becomes available once valid seed words are detected, regardless of whitespace format

Closes tari-project/universe#3128