### PR TITLE
fix: make wallet send setup idempotent

### DIFF
--- a/src-tauri/src/wallet/spend_wallet.rs
+++ b/src-tauri/src/wallet/spend_wallet.rs
@@ -128,11 +128,11 @@ impl SpendWallet {
         let data_dir = self.get_data_dir(app_handle)?;
         let working_dir = data_dir.join("spend_wallet");
         // Clean up spend wallet working directory
-        if let Err(err) = std::fs::remove_dir_all(&working_dir) {
-            if err.kind() != ErrorKind::NotFound {
-                return Err(anyhow::anyhow!(err))
-                    .context("Failed to clean up Spend Wallet working directory");
-            }
+        if let Err(err) = std::fs::remove_dir_all(&working_dir)
+            && err.kind() != ErrorKind::NotFound
+        {
+            return Err(anyhow::anyhow!(err))
+                .context("Failed to clean up Spend Wallet working directory");
         }
         std::fs::create_dir_all(&working_dir)
             .context("Failed to clean up Spend Wallet working directory")?;

--- a/src-tauri/src/wallet/spend_wallet.rs
+++ b/src-tauri/src/wallet/spend_wallet.rs
@@ -21,6 +21,7 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -127,8 +128,13 @@ impl SpendWallet {
         let data_dir = self.get_data_dir(app_handle)?;
         let working_dir = data_dir.join("spend_wallet");
         // Clean up spend wallet working directory
-        std::fs::remove_dir_all(&working_dir)
-            .and_then(|_| std::fs::create_dir_all(&working_dir))
+        if let Err(err) = std::fs::remove_dir_all(&working_dir) {
+            if err.kind() != ErrorKind::NotFound {
+                return Err(anyhow::anyhow!(err))
+                    .context("Failed to clean up Spend Wallet working directory");
+            }
+        }
+        std::fs::create_dir_all(&working_dir)
             .context("Failed to clean up Spend Wallet working directory")?;
 
         Ok(())

--- a/src-tauri/src/wallet/transaction_service.rs
+++ b/src-tauri/src/wallet/transaction_service.rs
@@ -131,7 +131,6 @@ impl<'a> TransactionService<'a> {
     /// * `Result<(), anyhow::Error>` - A result indicating success or failure
     pub async fn cancel_transaction(&self, tx_id: String) -> Result<(), anyhow::Error> {
         let wallet_txs_dir = get_transactions_directory(self.app_handle)?;
-        ensure_transactions_directory(&wallet_txs_dir)?;
         let unsigned_tx_file = wallet_txs_dir.join(format!("{tx_id}-unsigned.json"));
         let signed_tx_file = wallet_txs_dir.join(format!("{tx_id}.json"));
 

--- a/src-tauri/src/wallet/transaction_service.rs
+++ b/src-tauri/src/wallet/transaction_service.rs
@@ -31,6 +31,8 @@ use minotari_node_grpc_client::grpc::{
     PrepareOneSidedTransactionForSigningRequest, UserPaymentId,
 };
 use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
 use std::path::PathBuf;
 use tari_common::configuration::Network;
 use tauri::Manager;
@@ -98,13 +100,8 @@ impl<'a> TransactionService<'a> {
             ));
         };
 
-        // Create directory for transaction files if it doesn't exist
         let wallet_txs_dir = get_transactions_directory(self.app_handle)?;
-        if !wallet_txs_dir.exists() {
-            std::fs::create_dir_all(&wallet_txs_dir).unwrap_or_else(|e| {
-                log::error!(target: LOG_TARGET_APP_LOGIC, "Failed to create transactions directory: {e}");
-            });
-        }
+        ensure_transactions_directory(&wallet_txs_dir)?;
 
         // Extract transaction ID from the JSON response
         let parsed: serde_json::Value = serde_json::from_str(&unsigned_tx_json)
@@ -134,6 +131,7 @@ impl<'a> TransactionService<'a> {
     /// * `Result<(), anyhow::Error>` - A result indicating success or failure
     pub async fn cancel_transaction(&self, tx_id: String) -> Result<(), anyhow::Error> {
         let wallet_txs_dir = get_transactions_directory(self.app_handle)?;
+        ensure_transactions_directory(&wallet_txs_dir)?;
         let unsigned_tx_file = wallet_txs_dir.join(format!("{tx_id}-unsigned.json"));
         let signed_tx_file = wallet_txs_dir.join(format!("{tx_id}.json"));
 
@@ -160,8 +158,8 @@ impl<'a> TransactionService<'a> {
         };
 
         // Remove unsigned and signed transaction files
-        fs::remove_file(&unsigned_tx_file)?;
-        fs::remove_file(&signed_tx_file)?;
+        remove_file_if_exists(&unsigned_tx_file)?;
+        remove_file_if_exists(&signed_tx_file)?;
 
         Ok(())
     }
@@ -181,6 +179,7 @@ impl<'a> TransactionService<'a> {
     ) -> Result<PathBuf, anyhow::Error> {
         // Define the output file path for the signed transaction
         let wallet_txs_dir = get_transactions_directory(self.app_handle)?;
+        ensure_transactions_directory(&wallet_txs_dir)?;
         let signed_tx_destination_file = wallet_txs_dir.join(format!("{tx_id}.json"));
 
         // Sign the transaction using SpendWallet
@@ -253,4 +252,43 @@ pub fn get_transactions_directory(app_handle: &tauri::AppHandle) -> Result<PathB
         .join("sent_transactions");
 
     Ok(dir)
+}
+
+fn ensure_transactions_directory(dir: &Path) -> Result<(), anyhow::Error> {
+    fs::create_dir_all(dir)?;
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), anyhow::Error> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn ensure_transactions_directory_creates_nested_directory() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let target_dir = temp_dir.path().join("testnet").join("sent_transactions");
+
+        ensure_transactions_directory(&target_dir)
+            .expect("failed to create transactions directory");
+
+        assert!(target_dir.exists());
+        assert!(target_dir.is_dir());
+    }
+
+    #[test]
+    fn remove_file_if_exists_ignores_missing_files() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let missing_file = temp_dir.path().join("missing.json");
+
+        remove_file_if_exists(&missing_file).expect("missing file should be ignored");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the first-send missing-file failure in `tari-project/universe#3035` by making the wallet send-file setup idempotent.

Closes: #3035

## What changed

- Always create the `sent_transactions` directory before prepare/sign/cancel operations.
- Treat missing transaction files as non-fatal during cleanup.
- Make spend-wallet working directory cleanup tolerant of a missing directory.

## Why

The first send after app launch could fail with a missing-file error when the transaction directory or cleanup targets were not present yet. These paths now behave safely on a fresh install and after partial cleanup.

## Verification

- `cargo fmt --all`
- `cargo build -p process-wrapper`
- `cargo test -p tari-universe ensure_transactions_directory -- --nocapture`
- `cargo test -p tari-universe remove_file_if_exists_ignores_missing_files -- --nocapture`

## Notes

This is intentionally narrow and focused on the send flow only.
