### PR TITLE
docs(readme): clarify Linux is source-build only

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Tari Universe ecosystem includes:
 
 ### Download
 
-[Download binaries](https://www.tari.com/downloads/) from [tari.com](https://www.tari.com/). This is the easiest way to run Tari Universe.
+[Download binaries](https://www.tari.com/downloads/) from [tari.com](https://www.tari.com/). This is the easiest way to run Tari Universe on Windows and macOS.
 
 ### Install
 
@@ -34,18 +34,8 @@ Open the `.dmg` file and drag Tari Universe to your Applications folder.
 
 #### On Linux
 
-Install the `.deb` package:
-
-```bash
-sudo dpkg -i tari-universe_*.deb
-```
-
-Or run the `.AppImage`:
-
-```bash
-chmod +x Tari-Universe-*.AppImage
-./Tari-Universe-*.AppImage
-```
+Official Linux prebuilt binaries are not currently published.
+Build from source using the Linux dependency and build steps in [Building from source](#building-from-source).
 
 ### Run
 
@@ -107,9 +97,9 @@ npm run tauri build
 
 Built applications will be in `target/release/bundle/`:
 
-- **Linux**: `.deb` and `.AppImage` files
-- **Windows**: `.msi` installer
-- **macOS**: `.dmg` and `.app` bundle
+- **Windows**: `.msi` installer (official release artifact)
+- **macOS**: `.dmg` and `.app` bundle (official release artifacts)
+- **Linux**: build from source only (no official prebuilt release artifacts). Local Linux builds may produce distro-specific bundles depending on your environment.
 
 ## Contributing
 


### PR DESCRIPTION
## Description
Update README Linux installation/output docs to match current release policy: no official Linux prebuilt artifacts are published.

## Motivation and Context
Issue #3111 reports that the README currently implies official Linux .deb/.AppImage release artifacts exist.

## How Has This Been Tested?
- npm run lint (passes with one existing warning in src/store/actions/miningStoreActions.ts)
- git ls-files '*.toml' | xargs npx taplo format --check (passes on tracked TOML files)

## What process can a PR reviewer use to test or verify this change?
1. Open README.md
2. Confirm Linux binary install instructions no longer mention official .deb/.AppImage downloads
3. Confirm Linux output section states source-build-only for official artifacts
4. Optionally run lint commands above

## Breaking Changes
- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

Closes #3111.