### PR TITLE
fix: NAS/SMB mount support on macOS for custom node data location

### DIFF
--- a/src-tauri/src/node/data_location.rs
+++ b/src-tauri/src/node/data_location.rs
@@ -31,20 +31,68 @@ use fs_more::directory::{
 use fs_more::file::CollidingFileBehaviour;
 use log::{error, info, warn};
 use std::fs;
+use std::path::Path;
 use tari_common::configuration::Network;
 use tauri::ipc::InvokeError;
 
+/// Returns true if the given path is on a network-mounted filesystem.
+///
+/// On macOS, SMB/NFS mounts typically appear under /Volumes/ or /Network/.
+#[cfg(target_os = "macos")]
+fn is_network_filesystem(path: &Path) -> bool {
+    use std::path::Component;
+
+    // Convert to components and collect first two to check for /Volumes/<name> or /Network/<name>
+    let mut components = path.components();
+    match components.next() {
+        Some(Component::RootDir) => {
+            match components.next() {
+                Some(Component::Normal(s)) => {
+                    let name = s.to_string_lossy();
+                    name == "Volumes" || name == "Network"
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if the given path is on a network-mounted filesystem.
+/// Stub for non-macOS platforms.
+#[cfg(not(target_os = "macos"))]
+fn is_network_filesystem(_path: &Path) -> bool {
+    false
+}
+
 pub async fn update_data_location(to_path: String) -> Result<(), InvokeError> {
+    // Network filesystems (SMB/NFS on macOS) don't support atomic rename for
+    // cross-device moves. Force copy-and-delete strategy when destination is
+    // on a network mount to avoid EXDEV errors.
+    let is_dest_network = is_network_filesystem(Path::new(&to_path));
+    if is_dest_network {
+        info!(target: LOG_TARGET_APP_LOGIC, "Destination is on a network filesystem, forcing copy-and-delete move strategy");
+    }
+
     let move_options = DirectoryMoveOptions {
         destination_directory_rule: DestinationDirectoryRule::AllowNonEmpty {
             colliding_file_behaviour: CollidingFileBehaviour::Abort,
             colliding_subdirectory_behaviour: CollidingSubDirectoryBehaviour::Continue,
         },
-        allowed_strategies: DirectoryMoveAllowedStrategies::Either {
-            copy_and_delete_options: DirectoryMoveByCopyOptions {
-                broken_symlink_behaviour: BrokenSymlinkBehaviour::Abort,
-                symlink_behaviour: SymlinkBehaviour::Keep,
-            },
+        allowed_strategies: if is_dest_network {
+            DirectoryMoveAllowedStrategies::CopyAndDelete {
+                options: DirectoryMoveByCopyOptions {
+                    broken_symlink_behaviour: BrokenSymlinkBehaviour::Abort,
+                    symlink_behaviour: SymlinkBehaviour::Keep,
+                },
+            }
+        } else {
+            DirectoryMoveAllowedStrategies::Either {
+                copy_and_delete_options: DirectoryMoveByCopyOptions {
+                    broken_symlink_behaviour: BrokenSymlinkBehaviour::Abort,
+                    symlink_behaviour: SymlinkBehaviour::Keep,
+                },
+            }
         },
     };
     match canonicalize(to_path) {


### PR DESCRIPTION
## Summary

Fixes issue #3178 where moving the Tari node data directory to a NAS (SMB mount) on macOS fails with an EXDEV (cross-device link) error.

## Root Cause

The original implementation used `DirectoryMoveAllowedStrategies::Either`, which attempts atomic `rename()` first. On macOS, SMB/NFS mounts don't support atomic rename across devices, causing the move operation to fail.

## Fix

Added an `is_network_filesystem()` helper that detects network paths on macOS by checking if the destination path starts with `/Volumes/` or `/Network/` - the standard mount points for network volumes on macOS.

When a network destination is detected, the move strategy is forced to `CopyAndDelete`, which copies the directory tree then removes the source, avoiding the cross-device rename issue.

## Changes

- **src-tauri/src/node/data_location.rs**:
  - Added `is_network_filesystem()` function with `#[cfg(target_os = "macos")]`
  - Added `std::path::Path` import
  - Modified `update_data_location()` to check `is_network_filesystem()` and use `CopyAndDelete` strategy when destination is on a network mount
  - Added logging when network filesystem is detected

## Acceptance Criteria

- [x] Detects /Volumes/ and /Network/ paths on macOS as network filesystems
- [x] Uses copy-and-delete strategy for network destinations, avoiding EXDEV errors
- [x] Logs the detection of network filesystem for debugging

Closes #3178