### PR TITLE
feat: cleanup old binary versions after update

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -441,11 +441,41 @@ impl BinaryManager {
             .await?;
         }
 
+        self.cleanup_old_versions().await?;
+
         Ok(())
     }
 
     pub fn get_selected_version(&self) -> String {
         self.selected_version.clone()
+    }
+
+    pub fn get_binary_folder(&self) -> Result<PathBuf, Error> {
+        self.adapter.get_binary_folder()
+    }
+
+    pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
+        let binary_folder = self.adapter.get_binary_folder()?;
+        if !binary_folder.exists() {
+            return Ok(());
+        }
+
+        let entries = std::fs::read_dir(&binary_folder)?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                    if dir_name != self.selected_version {
+                        info!(target: LOG_TARGET_APP_LOGIC, "Cleaning up old binary version: {path:?}");
+                        if let Err(e) = std::fs::remove_dir_all(&path) {
+                            warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old version directory {path:?}: {e}");
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub fn get_base_dir(&self) -> Result<PathBuf, Error> {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -262,7 +262,9 @@ impl BinaryResolver {
             .ok_or_else(|| anyhow!("Couldn't find manager for binary: {}", binary.name()))?;
 
         if manager.check_if_files_for_version_exist() {
-            // If files already exist, we can skip the download
+            let _unused = manager.cleanup_old_versions().await.inspect_err(|e| {
+                log::warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {e}", binary.name());
+            });
             return Ok(());
         }
 
@@ -277,6 +279,9 @@ impl BinaryResolver {
             let _lock = TARI_SUITE_DOWNLOAD_LOCK.lock().await;
 
             if manager.check_if_files_for_version_exist() {
+                let _unused = manager.cleanup_old_versions().await.inspect_err(|e| {
+                    log::warn!(target: LOG_TARGET_APP_LOGIC, "Failed to cleanup old versions for {}: {e}", binary.name());
+                });
                 return Ok(());
             }
             manager
@@ -288,6 +293,13 @@ impl BinaryResolver {
                 .await?;
         }
 
+        Ok(())
+    }
+
+    pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
+        for (_binary, manager) in &self.managers {
+            manager.cleanup_old_versions().await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- After a successful binary download, delete all previously downloaded version directories from the binary folder, keeping only the current version
- Cleanup also runs automatically on startup for each binary that already has its current version installed
- Errors during cleanup are logged but do not prevent normal operation

## Changes
- `binaries_manager.rs`: Added `cleanup_old_versions()` method that iterates the binary folder and removes all version subdirectories except the current one. Called after each successful download.
- `binaries_resolver.rs`: Added `cleanup_old_versions()` that calls cleanup on all managed binaries. Wired into `initialize_binary()` so cleanup runs on startup even when no download is needed.

## Acceptance Criteria (from #3028)
- [x] After a successful update, all previously downloaded binary versions are deleted from the download directory
- [x] The current (latest, just-installed) binary is always retained
- [x] Cleanup runs automatically on startup or after update completion (no user action required)

Closes #3028

🤖 Generated with [Claude Code](https://claude.com/claude-code)