### PR TITLE
fix: preserve externally-launched binaries when TU shuts down

### DIFF
--- a/src-tauri/src/mining/cpu/manager.rs
+++ b/src-tauri/src/mining/cpu/manager.rs
@@ -321,8 +321,7 @@ impl CpuManager {
     pub async fn on_app_exit(&self) {
         match self
             .process_watcher
-            .adapter
-            .ensure_no_hanging_processes_are_running()
+            .ensure_no_hanging_process_is_running()
             .await
         {
             Ok(_) => {

--- a/src-tauri/src/mining/gpu/manager.rs
+++ b/src-tauri/src/mining/gpu/manager.rs
@@ -653,8 +653,7 @@ impl GpuManager {
     pub async fn on_app_exit(&self) {
         match self
             .process_watcher
-            .adapter
-            .ensure_no_hanging_processes_are_running()
+            .ensure_no_hanging_process_is_running()
             .await
         {
             Ok(_) => {

--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -444,16 +444,8 @@ impl NodeManager {
     }
 
     pub async fn on_app_exit(&self) {
-        if let Some(local_node_adapter) = {
-            let watcher_guard = self.local_node_watcher.read().await;
-            watcher_guard
-                .as_ref()
-                .map(|watcher| watcher.adapter.clone())
-        } {
-            match local_node_adapter
-                .ensure_no_hanging_processes_are_running()
-                .await
-            {
+        if let Some(watcher) = self.local_node_watcher.read().await.as_ref() {
+            match watcher.ensure_no_hanging_process_is_running().await {
                 Ok(_) => {
                     info!(target: LOG_TARGET_APP_LOGIC, "LocalNodeAdapter::on_app_exit completed successfully");
                 }
@@ -463,16 +455,8 @@ impl NodeManager {
             }
         }
 
-        if let Some(remote_node_adapter) = {
-            let watcher_guard = self.remote_node_watcher.read().await;
-            watcher_guard
-                .as_ref()
-                .map(|watcher| watcher.adapter.clone())
-        } {
-            match remote_node_adapter
-                .ensure_no_hanging_processes_are_running()
-                .await
-            {
+        if let Some(watcher) = self.remote_node_watcher.read().await.as_ref() {
+            match watcher.ensure_no_hanging_process_is_running().await {
                 Ok(_) => {
                     info!(target: LOG_TARGET_APP_LOGIC, "RemoteNodeAdapter::on_app_exit completed successfully");
                 }

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -25,11 +25,10 @@ use async_trait::async_trait;
 use futures_util::future::FusedFuture;
 use log::{error, info, warn};
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use sysinfo::System;
+use sysinfo::{ProcessesToUpdate, System};
 use tari_shutdown::Shutdown;
 use tauri_plugin_sentry::sentry;
 use tokio::runtime::Handle;
@@ -87,25 +86,48 @@ pub(crate) trait ProcessAdapter {
             .exists()
     }
 
-    fn find_process_pid_by_name(binary_name: &OsStr) -> Option<u32> {
-        let mut sys = System::new_all();
-        sys.refresh_all();
+    /// Searches for a running process whose executable path matches `binary_path`.
+    ///
+    /// File-name comparison is performed first to avoid the cost of canonicalization for
+    /// every process on the system. Canonicalization is only applied when the file names
+    /// match, making the common case (no match) cheap while handling symlinks and
+    /// relative-path components correctly.
+    fn find_process_pid_by_path(binary_path: &Path) -> Option<u32> {
+        let mut sys = System::new();
+        sys.refresh_processes(ProcessesToUpdate::All);
+
+        let target = fs::canonicalize(binary_path).unwrap_or_else(|_| binary_path.to_path_buf());
+        let target_file_name = target.file_name();
 
         for (pid, process) in sys.processes() {
-            if process.name() == binary_name {
-                return Some(pid.as_u32());
+            if let Some(exe) = process.exe() {
+                if exe.file_name() == target_file_name {
+                    let candidate = fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+                    if candidate == target {
+                        return Some(pid.as_u32());
+                    }
+                }
             }
         }
         None
     }
 
-    async fn ensure_no_hanging_processes_are_running(&self) -> Result<(), Error> {
-        let binary_name = OsStr::new(self.name());
-        if let Some(process) = Self::find_process_pid_by_name(binary_name) {
-            let parsed_id =
-                i32::try_from(process).expect("Failed to parse process ID from u32 to i32");
-            warn!(target: LOG_TARGET_APP_LOGIC, "{} process is already running with PID {}. Attempting to kill it.", self.name(), parsed_id);
-            kill_process(parsed_id).await?;
+    /// Kills any still-running instance of this adapter's binary at `binary_path`.
+    ///
+    /// Only the process whose on-disk executable matches `binary_path` exactly is
+    /// targeted. Externally-launched instances of the same binary (e.g. a user-run
+    /// `xmrig`) have a different path and are therefore left untouched.
+    async fn ensure_no_hanging_process_by_path(&self, binary_path: &Path) -> Result<(), Error> {
+        if let Some(pid) = Self::find_process_pid_by_path(binary_path) {
+            match i32::try_from(pid) {
+                Ok(parsed_id) => {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "{} is still running with PID {} at path {:?}. Killing.", self.name(), parsed_id, binary_path);
+                    kill_process(parsed_id).await?;
+                }
+                Err(_) => {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "{} PID {} does not fit into i32; skipping.", self.name(), pid);
+                }
+            }
         }
         Ok(())
     }
@@ -116,9 +138,6 @@ pub(crate) trait ProcessAdapter {
         binary_path: &Path,
     ) -> Result<(), Error> {
         info!(target: LOG_TARGET_APP_LOGIC, "Killing previous instances of {}", self.name());
-        let binary_name = binary_path
-            .file_name()
-            .expect("binary path must have a file name");
         match fs::read_to_string(base_folder.join(self.pid_file_name())) {
             Ok(pid) => match pid.trim().parse::<i32>() {
                 Ok(pid) => {
@@ -126,14 +145,18 @@ pub(crate) trait ProcessAdapter {
                     kill_process(pid).await?;
                 }
                 Err(_) => {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "pid file is not a valid integer: {pid}. Attempting to kill process by name");
-                    let pid_by_name = Self::find_process_pid_by_name(binary_name);
-                    if let Some(process) = pid_by_name {
-                        let parsed_id = i32::try_from(process)
-                            .expect("Failed to parse process ID from u32 to i32");
-                        kill_process(parsed_id).await?;
+                    warn!(target: LOG_TARGET_APP_LOGIC, "pid file is not a valid integer: {pid}. Attempting to find process by path");
+                    if let Some(process) = Self::find_process_pid_by_path(binary_path) {
+                        match i32::try_from(process) {
+                            Ok(parsed_id) => {
+                                kill_process(parsed_id).await?;
+                            }
+                            Err(_) => {
+                                warn!(target: LOG_TARGET_APP_LOGIC, "{} PID {} does not fit into i32; skipping.", self.name(), process);
+                            }
+                        }
                     } else {
-                        warn!(target: LOG_TARGET_APP_LOGIC, "No process found with name {}", binary_name.to_str().unwrap_or_default());
+                        warn!(target: LOG_TARGET_APP_LOGIC, "No process found at path {:?}", binary_path);
                     }
                 }
             },

--- a/src-tauri/src/process_watcher.rs
+++ b/src-tauri/src/process_watcher.rs
@@ -65,6 +65,11 @@ pub struct ProcessWatcher<TAdapter: ProcessAdapter> {
     pub stop_on_exit_codes: Vec<i32>,
     stats_broadcast: watch::Sender<ProcessWatcherStats>,
     is_first_start: Arc<AtomicBool>,
+    /// The on-disk path of the binary that was passed to the most recent `start()` call.
+    /// `None` if `start()` has never been called for this watcher instance.
+    /// Used by `ensure_no_hanging_process_is_running` to target only TU-owned
+    /// processes rather than killing by name (which would kill external instances).
+    last_started_binary_path: Option<PathBuf>,
 }
 
 impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
@@ -80,6 +85,7 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
             stop_on_exit_codes: Vec::new(),
             stats_broadcast,
             is_first_start: Arc::new(AtomicBool::new(true)),
+            last_started_binary_path: None,
         }
     }
 }
@@ -94,6 +100,22 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
             .kill_previous_instances(base_path, binary_path)
             .await?;
         Ok(())
+    }
+
+    /// Kills any still-running instance of the binary this watcher last launched.
+    ///
+    /// Targets only the exact on-disk path that was used when `start()` was called,
+    /// so externally-launched binaries with the same name (e.g. a user-run `xmrig`)
+    /// are left untouched. If `start()` was never called on this watcher the method
+    /// is a no-op.
+    pub async fn ensure_no_hanging_process_is_running(&self) -> Result<(), anyhow::Error> {
+        let Some(ref binary_path) = self.last_started_binary_path else {
+            // This watcher never started a process; nothing to clean up.
+            return Ok(());
+        };
+        self.adapter
+            .ensure_no_hanging_process_by_path(binary_path)
+            .await
     }
 
     pub async fn start(
@@ -116,6 +138,9 @@ impl<TAdapter: ProcessAdapter> ProcessWatcher<TAdapter> {
         }
         info!(target: LOG_TARGET_APP_LOGIC, "Starting process watcher for {name}");
         let binary_path = BinaryResolver::current().get_binary_path(binary).await?;
+        // Record the exact path so that shutdown cleanup can target only our child
+        // process and leave externally-launched instances of the same binary alone.
+        self.last_started_binary_path = Some(binary_path.clone());
         self.kill_previous_instances(base_path.clone(), &binary_path)
             .await?;
 

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -171,8 +171,7 @@ impl TorManager {
             .watcher
             .read()
             .await
-            .adapter
-            .ensure_no_hanging_processes_are_running()
+            .ensure_no_hanging_process_is_running()
             .await
         {
             Ok(_) => {

--- a/src-tauri/src/wallet/wallet_manager.rs
+++ b/src-tauri/src/wallet/wallet_manager.rs
@@ -198,8 +198,7 @@ impl WalletManager {
             .watcher
             .read()
             .await
-            .adapter
-            .ensure_no_hanging_processes_are_running()
+            .ensure_no_hanging_process_is_running()
             .await
         {
             Ok(_) => {


### PR DESCRIPTION
## Description

Fixes the bug where Tari Universe kills any process sharing a binary name with a TU-managed binary (xmrig, lolminer, minotari\_node, wallet, tor, mmproxy) on shutdown, including instances the user started independently.

## Root cause

`ProcessAdapter::ensure_no_hanging_processes_are_running()` scanned the process list by name (`process.name() == "xmrig"`) and killed the first match regardless of origin. A user-launched xmrig at `/usr/local/bin/xmrig` is indistinguishable from TU's xmrig at `~/.local/share/tari-universe/.../xmrig` when matching by name alone.

## Fix

Rather than adding a new required trait method to every adapter implementation, the fix stores the exact binary path inside `ProcessWatcher` at the point where it is already resolved by `BinaryResolver::get_binary_path()` during `start()`. A new method `ProcessWatcher::ensure_no_hanging_process_is_running()` uses that stored path to match processes by executable path instead of name.

Key properties:
- **No new required trait method** on `ProcessAdapter` - adapter implementations are unchanged.
- **Safe default**: if `start()` was never called on a watcher (process was never launched by TU), the cleanup is a no-op.
- **Path-based matching**: `find_process_pid_by_path()` canonicalizes only when the file names match first, keeping the common case (no hung process) cheap.
- **Covers all managed binaries**: xmrig, lolminer, minotari\_node (local + remote), wallet, tor, mmproxy - all updated.
- `kill_previous_instances()` fallback (crash-recovery path) similarly updated to match by path rather than name.

## Testing

1. Build TU from this branch
2. Start a standalone xmrig instance (from system package or manual install - different path to TU's copy)
3. Launch TU and confirm two xmrig processes are running
4. Close TU
5. Confirm the standalone xmrig is still running; only TU's managed process is gone

Closes #3204