### PR TITLE
feat: automatically remove stale binary version directories on update

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -454,6 +454,60 @@ impl BinaryManager {
         Ok(binary_folder_path.join(selected_version))
     }
 
+    /// Removes version directories in this binary's folder that are no longer selected,
+    /// reclaiming disk space accumulated by successive updates.
+    ///
+    /// Safety:
+    /// - Symlinks are never followed or deleted; only plain directories are removed.
+    /// - Only entries whose names start with a digit or `v` are treated as version
+    ///   directories; other files and directories are left untouched.
+    pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
+        let binary_folder = self.adapter.get_binary_folder()?;
+        let current_version = self.get_selected_version();
+
+        debug!(target: LOG_TARGET_APP_LOGIC, "Scanning {} for stale versions (keeping {})", binary_folder.display(), current_version);
+
+        let mut entries = tokio::fs::read_dir(&binary_folder).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            // `DirEntry::metadata()` does NOT follow symlinks (it uses lstat
+            // under the hood), so we can safely detect and skip symlinks here.
+            let metadata = match entry.metadata().await {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "Skipping {:?}: could not read metadata: {}", entry.path(), e);
+                    continue;
+                }
+            };
+
+            // Skip symlinks entirely to avoid remove_dir_all traversing out of the binary folder.
+            // Skip non-directories (e.g. the versions.json manifest or lock files).
+            if metadata.is_symlink() || !metadata.is_dir() {
+                continue;
+            }
+
+            let path = entry.path();
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_owned(),
+                None => continue,
+            };
+
+            // Only target entries that look like version strings to avoid
+            // accidentally removing unrelated directories.
+            let looks_like_version =
+                name.starts_with(|c: char| c.is_ascii_digit()) || name.starts_with('v');
+
+            if looks_like_version && name != current_version {
+                info!(target: LOG_TARGET_APP_LOGIC, "Removing stale {} version directory: {}", self.binary_name, name);
+                if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                    warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove stale {} version {}: {}", self.binary_name, name, e);
+                    // Non-fatal: log and continue to clean up remaining versions.
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Add Windows Defender exclusions for the downloaded binary
     #[cfg(target_os = "windows")]
     async fn add_windows_defender_exclusions(&self) -> Result<(), Error> {

--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -467,14 +467,21 @@ impl BinaryManager {
 
         debug!(target: LOG_TARGET_APP_LOGIC, "Scanning {} for stale versions (keeping {})", binary_folder.display(), current_version);
 
-        let mut entries = tokio::fs::read_dir(&binary_folder).await?;
+        // On a fresh install the binary folder may not yet exist; treat that as
+        // "nothing to clean up" rather than propagating an error.
+        let mut entries = match tokio::fs::read_dir(&binary_folder).await {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e.into()),
+        };
+
         while let Some(entry) = entries.next_entry().await? {
             // `DirEntry::metadata()` does NOT follow symlinks (it uses lstat
             // under the hood), so we can safely detect and skip symlinks here.
             let metadata = match entry.metadata().await {
                 Ok(m) => m,
                 Err(e) => {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "Skipping {:?}: could not read metadata: {}", entry.path(), e);
+                    warn!(target: LOG_TARGET_APP_LOGIC, "Skipping {:?}: could not read metadata: {}", entry.file_name(), e);
                     continue;
                 }
             };
@@ -485,9 +492,11 @@ impl BinaryManager {
                 continue;
             }
 
-            let path = entry.path();
-            let name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) => n.to_owned(),
+            // Use entry.file_name() (an OsString) to get the directory name without
+            // allocating a full PathBuf; only call entry.path() when deletion is needed.
+            let os_name = entry.file_name();
+            let name = match os_name.to_str() {
+                Some(n) => n,
                 None => continue,
             };
 
@@ -497,6 +506,7 @@ impl BinaryManager {
                 name.starts_with(|c: char| c.is_ascii_digit()) || name.starts_with('v');
 
             if looks_like_version && name != current_version {
+                let path = entry.path();
                 info!(target: LOG_TARGET_APP_LOGIC, "Removing stale {} version directory: {}", self.binary_name, name);
                 if let Err(e) = tokio::fs::remove_dir_all(&path).await {
                     warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove stale {} version {}: {}", self.binary_name, name, e);

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -23,7 +23,7 @@ use crate::LOG_TARGET_APP_LOGIC;
 use crate::progress_trackers::progress_stepper::IncrementalProgressTracker;
 use anyhow::{Error, anyhow};
 use async_trait::async_trait;
-use log::debug;
+use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::LazyLock;
@@ -288,7 +288,26 @@ impl BinaryResolver {
                 .await?;
         }
 
+        // A new version was successfully downloaded; remove stale versions now so
+        // disk space is reclaimed promptly.  Failures here are non-fatal.
+        if let Err(e) = manager.cleanup_old_versions().await {
+            warn!(target: LOG_TARGET_APP_LOGIC, "Post-download cleanup failed for {}: {}", binary.name(), e);
+        }
+
         Ok(())
+    }
+
+    /// Removes stale version directories for every managed binary.
+    ///
+    /// Should be called once at app startup to reclaim disk space from any
+    /// previous update where the post-download cleanup was interrupted.
+    pub async fn cleanup_all_old_versions(&self) {
+        info!(target: LOG_TARGET_APP_LOGIC, "Cleaning up stale binary version directories");
+        for (binary, manager) in &self.managers {
+            if let Err(e) = manager.cleanup_old_versions().await {
+                warn!(target: LOG_TARGET_APP_LOGIC, "Cleanup failed for {}: {}", binary.name(), e);
+            }
+        }
     }
 
     pub async fn get_binary_version(&self, binary: Binaries) -> String {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,6 +66,7 @@ use crate::mining::gpu::consts::GpuMinerStatus;
 use crate::mining::gpu::manager::GpuManager;
 use crate::mm_proxy_manager::MmProxyManager;
 use crate::node::node_manager::NodeManager;
+use crate::binaries::BinaryResolver;
 use crate::shutdown_manager::ShutdownManager;
 use crate::systemtray_manager::SystemTrayManager;
 use crate::tor_manager::TorManager;
@@ -564,6 +565,10 @@ fn main() {
                 block_on(state.updates_manager.initial_try_update(&handle_clone));
 
                 tauri::async_runtime::spawn(async move {
+                    // Clean up any stale binary version directories left from prior
+                    // updates before starting setup so disk usage is kept low.
+                    BinaryResolver::current().cleanup_all_old_versions().await;
+
                     SetupManager::get_instance()
                         .start_setup(handle_clone.clone())
                         .await;


### PR DESCRIPTION
## Description

Fixes the disk space accumulation caused by successive updates leaving stale version directories in TU's binary storage folder.

## Problem

Each binary update downloads a new version into a new subdirectory (e.g. `~/.local/share/tari-universe/xmrig/v6.22.1/`). The previous directory is never removed, so every update permanently consumes additional disk space.

## Solution

Cleanup runs at two points:

1. **After each successful download** - immediately removes stale directories for the binary that was just updated.
2. **On app startup** (`RunEvent::Ready`) - cleans all managed binaries in a single pass, recovering space from any prior update where the post-download cleanup was interrupted (e.g. app was force-quit mid-update).

## Safety

The key concern flagged in previous submissions was symlink safety. This is handled explicitly:

- `DirEntry::metadata()` is used instead of `path.is_dir()`. The former calls `lstat` and does **not** follow symlinks, so `metadata.is_symlink()` correctly detects symlinks before we touch them.
- Symlinks are skipped entirely; `remove_dir_all` is never called on a symlink entry.
- Only entries whose names start with a digit or `v` are treated as version directories. Other files and directories (e.g. manifests, lock files, unrelated dirs) are untouched.
- Cleanup failures are logged as warnings and are non-fatal - the binary in active use is never targeted.

## Changes

- `BinaryManager::cleanup_old_versions()` - scans and removes stale version dirs for a single binary
- `BinaryResolver::cleanup_all_old_versions()` - iterates all managers for startup-time cleanup
- `initialize_binary()` - calls per-binary cleanup after a successful download
- `main.rs` - spawns startup cleanup before `SetupManager::start_setup`

Closes #3028