### PR TITLE
Fix CPU hashrate units for RandomX mining

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -5,6 +5,7 @@ import MinerTile from './Miner.tsx';
 import { useEffect, useRef } from 'react';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { setupStoreSelectors } from '@app/store/selectors/setupStoreSelectors.ts';
+import { HashrateAlgorithm } from '@app/utils';
 
 export default function CPUTile() {
     const cpuPoolStats = useMiningPoolsStore((s) => s.cpuPoolStats);
@@ -39,6 +40,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            algo={HashrateAlgorithm.RandomX}
         />
     );
 }

--- a/src/containers/navigation/components/MiningTiles/Miner.tsx
+++ b/src/containers/navigation/components/MiningTiles/Miner.tsx
@@ -1,5 +1,5 @@
 import { PoolStats } from '@app/types/app-status';
-import { formatHashrate, formatNumber, FormatPreset } from '@app/utils';
+import { formatHashrate, formatNumber, FormatPreset, HashrateAlgorithm } from '@app/utils';
 import { Trans, useTranslation } from 'react-i18next';
 import Tile from './components/Tile/Tile';
 import { AnimatePresence } from 'motion/react';
@@ -31,7 +31,7 @@ export interface MinerTileProps {
     progressDiff?: number | null;
     unpaidFMT?: string;
     minerModuleState: AppModuleState;
-    algo?: GpuMiningAlgorithm;
+    algo?: GpuMiningAlgorithm | HashrateAlgorithm;
 }
 
 export default function MinerTile({
@@ -48,7 +48,7 @@ export default function MinerTile({
     progressDiff,
     unpaidFMT,
     minerModuleState,
-    algo = GpuMiningAlgorithm.C29,
+    algo = HashrateAlgorithm.C29,
 }: MinerTileProps) {
     const { t } = useTranslation(['mining-view', 'p2p'], { useSuspense: false });
 

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -209,6 +209,11 @@ describe('formatters', () => {
             expect(result).toEqual({ value: 1.5, unit: 'M' });
         });
 
+        it('returns empty unit for unscaled RandomX when joinUnit is false', () => {
+            const result = formatHashrate(500, false, HashrateAlgorithm.RandomX);
+            expect(result).toEqual({ value: 500, unit: '' });
+        });
+
         it('formats hashrates >= 1000000 with MG/s', () => {
             const result = formatHashrate(1_500_000);
             expect(result).toEqual({ value: 1.5, unit: ' MG/s' });
@@ -232,6 +237,11 @@ describe('formatters', () => {
         it('returns short unit when joinUnit is false', () => {
             const result = formatHashrate(1_500_000, false);
             expect(result).toEqual({ value: 1.5, unit: 'M' });
+        });
+
+        it('returns empty unit for unscaled hashrate when joinUnit is false', () => {
+            const result = formatHashrate(500, false);
+            expect(result).toEqual({ value: 500, unit: '' });
         });
 
         it('handles edge case at exactly 1000', () => {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -8,6 +8,7 @@ import {
     fmtTimePartString,
     formatAmountWithKM,
     formatDecimalCompact,
+    HashrateAlgorithm,
     roundToTwoDecimals,
     removeDecimals,
     removeXTMCryptoDecimals,
@@ -196,6 +197,16 @@ describe('formatters', () => {
         it('formats hashrates >= 1000 with kG/s', () => {
             const result = formatHashrate(1500);
             expect(result).toEqual({ value: 1.5, unit: ' kG/s' });
+        });
+
+        it('formats RandomX hashrates with H/s units', () => {
+            expect(formatHashrate(500, true, HashrateAlgorithm.RandomX)).toEqual({ value: 500, unit: 'H/s' });
+            expect(formatHashrate(1500, true, HashrateAlgorithm.RandomX)).toEqual({ value: 1.5, unit: ' kH/s' });
+        });
+
+        it('returns prefix-only unit for RandomX when joinUnit is false', () => {
+            const result = formatHashrate(1_500_000, false, HashrateAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: 'M' });
         });
 
         it('formats hashrates >= 1000000 with MG/s', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -143,7 +143,7 @@ export function formatHashrate(
     if (hashrate < 1000) {
         return {
             value: fixed(hashrate, 1),
-            unit: `${unit}/s`,
+            unit: joinUnit ? `${unit}/s` : '',
         };
     }
     if (hashrate < 1000000) {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -126,8 +126,19 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+export enum HashrateAlgorithm {
+    C29 = 'C29',
+    RandomX = 'RandomX',
+}
+
+type SupportedHashrateAlgorithm = GpuMiningAlgorithm | HashrateAlgorithm;
+
+export function formatHashrate(
+    hashrate: number,
+    joinUnit = true,
+    algo: SupportedHashrateAlgorithm = HashrateAlgorithm.C29
+): Hashrate {
+    const unit = algo === HashrateAlgorithm.RandomX ? 'H' : 'G';
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {


### PR DESCRIPTION
This PR fixes #3210 by formatting CPU mining as a RandomX hash rate instead of falling through the c29 graph-rate default. The changed surface is intentionally limited to the mining tile formatter path: CPU tiles now pass `RandomX`, while GPU tiles keep the c29 default.

| Area | Change | Evidence |
| --- | --- | --- |
| CPU mining tile | Passes the RandomX algorithm into the shared hashrate formatter | Formatter tests cover `H/s` and `kH/s` output for RandomX |
| Shared formatter | Selects `H` units for RandomX, keeps `G` units for c29, and honors `joinUnit=false` for unscaled values | Formatter tests cover RandomX and c29 base-case `joinUnit=false` output |
| Type surface | Allows `MinerTile` to accept either GPU miner algorithms or the shared hashrate algorithm enum | `tsc --noEmit` clean |

Validation run locally:

```text
npx vitest run src/utils/formatters.test.ts
65 passed

npx tsc --noEmit
clean

npx eslint src/utils/formatters.ts src/utils/formatters.test.ts src/containers/navigation/components/MiningTiles/CPU.tsx src/containers/navigation/components/MiningTiles/Miner.tsx
clean

git diff --check
clean
```

Broader branch validation after the follow-up commit:

```text
npm test
45 test files passed, 1058 tests passed

npm run lint
0 errors, 1 existing warning in src/store/actions/miningStoreActions.ts
```

The fix is algorithm-based rather than macOS-only: CPU mining is RandomX and should report hashes per second on every platform, while c29 remains graph-rate output for the GPU path that supports it.