### PR TITLE
fix(settings): remote node address follow-ups + audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -758,6 +758,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -774,6 +775,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -790,6 +792,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -806,6 +809,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -822,6 +826,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -838,6 +843,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -854,6 +860,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -870,6 +877,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -886,6 +894,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -902,6 +911,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -918,6 +928,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -934,6 +945,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -950,6 +962,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -966,6 +979,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -982,6 +996,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -998,6 +1013,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1014,6 +1030,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1030,6 +1047,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1046,6 +1064,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1062,6 +1081,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1078,6 +1098,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1094,6 +1115,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1110,6 +1132,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1126,6 +1149,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1142,6 +1166,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1158,6 +1183,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1955,6 +1981,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1968,6 +1995,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1981,6 +2009,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1994,6 +2023,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2007,6 +2037,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2020,6 +2051,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2033,6 +2065,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2046,6 +2079,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2059,6 +2093,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2072,6 +2107,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2085,6 +2121,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2098,6 +2135,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2111,6 +2149,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2124,6 +2163,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2137,6 +2177,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2150,6 +2191,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2163,6 +2205,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2176,6 +2219,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2189,6 +2233,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2202,6 +2247,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2215,6 +2261,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2228,6 +2275,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2241,6 +2289,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2254,6 +2303,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2267,6 +2317,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2816,7 +2867,7 @@
             "version": "24.10.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
             "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -3609,16 +3660,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-            "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -5086,6 +5137,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -6223,7 +6275,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -6492,9 +6544,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -8586,9 +8638,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-            "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -9409,7 +9461,7 @@
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unified": {
@@ -9591,9 +9643,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -142,7 +142,7 @@
     "data-title": "Node data settings"
   },
   "custom-remote-node-address": "Custom remote node address (gRPC)",
-  "custom-remote-node-address-error": "Address must start with http:// or https://",
+  "custom-remote-node-address-error": "Invalid address: {{reason}}",
   "node-configuration": "Node configuration",
   "node-configuration-description": "Connect with Remote, Local or both until your Local is ready to use",
   "node-connection-address": "Connection address",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1697,9 +1697,9 @@ pub async fn set_node_type(
 /// - Path, query, fragment, username and password are all rejected to
 ///   keep the persisted value a bare gRPC endpoint (no `/v1`, no
 ///   `user:pass@`, no `?x=y`).
-///
-/// IPv6 literals are preserved in their bracketed form (`[::1]`) so the
-/// canonical string remains parseable.
+/// - IPv6 literals are rejected. `RemoteNodeAdapter::set_grpc_address`
+///   splits on `:` to recover the port, which is unrecoverably ambiguous
+///   for `https://[::1]:443`. Hostnames and IPv4 literals are fine.
 fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::Error> {
     let parsed = url::Url::parse(input)
         .map_err(|e| anyhow::anyhow!("Invalid remote base node address {input:?}: {e}"))?;
@@ -1715,10 +1715,15 @@ fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::
         );
     }
 
-    let host = parsed
-        .host_str()
-        .filter(|h| !h.is_empty())
-        .ok_or_else(|| anyhow::anyhow!("Invalid remote base node address {input:?}: missing host"))?;
+    let host = parsed.host_str().filter(|h| !h.is_empty()).ok_or_else(|| {
+        anyhow::anyhow!("Invalid remote base node address {input:?}: missing host")
+    })?;
+
+    if matches!(parsed.host(), Some(url::Host::Ipv6(_))) {
+        anyhow::bail!(
+            "Invalid remote base node address {input:?}: IPv6 literals are not supported; use a hostname or IPv4 address"
+        );
+    }
 
     let port = parsed.port().ok_or_else(|| {
         anyhow::anyhow!(
@@ -1742,13 +1747,7 @@ fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::
         anyhow::bail!("Invalid remote base node address {input:?}: fragments are not permitted");
     }
 
-    // Preserve IPv6 brackets: `url` gives the unbracketed form via `host_str`.
-    let host_for_url = match parsed.host() {
-        Some(url::Host::Ipv6(addr)) => format!("[{addr}]"),
-        _ => host.to_string(),
-    };
-
-    Ok(format!("{scheme}://{host_for_url}:{port}"))
+    Ok(format!("{scheme}://{host}:{port}"))
 }
 
 /// Validate a candidate remote base node address without persisting it.
@@ -1764,7 +1763,9 @@ fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::
 pub fn validate_remote_base_node_address(address: String) -> Result<String, InvokeError> {
     let trimmed = address.trim();
     if trimmed.is_empty() {
-        return Ok(ConfigCoreContent::default().remote_base_node_address().clone());
+        return Ok(ConfigCoreContent::default()
+            .remote_base_node_address()
+            .clone());
     }
     canonicalise_remote_base_node_address(trimmed).map_err(InvokeError::from_anyhow)
 }
@@ -1795,7 +1796,9 @@ pub async fn set_remote_base_node_address(address: String) -> Result<String, Inv
     // the empty string the user typed.
     let trimmed_address = address.trim();
     let resolved = if trimmed_address.is_empty() {
-        ConfigCoreContent::default().remote_base_node_address().clone()
+        ConfigCoreContent::default()
+            .remote_base_node_address()
+            .clone()
     } else {
         canonicalise_remote_base_node_address(trimmed_address).map_err(InvokeError::from_anyhow)?
     };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1701,50 +1701,45 @@ pub async fn set_node_type(
 ///   splits on `:` to recover the port, which is unrecoverably ambiguous
 ///   for `https://[::1]:443`. Hostnames and IPv4 literals are fine.
 fn canonicalise_remote_base_node_address(input: &str) -> Result<String, anyhow::Error> {
-    let parsed = url::Url::parse(input)
-        .map_err(|e| anyhow::anyhow!("Invalid remote base node address {input:?}: {e}"))?;
+    // Error messages here are surfaced directly to the user as the `{{reason}}`
+    // interpolated into the `custom-remote-node-address-error` i18n string, so
+    // they are kept short, reason-only (no input echo), and sentence-cased for
+    // inline display. The input is already logged upstream in
+    // `set_remote_base_node_address` for debugging.
+    let parsed = url::Url::parse(input).map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let scheme = parsed.scheme().to_ascii_lowercase();
     if scheme != "http" && scheme != "https" {
-        anyhow::bail!("Invalid remote base node address scheme {scheme:?}: must be http or https");
+        anyhow::bail!("scheme {scheme:?} is not supported; use http or https");
     }
 
     if !parsed.username().is_empty() || parsed.password().is_some() {
-        anyhow::bail!(
-            "Invalid remote base node address {input:?}: userinfo (user:pass@) is not permitted"
-        );
+        anyhow::bail!("userinfo (user:pass@) is not permitted");
     }
 
-    let host = parsed.host_str().filter(|h| !h.is_empty()).ok_or_else(|| {
-        anyhow::anyhow!("Invalid remote base node address {input:?}: missing host")
-    })?;
+    let host = parsed
+        .host_str()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("missing host"))?;
 
     if matches!(parsed.host(), Some(url::Host::Ipv6(_))) {
-        anyhow::bail!(
-            "Invalid remote base node address {input:?}: IPv6 literals are not supported; use a hostname or IPv4 address"
-        );
+        anyhow::bail!("IPv6 literals are not supported; use a hostname or IPv4 address");
     }
 
-    let port = parsed.port().ok_or_else(|| {
-        anyhow::anyhow!(
-            "Invalid remote base node address {input:?}: an explicit port is required (e.g. :443)"
-        )
-    })?;
+    let port = parsed
+        .port()
+        .ok_or_else(|| anyhow::anyhow!("an explicit port is required (e.g. :443)"))?;
 
     // `url` normalises an empty path to "/" — treat that the same as no path
     // for the purpose of rejection, but reject anything longer.
     if !matches!(parsed.path(), "" | "/") {
-        anyhow::bail!(
-            "Invalid remote base node address {input:?}: path segments are not permitted"
-        );
+        anyhow::bail!("path segments are not permitted");
     }
     if parsed.query().is_some() {
-        anyhow::bail!(
-            "Invalid remote base node address {input:?}: query strings are not permitted"
-        );
+        anyhow::bail!("query strings are not permitted");
     }
     if parsed.fragment().is_some() {
-        anyhow::bail!("Invalid remote base node address {input:?}: fragments are not permitted");
+        anyhow::bail!("fragments are not permitted");
     }
 
     Ok(format!("{scheme}://{host}:{port}"))
@@ -1767,7 +1762,10 @@ pub fn validate_remote_base_node_address(address: String) -> Result<String, Invo
             .remote_base_node_address()
             .clone());
     }
-    canonicalise_remote_base_node_address(trimmed).map_err(InvokeError::from_anyhow)
+    canonicalise_remote_base_node_address(trimmed).map_err(|e| {
+        info!(target: LOG_TARGET_APP_LOGIC, "[validate_remote_base_node_address] rejected {address:?}: {e}");
+        InvokeError::from_anyhow(e)
+    })
 }
 
 #[tauri::command]

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.styles.ts
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.styles.ts
@@ -1,5 +1,14 @@
 import styled from 'styled-components';
 import { StyledInput as BaseStyledInput } from '@app/components/elements/inputs/Input.styles.ts';
+import { SettingsGroup, SettingsGroupContent } from '../../components/SettingsGroup.styles.ts';
+
+export const AddressSettingsGroup = styled(SettingsGroup)`
+    padding-top: 0;
+`;
+
+export const AddressSettingsGroupContent = styled(SettingsGroupContent)`
+    width: 100%;
+`;
 
 export const AddressFieldWrapper = styled.div`
     display: flex;

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
@@ -56,12 +56,14 @@ export default function NodeTypeConfiguration() {
         // Validate via the backend so inline errors use the exact same
         // rules — scheme, explicit port, no path/query/userinfo — that
         // `set_remote_base_node_address` will apply when it persists.
+        // The reason captured here is interpolated into the
+        // `custom-remote-node-address-error` i18n string at render time.
         try {
             await invoke<string>('validate_remote_base_node_address', { address: trimmed });
         } catch (e) {
             const message = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
             console.warn('Remote base node address failed validation:', message);
-            setAddressError(message || t('custom-remote-node-address-error'));
+            setAddressError(message || 'validation failed');
             return;
         }
 
@@ -70,9 +72,9 @@ export default function NodeTypeConfiguration() {
             await setRemoteBaseNodeAddress(trimmed);
         } catch (e) {
             const message = typeof e === 'string' ? e : e instanceof Error ? e.message : String(e);
-            setAddressError(message || t('custom-remote-node-address-error'));
+            setAddressError(message || 'validation failed');
         }
-    }, [addressInput, remote_base_node_address, t]);
+    }, [addressInput, remote_base_node_address]);
 
     const handleAddressChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setAddressInput(e.target.value);
@@ -146,7 +148,7 @@ export default function NodeTypeConfiguration() {
                             />
                             {addressError && (
                                 <AddressErrorMessage id={addressErrorId} role="alert">
-                                    {addressError}
+                                    {t('custom-remote-node-address-error', { reason: addressError })}
                                 </AddressErrorMessage>
                             )}
                         </AddressFieldWrapper>

--- a/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
+++ b/src/containers/floating/Settings/sections/connections/NodeTypeConfiguration.tsx
@@ -22,6 +22,8 @@ import {
     AddressFieldLabel,
     AddressFieldWrapper,
     AddressInput,
+    AddressSettingsGroup,
+    AddressSettingsGroupContent,
 } from './NodeTypeConfiguration.styles.ts';
 
 export default function NodeTypeConfiguration() {
@@ -120,8 +122,8 @@ export default function NodeTypeConfiguration() {
                 </SettingsGroupAction>
             </SettingsGroup>
             {showAddressInput && (
-                <SettingsGroup style={{ paddingTop: 0 }}>
-                    <SettingsGroupContent style={{ width: '100%' }}>
+                <AddressSettingsGroup>
+                    <AddressSettingsGroupContent>
                         <AddressFieldWrapper>
                             <AddressFieldLabel htmlFor={addressInputId}>
                                 {t('custom-remote-node-address')}
@@ -144,12 +146,12 @@ export default function NodeTypeConfiguration() {
                             />
                             {addressError && (
                                 <AddressErrorMessage id={addressErrorId} role="alert">
-                                    {t('custom-remote-node-address-error')}
+                                    {addressError}
                                 </AddressErrorMessage>
                             )}
                         </AddressFieldWrapper>
-                    </SettingsGroupContent>
-                </SettingsGroup>
+                    </AddressSettingsGroupContent>
+                </AddressSettingsGroup>
             )}
         </SettingsGroupWrapper>
     );


### PR DESCRIPTION
## Description

Three small changes stacked on `main`:

1. **Backend**: reject IPv6 literals in the remote base node address canonicaliser (`src-tauri/src/commands.rs`). `RemoteNodeAdapter::set_grpc_address` splits on `:` to recover the port, so `https://[::1]:443` lands with an empty `parts[2]` and mis-parses. Hostnames and IPv4 still go through.
2. **Frontend polish**: the two remaining inline `style={{}}` blocks on `SettingsGroup` / `SettingsGroupContent` moved into `AddressSettingsGroup` / `AddressSettingsGroupContent` in the sibling `.styles.ts`. The inline error now renders the backend's actual reason (`"an explicit port is required"`, `"path segments are not permitted"`, etc.) instead of the generic i18n fallback, which was the point of routing through `validate_remote_base_node_address` in the first place.
3. **Deps**: `npm audit fix` to patch the 2 high and 2 moderate advisories the daily security audit was failing on (lodash, vite, smol-toml, brace-expansion). Lockfile only, `package.json` unchanged.

## Motivation and Context

Post-merge follow-up to #3184. The IPv6 issue was flagged in review and deferred to a follow-up. The error-message render bug and the two leftover inline styles were caught re-reviewing the merge. The audit-fix commit is unrelated to the feature, but the audit workflow runs on every PR to `main` and was blocking unrelated work, so rolling it in here.

## How Has This Been Tested?

Local pre-flight covering the CI matrix:

- `cargo fmt --all -- --check`
- `cargo lints clippy --all-targets --all-features`
- `cargo check --release --all-targets --workspace`
- `cargo machete`
- `cargo test --locked --all-features --release` (180 tests)
- `npm run lint` (eslint + knip + tsc)
- `npm run lint:taplo` (tracked TOMLs)
- `npm run test` (1054 tests)
- `npm audit --audit-level=high` (0 vulns after fix)

Not run in a live Tauri build. The backend change is a single early-return in a helper and the frontend changes are small, but a manual browser check of Settings > Node Configuration is worth doing before merge.

## What process can a PR reviewer use to test or verify this change?

Settings > Node Configuration, switch to Remote or Remote & Local, then:

1. Enter `https://[::1]:443` and blur. Inline error should say IPv6 literals are not supported.
2. Enter `https://grpc.tari.com` (no port) and blur. Inline error should say an explicit port is required.
3. Enter `https://grpc.tari.com:443/v1` and blur. Inline error should mention path segments.
4. Clear the field. Should revert to the default remote address and the input should reflect that.
5. Enter `https://grpc.tari.com:443` and blur. Should accept and trigger a node phase restart.

## Breaking Changes

- [x] None

Co-authored with Claude Opus 4.7. Brian Pearce.