### PR TITLE
Fix RandomX hashrate units

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -5,7 +5,7 @@ import MinerTile from './Miner.tsx';
 import { useEffect, useRef } from 'react';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { setupStoreSelectors } from '@app/store/selectors/setupStoreSelectors.ts';
-import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
+import { MiningAlgorithm } from '@app/types/events-payloads.ts';
 
 export default function CPUTile() {
     const cpuPoolStats = useMiningPoolsStore((s) => s.cpuPoolStats);
@@ -40,7 +40,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
-            algo={GpuMiningAlgorithm.RandomX}
+            algo={MiningAlgorithm.RandomX}
         />
     );
 }

--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -5,6 +5,7 @@ import MinerTile from './Miner.tsx';
 import { useEffect, useRef } from 'react';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { setupStoreSelectors } from '@app/store/selectors/setupStoreSelectors.ts';
+import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
 
 export default function CPUTile() {
     const cpuPoolStats = useMiningPoolsStore((s) => s.cpuPoolStats);
@@ -39,6 +40,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            algo={GpuMiningAlgorithm.RandomX}
         />
     );
 }

--- a/src/containers/navigation/components/MiningTiles/Miner.tsx
+++ b/src/containers/navigation/components/MiningTiles/Miner.tsx
@@ -16,7 +16,7 @@ import { offset, useFloating, useHover, useInteractions } from '@floating-ui/rea
 import { useState } from 'react';
 import { PoolType } from '@app/store/useMiningPoolsStore.ts';
 import { AppModuleState, AppModuleStatus } from '@app/store/types/setup.ts';
-import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
+import { MiningAlgorithm } from '@app/types/events-payloads.ts';
 export interface MinerTileProps {
     title: PoolType;
     mainLabelKey: string;
@@ -31,7 +31,7 @@ export interface MinerTileProps {
     progressDiff?: number | null;
     unpaidFMT?: string;
     minerModuleState: AppModuleState;
-    algo?: GpuMiningAlgorithm;
+    algo?: MiningAlgorithm;
 }
 
 export default function MinerTile({
@@ -48,7 +48,7 @@ export default function MinerTile({
     progressDiff,
     unpaidFMT,
     minerModuleState,
-    algo = GpuMiningAlgorithm.C29,
+    algo = MiningAlgorithm.C29,
 }: MinerTileProps) {
     const { t } = useTranslation(['mining-view', 'p2p'], { useSuspense: false });
 

--- a/src/store/selectors/minningStoreSelectors.test.ts
+++ b/src/store/selectors/minningStoreSelectors.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { getSelectedMiner } from './minningStoreSelectors';
 import { MiningStoreState } from '../useMiningStore';
-import { GpuMiner, GpuMinerType, GpuMinerFeature, GpuMiningAlgorithm } from '@app/types/events-payloads';
+import { GpuMiner, GpuMinerType, GpuMinerFeature, MiningAlgorithm } from '@app/types/events-payloads';
 
 const createMockMiner = (minerType: GpuMinerType): GpuMiner => ({
     miner_type: minerType,
     features: [GpuMinerFeature.PoolMining],
-    supported_algorithms: [GpuMiningAlgorithm.C29],
+    supported_algorithms: [MiningAlgorithm.C29],
     is_healthy: true,
 });
 

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -102,7 +102,7 @@ export enum GpuMinerFeature {
     EngineSelection = 'EngineSelection',
 }
 
-export enum GpuMiningAlgorithm {
+export enum MiningAlgorithm {
     C29 = 'C29',
     RandomX = 'RandomX',
 }
@@ -118,7 +118,7 @@ export enum MinerControlsState {
 export interface GpuMiner {
     miner_type: GpuMinerType;
     features: GpuMinerFeature[];
-    supported_algorithms: GpuMiningAlgorithm[];
+    supported_algorithms: MiningAlgorithm[];
     is_healthy: boolean;
     last_error?: string;
 }

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -104,6 +104,7 @@ export enum GpuMinerFeature {
 
 export enum GpuMiningAlgorithm {
     C29 = 'C29',
+    RandomX = 'RandomX',
 }
 
 export enum MinerControlsState {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -13,7 +13,7 @@ import {
     removeXTMCryptoDecimals,
     formatValue,
 } from './formatters';
-import { GpuMiningAlgorithm } from '@app/types/events-payloads';
+import { MiningAlgorithm } from '@app/types/events-payloads';
 
 vi.mock('i18next', () => ({
     default: {
@@ -194,9 +194,19 @@ describe('formatters', () => {
             expect(result).toEqual({ value: 500, unit: 'G/s' });
         });
 
+        it('formats small RandomX hashrates with H/s unit', () => {
+            const result = formatHashrate(500, true, MiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 500, unit: 'H/s' });
+        });
+
         it('formats hashrates >= 1000 with kG/s', () => {
             const result = formatHashrate(1500);
             expect(result).toEqual({ value: 1.5, unit: ' kG/s' });
+        });
+
+        it('formats scaled RandomX hashrates with kH/s', () => {
+            const result = formatHashrate(1500, true, MiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: ' kH/s' });
         });
 
         it('formats hashrates >= 1000000 with MG/s', () => {
@@ -205,7 +215,7 @@ describe('formatters', () => {
         });
 
         it('uses hash units for RandomX hashrates', () => {
-            const result = formatHashrate(1_500_000, true, GpuMiningAlgorithm.RandomX);
+            const result = formatHashrate(1_500_000, true, MiningAlgorithm.RandomX);
             expect(result).toEqual({ value: 1.5, unit: ' MH/s' });
         });
 
@@ -226,6 +236,11 @@ describe('formatters', () => {
 
         it('returns short unit when joinUnit is false', () => {
             const result = formatHashrate(1_500_000, false);
+            expect(result).toEqual({ value: 1.5, unit: 'M' });
+        });
+
+        it('returns RandomX short unit when joinUnit is false', () => {
+            const result = formatHashrate(1_500_000, false, MiningAlgorithm.RandomX);
             expect(result).toEqual({ value: 1.5, unit: 'M' });
         });
 

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -13,6 +13,7 @@ import {
     removeXTMCryptoDecimals,
     formatValue,
 } from './formatters';
+import { GpuMiningAlgorithm } from '@app/types/events-payloads';
 
 vi.mock('i18next', () => ({
     default: {
@@ -201,6 +202,11 @@ describe('formatters', () => {
         it('formats hashrates >= 1000000 with MG/s', () => {
             const result = formatHashrate(1_500_000);
             expect(result).toEqual({ value: 1.5, unit: ' MG/s' });
+        });
+
+        it('uses hash units for RandomX hashrates', () => {
+            const result = formatHashrate(1_500_000, true, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: ' MH/s' });
         });
 
         it('formats hashrates >= 1000000000 with GG/s', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -126,8 +126,13 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+const HASHRATE_BASE_UNITS: Record<GpuMiningAlgorithm, 'G' | 'H'> = {
+    [GpuMiningAlgorithm.C29]: 'G',
+    [GpuMiningAlgorithm.RandomX]: 'H',
+};
+
+export function formatHashrate(hashrate: number, joinUnit = true, algo = GpuMiningAlgorithm.C29): Hashrate {
+    const unit = HASHRATE_BASE_UNITS[algo];
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,4 +1,4 @@
-import { GpuMiningAlgorithm } from '@app/types/events-payloads';
+import { MiningAlgorithm } from '@app/types/events-payloads';
 import i18n from 'i18next';
 import { TimeParts } from '@app/types/mining/schedule.ts';
 
@@ -126,12 +126,12 @@ interface Hashrate {
     unit: string;
 }
 
-const HASHRATE_BASE_UNITS: Record<GpuMiningAlgorithm, 'G' | 'H'> = {
-    [GpuMiningAlgorithm.C29]: 'G',
-    [GpuMiningAlgorithm.RandomX]: 'H',
+const HASHRATE_BASE_UNITS: Record<MiningAlgorithm, 'G' | 'H'> = {
+    [MiningAlgorithm.C29]: 'G',
+    [MiningAlgorithm.RandomX]: 'H',
 };
 
-export function formatHashrate(hashrate: number, joinUnit = true, algo = GpuMiningAlgorithm.C29): Hashrate {
+export function formatHashrate(hashrate: number, joinUnit = true, algo = MiningAlgorithm.C29): Hashrate {
     const unit = HASHRATE_BASE_UNITS[algo];
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {


### PR DESCRIPTION
## Summary

Fixes #3210 by making hashrate display units depend on the mining algorithm instead of always using graph-rate units.

This change:
- formats C29 mining with graph units (`G/s`, `kG/s`, `MG/s`, etc.)
- formats RandomX mining with hash units (`H/s`, `kH/s`, `MH/s`, etc.)
- passes `RandomX` explicitly from the CPU mining tile so macOS CPU mining no longer displays `G/s`
- adds formatter coverage for RandomX units

## Verification

- `npm test -- --run src/utils/formatters.test.ts` — 62 tests passed
- `npm exec tsc -- --noEmit`
- `git diff --check`

Note: Vitest printed its existing "close timed out" warning after the tests passed, but exited successfully.