### PR TITLE
fix(auto-launcher): quote app path on Windows for HKCU Run registry (closes #1588)

### DIFF
--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -248,11 +248,24 @@ impl AutoLauncher {
             .and_then(|file| file.to_str())
             .ok_or(anyhow!("Failed to get file stem"))?;
 
-        let app_path = app_exe
+        let app_path_raw = app_exe
             .as_os_str()
             .to_str()
             .ok_or(anyhow!("Failed to convert path to string"))?
             .to_string();
+
+        // On Windows, the installed executable path can contain spaces and parens
+        // (e.g. `C:\Users\<user>\AppData\Local\Programs\Tari Universe (Alpha)\Tari Universe (Alpha).exe`).
+        // The `auto-launch` crate writes the path verbatim to `HKCU\...\Run` without quoting it.
+        // `winlogon` then tokenises the value on whitespace and silently fails to launch the app
+        // because the parens/spaces break parsing. Wrapping the path in double quotes makes the
+        // registry value a single token (`"C:\...\app.exe"`) which `winlogon` parses correctly.
+        // See issue #1588.
+        let app_path = if cfg!(target_os = "windows") {
+            format!("\"{app_path_raw}\"")
+        } else {
+            app_path_raw
+        };
 
         info!(target: LOG_TARGET_APP_LOGIC, "Building auto-launcher with app_name: {app_name} and app_path: {app_path}");
         let auto_launcher = AutoLauncher::build_auto_launcher(app_name, &app_path)?;


### PR DESCRIPTION
## Description

Fixes #1588 - "Auto-start on system boot" silently fails on Windows. Enabling the setting in Tari Universe does not actually launch the app on system restart.

## Root cause

The installed executable path on Windows contains spaces and parentheses:

```
C:\Users\<user>\AppData\Local\Programs\Tari Universe (Alpha)\Tari Universe (Alpha).exe
```

The `auto-launch` crate (v0.5.0) writes this path verbatim to `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` without quoting:

```rust
// auto-launch source (windows.rs):
let value: String = format!(r#"{} {}"#, self.app_path, self.args.join(" "));
```

When `winlogon` reads this value on user logon, it tokenises on whitespace. The unquoted path with spaces and parens fails to parse - the registry entry exists, but Windows silently fails to launch the app.

## Fix

Wrap the path in double quotes before passing it to `AutoLaunchBuilder::set_app_path` on Windows. The registry value becomes a single token:

```
"C:\Users\<user>\AppData\Local\Programs\Tari Universe (Alpha)\Tari Universe (Alpha).exe"
```

which `winlogon` parses correctly.

The change is gated on `cfg!(target_os = "windows")`, so macOS and Linux behaviour is unchanged.

## Files changed

- `src-tauri/src/auto_launcher.rs` - one branch in `initialize_auto_launcher` to quote the path on Windows.

## Testing

Manual reboot test on Windows 11:

1. Build with `npm run tauri build` and install via the nsis output.
2. Launch app, toggle "Auto-start on system boot" on.
3. Open `regedit`, navigate to `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. Verify the `tari-universe` value is wrapped in double quotes.
4. `shutdown /r /t 0` and log back in. Verify Tari Universe launches automatically.
5. Toggle the setting off, verify the registry value is removed.
6. Optional: install to a path without parens (custom dir) to confirm no regression on simple paths.

## Acceptance criteria from #1588

- [x] Enabling "Auto-start on system boot" correctly registers Tari Universe to launch on system boot (via the registry Run key)
- [x] The app launches automatically after a system restart when the setting is enabled
- [x] The auto-start entry is visible and verifiable through `regedit` at `HKCU\...\Run`
- [x] Disabling the setting removes the auto-start entry

## Notes

- Issue #1588 also mentions Task Scheduler visibility. The Task Scheduler path uses `RunLevel::Highest` which fails silently with `E_ACCESSDENIED` on per-user installs (the default nsis installer). That's a separate concern - this PR fixes the primary mechanism (registry Run key) which is sufficient for the auto-start to work. Happy to follow up with a Task Scheduler PR if maintainers prefer.
- The unquoted-path bug is upstream in `auto-launch` v0.5.0 and v0.6.x. Quoting at our call site is the simplest fix without forking the dependency.