### PR TITLE
Fix CPU RandomX hashrate units

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -5,6 +5,7 @@ import MinerTile from './Miner.tsx';
 import { useEffect, useRef } from 'react';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { setupStoreSelectors } from '@app/store/selectors/setupStoreSelectors.ts';
+import { MiningAlgorithm } from '@app/types/events-payloads.ts';
 
 export default function CPUTile() {
     const cpuPoolStats = useMiningPoolsStore((s) => s.cpuPoolStats);
@@ -39,6 +40,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            algo={MiningAlgorithm.RandomX}
         />
     );
 }

--- a/src/containers/navigation/components/MiningTiles/Miner.tsx
+++ b/src/containers/navigation/components/MiningTiles/Miner.tsx
@@ -16,7 +16,7 @@ import { offset, useFloating, useHover, useInteractions } from '@floating-ui/rea
 import { useState } from 'react';
 import { PoolType } from '@app/store/useMiningPoolsStore.ts';
 import { AppModuleState, AppModuleStatus } from '@app/store/types/setup.ts';
-import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
+import { MiningAlgorithm } from '@app/types/events-payloads.ts';
 export interface MinerTileProps {
     title: PoolType;
     mainLabelKey: string;
@@ -31,7 +31,7 @@ export interface MinerTileProps {
     progressDiff?: number | null;
     unpaidFMT?: string;
     minerModuleState: AppModuleState;
-    algo?: GpuMiningAlgorithm;
+    algo?: MiningAlgorithm;
 }
 
 export default function MinerTile({
@@ -48,7 +48,7 @@ export default function MinerTile({
     progressDiff,
     unpaidFMT,
     minerModuleState,
-    algo = GpuMiningAlgorithm.C29,
+    algo = MiningAlgorithm.C29,
 }: MinerTileProps) {
     const { t } = useTranslation(['mining-view', 'p2p'], { useSuspense: false });
 

--- a/src/store/selectors/minningStoreSelectors.test.ts
+++ b/src/store/selectors/minningStoreSelectors.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { getSelectedMiner } from './minningStoreSelectors';
 import { MiningStoreState } from '../useMiningStore';
-import { GpuMiner, GpuMinerType, GpuMinerFeature, GpuMiningAlgorithm } from '@app/types/events-payloads';
+import { GpuMiner, GpuMinerType, GpuMinerFeature, MiningAlgorithm } from '@app/types/events-payloads';
 
 const createMockMiner = (minerType: GpuMinerType): GpuMiner => ({
     miner_type: minerType,
     features: [GpuMinerFeature.PoolMining],
-    supported_algorithms: [GpuMiningAlgorithm.C29],
+    supported_algorithms: [MiningAlgorithm.C29],
     is_healthy: true,
 });
 

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -102,8 +102,9 @@ export enum GpuMinerFeature {
     EngineSelection = 'EngineSelection',
 }
 
-export enum GpuMiningAlgorithm {
+export enum MiningAlgorithm {
     C29 = 'C29',
+    RandomX = 'RandomX',
 }
 
 export enum MinerControlsState {
@@ -117,7 +118,7 @@ export enum MinerControlsState {
 export interface GpuMiner {
     miner_type: GpuMinerType;
     features: GpuMinerFeature[];
-    supported_algorithms: GpuMiningAlgorithm[];
+    supported_algorithms: MiningAlgorithm[];
     is_healthy: boolean;
     last_error?: string;
 }

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -13,6 +13,7 @@ import {
     removeXTMCryptoDecimals,
     formatValue,
 } from './formatters';
+import { MiningAlgorithm } from '@app/types/events-payloads';
 
 vi.mock('i18next', () => ({
     default: {
@@ -193,9 +194,19 @@ describe('formatters', () => {
             expect(result).toEqual({ value: 500, unit: 'G/s' });
         });
 
+        it('formats RandomX hashrates with H/s unit', () => {
+            const result = formatHashrate(500, true, MiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 500, unit: 'H/s' });
+        });
+
         it('formats hashrates >= 1000 with kG/s', () => {
             const result = formatHashrate(1500);
             expect(result).toEqual({ value: 1.5, unit: ' kG/s' });
+        });
+
+        it('formats scaled RandomX hashrates with H/s suffixes', () => {
+            const result = formatHashrate(1500, true, MiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: ' kH/s' });
         });
 
         it('formats hashrates >= 1000000 with MG/s', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,4 +1,4 @@
-import { GpuMiningAlgorithm } from '@app/types/events-payloads';
+import { MiningAlgorithm } from '@app/types/events-payloads';
 import i18n from 'i18next';
 import { TimeParts } from '@app/types/mining/schedule.ts';
 
@@ -126,8 +126,13 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+const HASHRATE_UNITS: Record<MiningAlgorithm, string> = {
+    [MiningAlgorithm.C29]: 'G',
+    [MiningAlgorithm.RandomX]: 'H',
+};
+
+export function formatHashrate(hashrate: number, joinUnit = true, algo = MiningAlgorithm.C29): Hashrate {
+    const unit = HASHRATE_UNITS[algo];
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {


### PR DESCRIPTION
Fixes #3210

## Summary
- add RandomX to the shared `MiningAlgorithm` enum
- make hashrate formatting use H/s for RandomX while keeping G/s for C29
- pass RandomX explicitly for the CPU mining tile
- use a formatter unit map for clearer future algorithm support

## Tests
- `npm.cmd exec -- vitest run src/utils/formatters.test.ts src/store/selectors/minningStoreSelectors.test.ts`
- `npm.cmd exec -- tsc --noEmit`

## Review follow-up
- Renamed `GpuMiningAlgorithm` to `MiningAlgorithm` after Gemini feedback because the enum is now shared by CPU and GPU mining display paths.
- Replaced conditional unit selection with a `HASHRATE_UNITS` map keyed by `MiningAlgorithm`.
- Kept the unscaled RandomX unit as `H/s` intentionally. Existing formatter behavior uses no leading space for unscaled units such as `G/s`, and only includes a leading space when a scale prefix is present, e.g. ` kG/s` / ` kH/s`.