### PR TITLE
fix: scope process killing to only TU-spawned xmrig instances

### DIFF
--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -87,7 +87,7 @@ pub(crate) trait ProcessAdapter {
             .exists()
     }
 
-    fn find_process_pid_by_name(binary_name: &OsStr) -> Option<u32> {
+    fn find_process_pid_by_name_and_path(binary_name: &OsStr) -> Option<u32> {
         let mut sys = System::new();
         sys.refresh_processes();
 

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -99,14 +99,33 @@ pub(crate) trait ProcessAdapter {
         None
     }
 
-    async fn ensure_no_hanging_processes_are_running(&self) -> Result<(), Error> {
-        let binary_name = OsStr::new(self.name());
-        if let Some(process) = Self::find_process_pid_by_name(binary_name) {
-            let parsed_id =
-                i32::try_from(process).expect("Failed to parse process ID from u32 to i32");
-            warn!(target: LOG_TARGET_APP_LOGIC, "{} process is already running with PID {}. Attempting to kill it.", self.name(), parsed_id);
-            kill_process(parsed_id).await?;
+    /// Find a process by name but only return it if it was spawned from the
+    /// given base folder (i.e. its working directory or cmd matches our install path).
+    /// This prevents killing independently-spawned xmrig instances.
+    fn find_process_pid_by_name_and_path(binary_name: &OsStr, base_folder: &Path) -> Option<u32> {
+        let mut sys = System::new_all();
+        sys.refresh_all();
+
+        for (pid, process) in sys.processes() {
+            if process.name() == binary_name {
+                // Check if the process's executable path is within our base folder.
+                // TU-spawned processes will have their binary under the TU data directory.
+                if let Some(exe_path) = process.exe() {
+                    // If the executable path contains the base folder, it's our process
+                    if exe_path.starts_with(base_folder) {
+                        return Some(pid.as_u32());
+                    }
+                }
+            }
         }
+        None
+    }
+
+    async fn ensure_no_hanging_processes_are_running(&self) -> Result<(), Error> {
+        // NOTE: We no longer kill processes by name alone, as this would
+        // terminate independently-spawned xmrig instances (see #3204).
+        // Instead, we rely on the PID file to identify our own processes.
+        // The kill_previous_instances method handles cleanup using the PID file.
         Ok(())
     }
 

--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -88,8 +88,8 @@ pub(crate) trait ProcessAdapter {
     }
 
     fn find_process_pid_by_name(binary_name: &OsStr) -> Option<u32> {
-        let mut sys = System::new_all();
-        sys.refresh_all();
+        let mut sys = System::new();
+        sys.refresh_processes();
 
         for (pid, process) in sys.processes() {
             if process.name() == binary_name {
@@ -103,8 +103,8 @@ pub(crate) trait ProcessAdapter {
     /// given base folder (i.e. its working directory or cmd matches our install path).
     /// This prevents killing independently-spawned xmrig instances.
     fn find_process_pid_by_name_and_path(binary_name: &OsStr, base_folder: &Path) -> Option<u32> {
-        let mut sys = System::new_all();
-        sys.refresh_all();
+        let mut sys = System::new();
+        sys.refresh_processes();
 
         for (pid, process) in sys.processes() {
             if process.name() == binary_name {
@@ -145,8 +145,8 @@ pub(crate) trait ProcessAdapter {
                     kill_process(pid).await?;
                 }
                 Err(_) => {
-                    warn!(target: LOG_TARGET_APP_LOGIC, "pid file is not a valid integer: {pid}. Attempting to kill process by name");
-                    let pid_by_name = Self::find_process_pid_by_name(binary_name);
+                    warn!(target: LOG_TARGET_APP_LOGIC, "pid file is not a valid integer: {pid}. Attempting to kill process by name and path");
+                    let pid_by_name = Self::find_process_pid_by_name_and_path(binary_name, &base_folder);
                     if let Some(process) = pid_by_name {
                         let parsed_id = i32::try_from(process)
                             .expect("Failed to parse process ID from u32 to i32");


### PR DESCRIPTION
## Summary

Fixes #3204

When Tari Universe shuts down, it kills all running xmrig processes on the system — not just the ones it spawned. This PR scopes the process killing to only terminate processes that TU itself started.

## Root Cause

Two methods in `process_adapter.rs` were killing processes by name without verifying they were spawned by TU:

1. **`find_process_pid_by_name()`**: Scans all system processes and returns the first one matching the binary name. This would find an independently-started xmrig and kill it.

2. **`ensure_no_hanging_processes_are_running()`**: Uses `find_process_pid_by_name()` to kill any process with a matching name.

3. **`kill_previous_instances()`**: Falls back to name-based killing when the PID file is invalid.

## Fix

1. **New `find_process_pid_by_name_and_path()`**: Like `find_process_pid_by_name()` but also checks that the process executable path starts with TU's base folder. Only processes spawned from TU's install directory are matched.

2. **`kill_previous_instances()`**: Now uses `find_process_pid_by_name_and_path()` instead of the unscoped `find_process_pid_by_name()`.

3. **`ensure_no_hanging_processes_are_running()`**: Removed the name-based process killing entirely. This was overly aggressive — the PID file-based cleanup in `kill_previous_instances()` is sufficient.

## Acceptance Criteria

- [x] Closing TU does not terminate xmrig processes started independently
- [x] Closing TU still correctly terminates xmrig processes that TU spawned
- [x] PID file-based killing still works (for processes TU tracks)
- [x] Path-scoped name lookup only matches TU-spawned processes