### PR TITLE
Fix Windows auto-start path quoting

### DIFF
--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -62,7 +62,7 @@ impl AutoLauncher {
         match PlatformUtils::detect_current_os() {
             CurrentOperatingSystem::Windows => AutoLaunchBuilder::new()
                 .set_app_name(app_name)
-                .set_app_path(app_path)
+                .set_app_path(&quote_windows_auto_launch_path(app_path))
                 .set_use_launch_agent(false)
                 .build()
                 .map_err(|e| e.into()),
@@ -301,5 +301,39 @@ impl AutoLauncher {
 
     pub fn current() -> &'static AutoLauncher {
         &INSTANCE
+    }
+}
+
+fn quote_windows_auto_launch_path(app_path: &str) -> String {
+    let trimmed_path = app_path.trim();
+
+    // auto-launch 0.5.0 writes the Run value as `app_path + args`.
+    // Quote the executable so Windows does not split installed paths at spaces.
+    if trimmed_path.starts_with('"') && trimmed_path.ends_with('"') {
+        trimmed_path.to_string()
+    } else {
+        format!("\"{trimmed_path}\"")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quote_windows_auto_launch_path;
+
+    #[test]
+    fn quotes_windows_auto_launch_paths_with_spaces() {
+        let app_path = r"C:\Program Files\Tari Universe\Tari Universe.exe";
+
+        assert_eq!(
+            quote_windows_auto_launch_path(app_path),
+            r#""C:\Program Files\Tari Universe\Tari Universe.exe""#
+        );
+    }
+
+    #[test]
+    fn does_not_double_quote_windows_auto_launch_paths() {
+        let app_path = r#""C:\Program Files\Tari Universe\Tari Universe.exe""#;
+
+        assert_eq!(quote_windows_auto_launch_path(app_path), app_path);
     }
 }


### PR DESCRIPTION
## Description

Closes tari-project/universe#1588.

This quotes the Windows executable path before passing it to `auto-launch`. Linux and macOS behavior are unchanged.

## Motivation and Context

The Windows auto-launch path goes through `auto-launch` 0.5.0. That crate writes the Run key command as the executable path plus args. If the installed executable is under a path such as `C:\Program Files\Tari Universe\Tari Universe.exe`, Windows can split the command at the first space unless the executable path is quoted.

That matches the reported behavior where the setting appears enabled but the app does not reliably start after reboot.

## How Has This Been Tested?

- `git diff --check HEAD~1 HEAD` passes locally.
- Added Rust unit tests for path quoting behavior.

I could not run `cargo fmt` or Rust tests in this Codex workspace because `cargo`/`rustc` are not installed here.

## What process can a PR reviewer use to test or verify this change?

1. Build/install Tari Universe on Windows in a path with spaces, for example under `C:\Program Files\Tari Universe`.
2. Enable launch on startup in the app.
3. Confirm the Windows Run startup command stores the executable path quoted.
4. Reboot/sign in and confirm Tari Universe starts.
5. Disable launch on startup and confirm the startup entry is removed.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
