### PR TITLE
fix: show CPU RandomX hashrates in H/s

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -39,6 +39,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            algo="RandomX"
         />
     );
 }

--- a/src/containers/navigation/components/MiningTiles/Miner.tsx
+++ b/src/containers/navigation/components/MiningTiles/Miner.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { PoolType } from '@app/store/useMiningPoolsStore.ts';
 import { AppModuleState, AppModuleStatus } from '@app/store/types/setup.ts';
 import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
+import type { HashrateAlgorithm } from '@app/utils/formatters.ts';
 export interface MinerTileProps {
     title: PoolType;
     mainLabelKey: string;
@@ -31,7 +32,7 @@ export interface MinerTileProps {
     progressDiff?: number | null;
     unpaidFMT?: string;
     minerModuleState: AppModuleState;
-    algo?: GpuMiningAlgorithm;
+    algo?: HashrateAlgorithm;
 }
 
 export default function MinerTile({

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -13,6 +13,7 @@ import {
     removeXTMCryptoDecimals,
     formatValue,
 } from './formatters';
+import { GpuMiningAlgorithm } from '@app/types/events-payloads';
 
 vi.mock('i18next', () => ({
     default: {
@@ -191,6 +192,16 @@ describe('formatters', () => {
         it('formats small hashrates with G/s unit', () => {
             const result = formatHashrate(500);
             expect(result).toEqual({ value: 500, unit: 'G/s' });
+        });
+
+        it('formats C29 hashrates with graph units', () => {
+            const result = formatHashrate(1500, true, GpuMiningAlgorithm.C29);
+            expect(result).toEqual({ value: 1.5, unit: ' kG/s' });
+        });
+
+        it('formats RandomX hashrates with hash units', () => {
+            const result = formatHashrate(1500, true, 'RandomX');
+            expect(result).toEqual({ value: 1.5, unit: ' kH/s' });
         });
 
         it('formats hashrates >= 1000 with kG/s', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -128,12 +128,17 @@ interface Hashrate {
 
 export type HashrateAlgorithm = GpuMiningAlgorithm | 'RandomX';
 
+const HASHRATE_BASE_UNITS: Record<HashrateAlgorithm, 'G' | 'H'> = {
+    [GpuMiningAlgorithm.C29]: 'G',
+    RandomX: 'H',
+};
+
 export function formatHashrate(
     hashrate: number,
     joinUnit = true,
     algo: HashrateAlgorithm = GpuMiningAlgorithm.C29
 ): Hashrate {
-    const unit = algo === GpuMiningAlgorithm.C29 ? 'G' : 'H';
+    const unit = HASHRATE_BASE_UNITS[algo];
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -126,8 +126,14 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+export type HashrateAlgorithm = GpuMiningAlgorithm | 'RandomX';
+
+export function formatHashrate(
+    hashrate: number,
+    joinUnit = true,
+    algo: HashrateAlgorithm = GpuMiningAlgorithm.C29
+): Hashrate {
+    const unit = algo === GpuMiningAlgorithm.C29 ? 'G' : 'H';
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {


### PR DESCRIPTION
## Description

Fixes #3210.

CPU mining uses RandomX, so its hashrate should be displayed with hash units (`H/s`, `kH/s`, etc.) instead of graph units (`G/s`). This updates the shared hashrate formatter to preserve graph units for C29 and use hash units for RandomX, then passes `RandomX` from the CPU mining tile.

## Motivation and Context

On macOS there is no C29 GPU mining path, so showing CPU mining as `G/s` is misleading. GPU/C29 formatting remains unchanged.

## How Has This Been Tested?

- `npm test -- src/utils/formatters.test.ts` - 63 tests passed
- `npx tsc --noEmit` - passed
- `npm run lint` - passed with one existing warning in untouched `src/store/actions/miningStoreActions.ts`
- `git diff --check` - passed
- `gitleaks detect --pipe --redact --verbose --no-color` on the diff - no leaks found

Not completed: `npm run build` timed out locally while the Vite build was running, so I did not use it as validation.

## What process can a PR reviewer use to test or verify this change?

Run the formatter test and inspect the CPU/GPU mining tiles:

```bash
npm test -- src/utils/formatters.test.ts
npx tsc --noEmit
```

The expected behavior is:

- CPU tile hashrates use `H/s`, `kH/s`, `MH/s`, etc.
- C29/GPU hashrates continue using `G/s`, `kG/s`, `MG/s`, etc.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

Disclosure: AI-assisted contribution.
