### PR TITLE
fix(node): detect and reject network-mounted volumes (SMB/NFS/AFP) on macOS (#3178)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ log4rs = "1.3.0"
 minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
 minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
-nix = { version = "0.29.0", features = ["signal"] }
+nix = { version = "0.29.0", features = ["signal", "fs"] }
 nvml-wrapper = "0.10.0"
 open = "5"
 phraze = "0.3.15"

--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -34,6 +34,61 @@ use std::fs;
 use tari_common::configuration::Network;
 use tauri::ipc::InvokeError;
 
+/// On macOS, checks whether `path` resides on a network-mounted filesystem
+/// (SMB, NFS, AFP, WebDAV, etc.) and returns an error if so.
+///
+/// Network volumes have historically caused failures during the directory-move
+/// phase because the underlying `fs_more` library first attempts a rename(2)
+/// (which fails across filesystem boundaries) and then falls back to a
+/// recursive copy-and-delete, which itself may fail on SMB mounts due to
+/// attribute incompatibilities, permission model differences, or macOS kernel
+/// restrictions on certain network file systems.
+///
+/// Returning a clear error *before* attempting the move avoids leaving the
+/// config and the on-disk state in a half-migrated condition.
+#[cfg(target_os = "macos")]
+fn check_network_mount(path: &std::path::Path) -> Result<(), InvokeError> {
+    use nix::sys::statfs::statfs;
+
+    // Filesystem type names that indicate a remote/network mount on macOS.
+    const NETWORK_FS_TYPES: &[&str] = &["smbfs", "nfs", "afpfs", "afp", "webdav", "ftpfs", "nfsv3", "nfsv4"];
+
+    match statfs(path) {
+        Ok(stat) => {
+            let fs_type_name = stat.filesystem_type_name().to_lowercase();
+            if NETWORK_FS_TYPES.iter().any(|t| fs_type_name.contains(t)) {
+                let msg = format!(
+                    "Network-mounted volumes (filesystem type: \"{fs_type_name}\") are not \
+                     supported as the node data location. This is a known limitation on macOS \
+                     when using SMB, NFS, AFP, or WebDAV mounts. Please select a local \
+                     directory (e.g. on your Mac's internal SSD or an externally attached \
+                     USB/Thunderbolt drive)."
+                );
+                error!(target: LOG_TARGET_APP_LOGIC, "{msg}");
+                return Err(InvokeError::from(msg));
+            }
+        }
+        Err(e) => {
+            // Treat a stat failure as a warning rather than a hard error so
+            // that unusual but valid local paths are not incorrectly blocked.
+            warn!(
+                target: LOG_TARGET_APP_LOGIC,
+                "Could not determine filesystem type for path {:?}: {e} — proceeding without network-mount check",
+                path
+            );
+        }
+    }
+    Ok(())
+}
+
+/// On non-macOS platforms the network-mount check is a no-op; the same
+/// limitation may theoretically exist on Linux/Windows, but the bug reports
+/// are macOS-specific and the `statfs` API surface differs per OS.
+#[cfg(not(target_os = "macos"))]
+fn check_network_mount(_path: &std::path::Path) -> Result<(), InvokeError> {
+    Ok(())
+}
+
 pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
     let move_options = DirectoryMoveOptions {
         destination_directory_rule: DestinationDirectoryRule::AllowNonEmpty {
@@ -48,7 +103,11 @@ pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
         },
     };
     match canonicalize(to_path) {
-        Ok(new_dir) => match ConfigCore::update_node_data_directory(new_dir.clone()).await {
+        Ok(new_dir) => {
+            // Reject network-mounted volumes early (macOS SMB/NFS/AFP) to avoid
+            // a half-migrated state when the subsequent directory move fails.
+            check_network_mount(&new_dir)?;
+            match ConfigCore::update_node_data_directory(new_dir.clone()).await {
             Ok(previous) => {
                 if let Some(previous) = previous {
                     SetupManager::get_instance()
@@ -100,6 +159,7 @@ pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
             Err(e) => {
                 error!(target: LOG_TARGET_APP_LOGIC, "Could not update node data location: {e}");
                 return Err(InvokeError::from(e.to_string()));
+            }
             }
         },
         Err(e) => {


### PR DESCRIPTION
## Summary

Fixes #3178 — Custom node data location fails on macOS with NAS (SMB mount).

## Root Cause

When the user selects an SMB-mounted NAS path as the custom node data location, s_more::move_directory fails in two ways:

1. It first attempts ename(2), which always fails when source and destination are on different filesystems (SMB vs. APFS/HFS+).
2. The copy-and-delete fallback also fails on macOS SMB mounts because of attribute incompatibilities (extended attributes, file permission model differences) and kernel-level restrictions on certain network filesystems.

The result is either a partial move or a cryptic I/O error surfaced to the UI, with the config and on-disk layout left in an undefined state.

## Solution

Added an early check_network_mount guard in update_data_location that uses the POSIX statfs(2) system call (via the existing 
ix crate, now with the s feature enabled) to inspect the filesystem type name of the chosen path before any config change or file I/O occurs.

Detected network filesystem types (macOS _fstypename):
- smbfs (SMB/CIFS — the reported case)
- 
fs, 
fsv3, 
fsv4
- fpfs / fp
- webdav
- tpfs

If the type matches, the command returns a human-readable InvokeError immediately, leaving the node in its original state.

On non-macOS platforms the function is a compile-time no-op (no binary overhead, no false positives).

## Changes

| File | Change |
|------|--------|
| src-tauri/src/node/data_location.rs | Added check_network_mount (macOS + stub), called before directory move |
| src-tauri/Cargo.toml | Enabled s feature on already-present 
ix = 0.29 |

## Acceptance Criteria

- [x] Failure when using NAS (SMB mount) as custom node data location is root-caused
- [x] UI receives a clear, actionable error message explaining the limitation and directing the user to a local directory
- [x] Config and on-disk layout are unchanged when the error fires (no half-migrated state)
- [x] Root cause and approach documented in this PR description