### PR TITLE
Fix #3204: don't kill external xmrig processes on TU shutdown

### DIFF
--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -111,13 +111,72 @@ pub(crate) trait ProcessAdapter {
     /// Verify that the running process at `pid` currently has binary name
     /// `expected_name`. Used to confirm a PID file points at the process we
     /// actually started, not a recycled PID belonging to something unrelated.
+    ///
+    /// Implementation notes (per #3217 review):
+    ///   - We refresh only the single PID we care about (`refresh_processes_specifics`)
+    ///     instead of the whole system — `System::new_all()` + `refresh_all()` would
+    ///     scan CPU/memory/disks/network just to look up one PID, which is wasteful
+    ///     in a frequently-called path.
+    ///   - On Linux, `Process::name()` is read from `/proc/<pid>/stat`'s `comm`
+    ///     field which is **truncated to 15 chars** (TASK_COMM_LEN). Binary names
+    ///     longer than that (e.g. `minotari_node`, `sha-p2pool-rs`) won't compare
+    ///     equal verbatim. We handle this by also accepting a prefix match against
+    ///     the first 15 bytes of `expected_name`, and as a final fallback compare
+    ///     the file_name() of the executable path (which is NOT truncated).
     fn pid_matches_binary_name(pid: u32, expected_name: &OsStr) -> bool {
-        let mut sys = System::new_all();
-        sys.refresh_all();
-        sys.processes()
-            .get(&sysinfo::Pid::from_u32(pid))
-            .map(|p| p.name() == expected_name)
-            .unwrap_or(false)
+        let sys_pid = sysinfo::Pid::from_u32(pid);
+        let mut sys = System::new();
+        // Refresh only the single PID; falls back to nothing if the PID isn't there.
+        sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[sys_pid]),
+            true,
+            sysinfo::ProcessRefreshKind::nothing().with_exe(sysinfo::UpdateKind::Always),
+        );
+
+        let Some(process) = sys.process(sys_pid) else {
+            return false;
+        };
+
+        // Fast path: exact match on the (possibly-truncated) `comm` name.
+        let actual = process.name();
+        if actual == expected_name {
+            return true;
+        }
+
+        // Linux fallback: `comm` is truncated to TASK_COMM_LEN (16, including NUL ⇒ 15 visible).
+        // Compare expected_name's first 15 bytes against the actual.
+        #[cfg(target_os = "linux")]
+        {
+            const TASK_COMM_LEN: usize = 15;
+            let expected_bytes = expected_name.as_encoded_bytes();
+            if expected_bytes.len() > TASK_COMM_LEN {
+                let truncated = &expected_bytes[..TASK_COMM_LEN];
+                if actual.as_encoded_bytes() == truncated {
+                    return true;
+                }
+            }
+        }
+
+        // Final fallback: compare against the executable path's file name, which is
+        // not truncated by the kernel on any platform we support.
+        if let Some(exe) = process.exe() {
+            if let Some(file) = exe.file_name() {
+                if file == expected_name {
+                    return true;
+                }
+                // Strip an .exe suffix on Windows for the comparison.
+                #[cfg(target_os = "windows")]
+                {
+                    let file_str = file.to_string_lossy();
+                    let exp_str = expected_name.to_string_lossy();
+                    if file_str.eq_ignore_ascii_case(&format!("{exp_str}.exe")) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
     }
 
     /// Best-effort cleanup of a hanging child process Tari Universe itself

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -87,6 +87,15 @@ pub(crate) trait ProcessAdapter {
             .exists()
     }
 
+    /// Look up a PID for a process matching the given binary name.
+    ///
+    /// **Caution:** matches ANY process on the system whose binary name
+    /// matches — including processes started independently of Tari Universe.
+    /// Callers must verify the PID belongs to a TU child (e.g. by reading
+    /// TU's own PID file) before passing the result to `kill_process`.
+    /// Killing a PID returned here without that check terminates user-owned
+    /// processes (this was the cause of #3204 — TU was killing user-started
+    /// xmrig instances on shutdown).
     fn find_process_pid_by_name(binary_name: &OsStr) -> Option<u32> {
         let mut sys = System::new_all();
         sys.refresh_all();
@@ -99,14 +108,38 @@ pub(crate) trait ProcessAdapter {
         None
     }
 
+    /// Verify that the running process at `pid` currently has binary name
+    /// `expected_name`. Used to confirm a PID file points at the process we
+    /// actually started, not a recycled PID belonging to something unrelated.
+    fn pid_matches_binary_name(pid: u32, expected_name: &OsStr) -> bool {
+        let mut sys = System::new_all();
+        sys.refresh_all();
+        sys.processes()
+            .get(&sysinfo::Pid::from_u32(pid))
+            .map(|p| p.name() == expected_name)
+            .unwrap_or(false)
+    }
+
+    /// Best-effort cleanup of a hanging child process Tari Universe itself
+    /// spawned earlier. Intentionally a no-op when we can't prove the process
+    /// is ours — the previous implementation walked every process on the system
+    /// looking for a binary-name match and killed it, which terminated
+    /// user-started instances of xmrig / sha-p2pool / minotari_node etc.
+    /// (#3204).
+    ///
+    /// We can no longer safely identify our child here without a PID file (the
+    /// trait method does not have access to the data dir). Removing the kill
+    /// path is the safe move — the actual child process is already cleanly
+    /// terminated by `ProcessInstance::stop` / `kill_on_drop(true)` /
+    /// `graceful_kill` along the normal shutdown path. This function remains
+    /// only as an extension point for adapters that have access to the data
+    /// dir; the default impl logs and returns.
     async fn ensure_no_hanging_processes_are_running(&self) -> Result<(), Error> {
-        let binary_name = OsStr::new(self.name());
-        if let Some(process) = Self::find_process_pid_by_name(binary_name) {
-            let parsed_id =
-                i32::try_from(process).expect("Failed to parse process ID from u32 to i32");
-            warn!(target: LOG_TARGET_APP_LOGIC, "{} process is already running with PID {}. Attempting to kill it.", self.name(), parsed_id);
-            kill_process(parsed_id).await?;
-        }
+        info!(
+            target: LOG_TARGET_APP_LOGIC,
+            "{}::ensure_no_hanging_processes_are_running: skipping name-based kill (see #3204); rely on PID-file path via kill_previous_instances at startup",
+            self.name(),
+        );
         Ok(())
     }
 
@@ -119,22 +152,31 @@ pub(crate) trait ProcessAdapter {
         let binary_name = binary_path
             .file_name()
             .expect("binary path must have a file name");
-        match fs::read_to_string(base_folder.join(self.pid_file_name())) {
-            Ok(pid) => match pid.trim().parse::<i32>() {
+        let pid_file_path = base_folder.join(self.pid_file_name());
+        match fs::read_to_string(&pid_file_path) {
+            Ok(pid) => match pid.trim().parse::<u32>() {
                 Ok(pid) => {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "{} process did not shut down cleanly: {} pid file was created", pid, self.pid_file_name());
-                    kill_process(pid).await?;
-                }
-                Err(_) => {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "pid file is not a valid integer: {pid}. Attempting to kill process by name");
-                    let pid_by_name = Self::find_process_pid_by_name(binary_name);
-                    if let Some(process) = pid_by_name {
-                        let parsed_id = i32::try_from(process)
+                    // Cross-check the PID against the binary name to guard
+                    // against PID recycling (a fresh process unrelated to TU
+                    // could be at the same PID after reboot).
+                    if Self::pid_matches_binary_name(pid, binary_name) {
+                        let parsed_id = i32::try_from(pid)
                             .expect("Failed to parse process ID from u32 to i32");
+                        warn!(target: LOG_TARGET_APP_LOGIC, "{} process did not shut down cleanly: PID {} from {} matches; terminating", self.name(), pid, self.pid_file_name());
                         kill_process(parsed_id).await?;
                     } else {
-                        warn!(target: LOG_TARGET_APP_LOGIC, "No process found with name {}", binary_name.to_str().unwrap_or_default());
+                        info!(target: LOG_TARGET_APP_LOGIC, "{} pid file points at PID {} but no matching {:?} process is running; cleaning up stale pid file", self.name(), pid, binary_name);
                     }
+                    let _ = fs::remove_file(&pid_file_path);
+                }
+                Err(_) => {
+                    // Previously we fell back to `find_process_pid_by_name`
+                    // here, but that scanned the whole system and could kill
+                    // processes started independently of TU (#3204). Drop the
+                    // fallback: log, remove the bogus pid file, and leave any
+                    // system processes alone.
+                    warn!(target: LOG_TARGET_APP_LOGIC, "{} pid file at {:?} is not a valid integer ({:?}); skipping kill to avoid terminating an unrelated process", self.name(), pid_file_path, pid);
+                    let _ = fs::remove_file(&pid_file_path);
                 }
             },
             Err(e) => {


### PR DESCRIPTION
Closes #3204

## Root cause
`ProcessAdapter::ensure_no_hanging_processes_are_running` (called from `*Manager::on_app_exit` for cpu/gpu miners, node, tor, wallet) walked the *entire process table*, found any process whose binary name matched (`xmrig`, `sha-p2pool`, `minotari_node`, etc.), and killed it. That terminated user-started processes that TU never spawned.

The same dangerous fallback also lived in `kill_previous_instances` for the case where the PID file had garbage in it.

## Fix (single file: `src-tauri/src/process_adapter.rs`)

1. **`ensure_no_hanging_processes_are_running` becomes a no-op** that logs an info line. The trait method has no access to the data dir, so it has no way to safely identify *our* child. The actual TU-spawned child is already terminated cleanly by the regular shutdown path: `ProcessInstance::stop` / `tokio::process::Command::kill_on_drop(true)` / `process_utils::graceful_kill`. Removing the by-name kill is the safe move and requires no caller changes.

2. **`kill_previous_instances`** (already gets `base_folder`) now requires *both* (a) a PID file that parses cleanly, AND (b) the running PID still has the expected binary name (guarding PID recycling). Otherwise the stale pid file is removed and no kill is attempted. The previous fallback to `find_process_pid_by_name` is gone.

3. New helper `pid_matches_binary_name(pid, expected_name)` does the verification.

4. `find_process_pid_by_name` is kept but its docstring now warns callers that any returned PID must be cross-checked against TU's own PID file before being passed to `kill_process`.

## Why this is the minimal fix
- Single file, single trait, no signature changes — zero call-site churn.
- The actual child cleanup path (`ProcessInstance::stop` → `graceful_kill` → `tokio::process::Command::kill_on_drop`) was already correct and PID-tracked. The bug lived only in the *redundant* shutdown-time scan.

## Acceptance criteria
- [x] **Closing TU does not terminate independently-started xmrig** — name-based kill is removed from both the on-exit path and the startup fallback path.
- [x] **TU still terminates xmrig processes it spawned** — `ProcessInstance::stop` (via `kill_on_drop(true)` and `graceful_kill`) handles this on the normal shutdown path; `kill_previous_instances` handles the post-crash case via the PID file.
- [x] **No regressions in normal TU shutdown** — the change deletes only the dangerous fallback; the well-behaved PID-file path is preserved with an added safety check.
- [ ] **Verified on at least one platform with reproduction steps** — see "Manual verification" below; I'm running this against a freshly-built local Tauri build is the appropriate next step on the maintainer side, since cross-compiling Tari Universe requires the full mining-binary harness.

## Manual verification (suggested)

Linux:
```sh
# in one terminal
xmrig --donate-level 1 --no-cpu &
EXTERNAL_PID=$!

# in another terminal: launch TU, wait for CPU mining to start, close TU.
# After:
ps -p $EXTERNAL_PID >/dev/null && echo OK external still alive || echo FAIL external killed
```

Windows:
```powershell
Start-Process xmrig.exe -PassThru | Tee-Object -Variable ext
# launch TU, wait for mining, close TU
Get-Process -Id $ext.Id -ErrorAction SilentlyContinue
```

## Notes
- AI-assisted development per the issue notes ("AI-assisted development is expected and encouraged").
- Diff is 60 insertions / 18 deletions in a single file — should be straightforward to review.
