### PR TITLE
fix: detect network mounts before moving node data on macOS

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ keyring = { version = "3.0.5", features = [
   "linux-native-sync-persistent",
   "windows-native",
 ] }
+libc = "0.2"
 log = "0.4.22"
 log4rs = "1.3.0"
 minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -31,8 +31,60 @@ use fs_more::directory::{
 use fs_more::file::CollidingFileBehaviour;
 use log::{error, info, warn};
 use std::fs;
+use std::path::Path;
 use tari_common::configuration::Network;
 use tauri::ipc::InvokeError;
+
+/// Checks if the given path resides on a network-mounted filesystem (e.g. SMB, NFS, AFP).
+/// Returns `Some(fs_type_name)` if network-mounted, `None` if local.
+#[cfg(target_os = "macos")]
+fn detect_network_mount(path: &Path) -> Option<&'static str> {
+    use std::ffi::CString;
+    use std::os::raw::c_char;
+
+    let path_str = match path.to_str() {
+        Some(s) => s,
+        None => return None,
+    };
+    let c_path = match CString::new(path_str) {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+
+    unsafe {
+        let mut stat: libc::statfs = std::mem::zeroed();
+        if libc::statfs(c_path.as_ptr(), &mut stat) != 0 {
+            return None;
+        }
+
+        let fs_type_bytes: &[c_char] = &stat.f_fstypename;
+        let fs_type = std::ffi::CStr::from_ptr(fs_type_bytes.as_ptr())
+            .to_str()
+            .unwrap_or("");
+
+        // MNT_LOCAL flag (0x00001000) is set for local filesystems on macOS.
+        // If it's absent, the filesystem is remote/network-mounted.
+        let mnt_local: u32 = 0x00001000;
+        let is_remote = (stat.f_flags as u32) & mnt_local == 0;
+
+        if is_remote {
+            match fs_type {
+                "smbfs" => Some("SMB"),
+                "nfs" => Some("NFS"),
+                "afpfs" => Some("AFP"),
+                "webdavfs" => Some("WebDAV"),
+                _ => Some("network"),
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn detect_network_mount(_path: &Path) -> Option<&'static str> {
+    None
+}
 
 pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
     let move_options = DirectoryMoveOptions {
@@ -48,60 +100,76 @@ pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
         },
     };
     match canonicalize(to_path) {
-        Ok(new_dir) => match ConfigCore::update_node_data_directory(new_dir.clone()).await {
-            Ok(previous) => {
-                if let Some(previous) = previous {
-                    SetupManager::get_instance()
-                        .shutdown_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                        .await;
+        Ok(new_dir) => {
+            if let Some(mount_type) = detect_network_mount(&new_dir) {
+                let msg = format!(
+                    "The selected directory is on a {} network mount. \
+                     Network-mounted drives (such as NAS devices connected via SMB) are not \
+                     supported as node data locations due to filesystem compatibility issues. \
+                     Please choose a directory on a local drive instead."
+                    , mount_type
+                );
+                warn!(target: LOG_TARGET_APP_LOGIC, "{}", msg);
+                return Err(InvokeError::from(msg));
+            }
 
-                    let network = Network::get_current().to_string().to_lowercase();
-                    let source_dir = previous.join("node").join(&network);
-                    let destination_dir = new_dir.join("node").join(&network);
+            match ConfigCore::update_node_data_directory(new_dir.clone()).await {
+                Ok(previous) => {
+                    if let Some(previous) = previous {
+                        SetupManager::get_instance()
+                            .shutdown_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                            .await;
 
-                    if let Some(parent) = destination_dir.parent() {
-                        fs::create_dir_all(parent).map_err(|e| InvokeError::from(e.to_string()))?;
-                    }
+                        let network = Network::get_current().to_string().to_lowercase();
+                        let source_dir = previous.join("node").join(&network);
+                        let destination_dir = new_dir.join("node").join(&network);
 
-                    let dest_existed = destination_dir.exists();
-
-                    match move_directory(source_dir, destination_dir.clone(), move_options) {
-                        Ok(res) => {
-                            info!(target: LOG_TARGET_APP_LOGIC, "Successfully moved items - Total bytes: {}, Directories: {:?}", res.total_bytes_moved, res.directories_moved);
-                        }
-                        Err(e) => {
-                            error!(target: LOG_TARGET_APP_LOGIC, "Could not move items, reverting config change: {e}");
-
-                            if !dest_existed
-                                && destination_dir.exists()
-                                && let Err(cleanup_err) = fs::remove_dir_all(&destination_dir)
-                            {
-                                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to clean up destination after failed move: {cleanup_err}");
-                            }
-
-                            ConfigCore::update_node_data_directory(previous)
-                                .await
+                        if let Some(parent) = destination_dir.parent() {
+                            fs::create_dir_all(parent)
                                 .map_err(|e| InvokeError::from(e.to_string()))?;
-
-                            SetupManager::get_instance()
-                                .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                                .await;
-
-                            return Err(InvokeError::from(e.to_string()));
                         }
-                    };
 
-                    info!(target: LOG_TARGET_APP_LOGIC, "[ set_custom_node_directory ] restarting phases");
-                    SetupManager::get_instance()
-                        .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
-                        .await;
+                        let dest_existed = destination_dir.exists();
+
+                        match move_directory(source_dir, destination_dir.clone(), move_options) {
+                            Ok(res) => {
+                                info!(target: LOG_TARGET_APP_LOGIC, "Successfully moved items - Total bytes: {}, Directories: {:?}", res.total_bytes_moved, res.directories_moved);
+                            }
+                            Err(e) => {
+                                error!(target: LOG_TARGET_APP_LOGIC, "Could not move items, reverting config change: {e}");
+
+                                if !dest_existed
+                                    && destination_dir.exists()
+                                    && let Err(cleanup_err) =
+                                        fs::remove_dir_all(&destination_dir)
+                                {
+                                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to clean up destination after failed move: {cleanup_err}");
+                                }
+
+                                ConfigCore::update_node_data_directory(previous)
+                                    .await
+                                    .map_err(|e| InvokeError::from(e.to_string()))?;
+
+                                SetupManager::get_instance()
+                                    .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                                    .await;
+
+                                return Err(InvokeError::from(e.to_string()));
+                            }
+                        };
+
+                        info!(target: LOG_TARGET_APP_LOGIC, "[ set_custom_node_directory ] restarting phases");
+                        SetupManager::get_instance()
+                            .resume_phases(vec![SetupPhase::Wallet, SetupPhase::Node])
+                            .await;
+                    }
+                }
+                Err(e) => {
+                    error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
+                    return Err(InvokeError::from(e.to_string()));
                 }
             }
-            Err(e) => {
-                error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
-                return Err(InvokeError::from(e.to_string()));
-            }
-        },
+        }
         Err(e) => {
             error!(target: LOG_TARGET_APP_LOGIC, "New node directory does not exist: {e}");
             return Err(InvokeError::from(e.to_string()));


### PR DESCRIPTION
## Description

Adds network mount detection for the custom node data location feature on macOS, preventing failures when users select NAS paths (SMB, NFS, AFP, WebDAV).

### Root Cause

The `fs_more::move_directory` operation fails on SMB-mounted volumes because network filesystems lack support for certain POSIX operations (hard links, atomic renames across mount points) that the move strategy relies on. When a user selects an SMB-mounted NAS directory as the custom node data location, the move attempt fails with an opaque error after already updating the config and shutting down node phases.

### Approach

Rather than attempting the move and failing, we now detect network mounts **upfront** using macOS `statfs(2)`:

- Check the `MNT_LOCAL` flag on the target path's filesystem — if absent, the mount is remote
- Identify the specific filesystem type (`smbfs`, `nfs`, `afpfs`, `webdavfs`) from `f_fstypename`
- Return a clear, user-facing error message **before** any config changes or phase shutdowns occur
- On non-macOS platforms, the detection is a no-op (returns `None`)

### Changes

- `src-tauri/src/node/data_location.rs`: Added `detect_network_mount()` with `#[cfg(target_os = "macos")]` that uses `libc::statfs` to check the `MNT_LOCAL` flag and filesystem type. Called at the start of `update_data_location()` before any config or move operations.
- `src-tauri/Cargo.toml`: Added `libc` dependency for macOS filesystem detection.

### User Experience

When selecting a network-mounted directory, users now see a clear toast error:
> "The selected directory is on a SMB network mount. Network-mounted drives (such as NAS devices connected via SMB) are not supported as node data locations due to filesystem compatibility issues. Please choose a directory on a local drive instead."

This prevents the confusing previous behavior where the operation would fail mid-move.

## How Has This Been Tested?

- Verified the `detect_network_mount` function correctly identifies SMB mount points via `statfs` on macOS
- Verified local paths return `None` (no false positives)
- The error path returns an `InvokeError` that surfaces as a toast in the UI via the existing error handling in `setDirectory()`

## Acceptance Criteria

- [x] Root cause identified: `fs_more::move_directory` fails on network mounts due to unsupported POSIX operations
- [x] UI detects network-mounted paths and shows a clear error message before attempting the move
- [x] Root cause and approach documented in PR description

/claim #3178