### PR TITLE
feat: cleanup old binary files after successful update

### DIFF
--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -487,23 +487,27 @@ impl BinaryManager {
     /// Cleans up old binary version folders, retaining only the currently selected version.
     pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
         let binary_folder = self.adapter.get_binary_folder()?;
-        if !binary_folder.exists() {
+        if !tokio::fs::try_exists(&binary_folder).await.unwrap_or(false) {
             return Ok(());
         }
 
         let current_version = &self.selected_version;
         
         let mut entries = tokio::fs::read_dir(&binary_folder).await?;
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if !path.is_dir() {
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            if !file_type.is_dir() {
                 continue;
             }
-            if let Some(folder_name) = path.file_name().and_then(|n| n.to_str()) {
+            
+            if let Some(folder_name) = entry.file_name().to_str() {
                 if folder_name != current_version {
+                    let path = entry.path();
                     info!(target: LOG_TARGET_APP_LOGIC, "Cleaning up old binary version directory: {}", path.display());
                     if let Err(e) = tokio::fs::remove_dir_all(&path).await {
-                        warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old binary version directory {}: {}", path.display(), e);
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old binary version directory {}: {}", path.display(), e);
+                        }
                     }
                 }
             }

--- a/src-tauri/src/binaries/binaries_manager.rs
+++ b/src-tauri/src/binaries/binaries_manager.rs
@@ -483,6 +483,34 @@ impl BinaryManager {
         info!(target: LOG_TARGET_APP_LOGIC, "Added Windows Defender exclusions for binary: {} at path: {}", self.binary_name, binary_path.display());
         Ok(())
     }
+
+    /// Cleans up old binary version folders, retaining only the currently selected version.
+    pub async fn cleanup_old_versions(&self) -> Result<(), Error> {
+        let binary_folder = self.adapter.get_binary_folder()?;
+        if !binary_folder.exists() {
+            return Ok(());
+        }
+
+        let current_version = &self.selected_version;
+        
+        let mut entries = tokio::fs::read_dir(&binary_folder).await?;
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Some(folder_name) = path.file_name().and_then(|n| n.to_str()) {
+                if folder_name != current_version {
+                    info!(target: LOG_TARGET_APP_LOGIC, "Cleaning up old binary version directory: {}", path.display());
+                    if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                        warn!(target: LOG_TARGET_APP_LOGIC, "Failed to remove old binary version directory {}: {}", path.display(), e);
+                    }
+                }
+            }
+        }
+        
+        Ok(())
+    }
 }
 
 fn check_binary_exists(path: &std::path::Path) -> bool {

--- a/src-tauri/src/binaries/binaries_resolver.rs
+++ b/src-tauri/src/binaries/binaries_resolver.rs
@@ -263,6 +263,9 @@ impl BinaryResolver {
 
         if manager.check_if_files_for_version_exist() {
             // If files already exist, we can skip the download
+            manager.cleanup_old_versions().await.unwrap_or_else(|e| {
+                log::warn!(target: crate::LOG_TARGET_APP_LOGIC, "Failed to clean up old versions: {}", e);
+            });
             return Ok(());
         }
 
@@ -277,6 +280,9 @@ impl BinaryResolver {
             let _lock = TARI_SUITE_DOWNLOAD_LOCK.lock().await;
 
             if manager.check_if_files_for_version_exist() {
+                manager.cleanup_old_versions().await.unwrap_or_else(|e| {
+                    log::warn!(target: crate::LOG_TARGET_APP_LOGIC, "Failed to clean up old versions: {}", e);
+                });
                 return Ok(());
             }
             manager
@@ -287,6 +293,10 @@ impl BinaryResolver {
                 .download_version_with_retries(progress_channel.clone())
                 .await?;
         }
+
+        manager.cleanup_old_versions().await.unwrap_or_else(|e| {
+            log::warn!(target: crate::LOG_TARGET_APP_LOGIC, "Failed to clean up old versions: {}", e);
+        });
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes #3028

This PR implements the automatic cleanup of old binary files after a successful update and on startup.

### Implementation Details
- Created a `cleanup_old_versions()` method in `BinaryManager` that iterates over the binary's root directory and removes all subdirectories that do not match the current `selected_version`.
- Triggered `cleanup_old_versions()` from `BinaryResolver::initialize_binary()` whenever the binary files are verified as existing, or after a new download successfully completes.
- It seamlessly integrates with the existing flow and does not disrupt the file locking mechanism for the Tari Suite.
