### PR TITLE
fix: implement automatic cleanup of old binary versions (closes #3028)

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -454,6 +454,31 @@ impl BinaryManager {
         Ok(binary_folder_path.join(selected_version))
     }
 
+    /// Cleanup old binary versions from the download directory, keeping only the selected version
+    pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
+        let binary_folder = self.adapter.get_binary_folder()?;
+        let current_version = self.get_selected_version();
+
+        debug!(target: LOG_TARGET_APP_LOGIC, "Scanning for old versions of {} in {}", self.binary_name, binary_folder.display());
+
+        let mut entries = tokio::fs::read_dir(binary_folder).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    // Check if the directory name looks like a version and is not the current version
+                    if name != current_version && (name.chars().next().map_or(false, |c| c.is_ascii_digit()) || name.starts_with('v')) {
+                        info!(target: LOG_TARGET_APP_LOGIC, "Cleaning up old binary version for {}: {} at {}", self.binary_name, name, path.display());
+                        if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                             warn!(target: LOG_TARGET_APP_LOGIC, "Failed to delete old binary version {}: {}", name, e);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Add Windows Defender exclusions for the downloaded binary
     #[cfg(target_os = "windows")]
     async fn add_windows_defender_exclusions(&self) -> Result<(), Error> {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -262,6 +262,10 @@ impl BinaryResolver {
             .ok_or_else(|| anyhow!("Couldn't find manager for binary: {}", binary.name()))?;
 
         if manager.check_if_files_for_version_exist() {
+            // Trigger cleanup of old versions even if current version exists
+            if let Err(e) = manager.cleanup_old_versions().await {
+                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
+            }
             // If files already exist, we can skip the download
             return Ok(());
         }
@@ -277,6 +281,10 @@ impl BinaryResolver {
             let _lock = TARI_SUITE_DOWNLOAD_LOCK.lock().await;
 
             if manager.check_if_files_for_version_exist() {
+                // Trigger cleanup here too
+                if let Err(e) = manager.cleanup_old_versions().await {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
+                }
                 return Ok(());
             }
             manager
@@ -288,7 +296,21 @@ impl BinaryResolver {
                 .await?;
         }
 
+        // After successful download, cleanup old versions
+        if let Err(e) = manager.cleanup_old_versions().await {
+            warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
+        }
+
         Ok(())
+    }
+
+    pub async fn cleanup_all_old_versions(&self) {
+        info!(target: LOG_TARGET_APP_LOGIC, "Starting global cleanup of old binary versions");
+        for (binary, manager) in &self.managers {
+            if let Err(e) = manager.cleanup_old_versions().await {
+                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
+            }
+        }
     }
 
     pub async fn get_binary_version(&self, binary: Binaries) -> String {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -263,9 +263,7 @@ impl BinaryResolver {
 
         if manager.check_if_files_for_version_exist() {
             // Trigger cleanup of old versions even if current version exists
-            if let Err(e) = manager.cleanup_old_versions().await {
-                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
-            }
+            self.cleanup_manager_versions(&binary, manager).await;
             // If files already exist, we can skip the download
             return Ok(());
         }
@@ -282,9 +280,7 @@ impl BinaryResolver {
 
             if manager.check_if_files_for_version_exist() {
                 // Trigger cleanup here too
-                if let Err(e) = manager.cleanup_old_versions().await {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
-                }
+                self.cleanup_manager_versions(&binary, manager).await;
                 return Ok(());
             }
             manager
@@ -297,9 +293,7 @@ impl BinaryResolver {
         }
 
         // After successful download, cleanup old versions
-        if let Err(e) = manager.cleanup_old_versions().await {
-            warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
-        }
+        self.cleanup_manager_versions(&binary, manager).await;
 
         Ok(())
     }
@@ -307,9 +301,13 @@ impl BinaryResolver {
     pub async fn cleanup_all_old_versions(&self) {
         info!(target: LOG_TARGET_APP_LOGIC, "Starting global cleanup of old binary versions");
         for (binary, manager) in &self.managers {
-            if let Err(e) = manager.cleanup_old_versions().await {
-                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
-            }
+            self.cleanup_manager_versions(binary, manager).await;
+        }
+    }
+
+    async fn cleanup_manager_versions(&self, binary: &Binaries, manager: &BinaryManager) {
+        if let Err(e) = manager.cleanup_old_versions().await {
+            log::warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {}", binary.name(), e);
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ use updates_manager::UpdatesManager;
 use utils::system_status::SystemStatus;
 use websocket_events_manager::WebsocketEventsManager;
 use websocket_manager::{WebsocketManager, WebsocketManagerStatusMessage, WebsocketMessage};
+use binaries::BinaryResolver;
 
 use log4rs::config::RawConfig;
 use std::sync::Arc;
@@ -564,6 +565,8 @@ fn main() {
                 block_on(state.updates_manager.initial_try_update(&handle_clone));
 
                 tauri::async_runtime::spawn(async move {
+                    BinaryResolver::current().cleanup_all_old_versions().await;
+
                     SetupManager::get_instance()
                         .start_setup(handle_clone.clone())
                         .await;


### PR DESCRIPTION
## Summary

Closes #3028

Implements automatic cleanup of old binary versions from the application cache. This prevents the accumulation of large binary files after multiple updates.

## Changes

- **BinaryManager**: Added an asynchronous `cleanup_old_versions()` method that:
    - Identifies the base binary directory for the component.
    - Iterates through sibling directories (previous versions).
    - Deletes any directory that doesn't match the currently selected version.
- **BinaryResolver**: Added `cleanup_all_old_versions()` as a global maintenance task and integrated per-binary cleanup into `initialize_binary()`.
- **Main**: Triggered the global cleanup task during the application startup (`RunEvent::Ready`) ensuring maintenance runs even if updates aren't triggered.

## Verification

- [x] Verified code structure matches existing `BinaryManager` and `BinaryResolver` patterns.
- [x] Used `tokio::fs` for non-blocking file operations.
- [x] Added safety check to ensure only version-like folders (starting with a digit or 'v') are targeted for deletion.

This ensures that users who have been running Tari Universe for a long time will have their disk space reclaimed automatically.
