### PR TITLE
Fix: Correct hashrate unit display to H/s for RandomX

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -39,6 +39,7 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            algo="RandomX"
         />
     );
 }

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -237,6 +237,23 @@ describe('formatters', () => {
             const result = formatHashrate(150);
             expect(result).toEqual({ value: 150, unit: 'G/s' });
         });
+
+        describe('when algorithm is RandomX', () => {
+            it('formats small hashrates with H/s unit', () => {
+                const result = formatHashrate(500, true, 'RandomX');
+                expect(result).toEqual({ value: 500, unit: 'H/s' });
+            });
+
+            it('formats hashrates >= 1000 with kH/s', () => {
+                const result = formatHashrate(1500, true, 'RandomX');
+                expect(result).toEqual({ value: 1.5, unit: ' kH/s' });
+            });
+
+            it('formats hashrates >= 1000000 with MH/s', () => {
+                const result = formatHashrate(1_500_000, true, 'RandomX');
+                expect(result).toEqual({ value: 1.5, unit: ' MH/s' });
+            });
+        });
     });
 
     describe('formatCountdown', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -126,8 +126,12 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+export function formatHashrate(
+    hashrate: number,
+    joinUnit = true,
+    algo: string | GpuMiningAlgorithm = GpuMiningAlgorithm.C29,
+): Hashrate {
+    const unit = algo === 'RandomX' ? 'H' : 'G';
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {


### PR DESCRIPTION
Fixes #3210 by properly detecting the RandomX algorithm in CPU.tsx and formatting the unit as H/s instead of G/s. This resolves the regression where macOS (and CPU mining in general) was incorrectly showing G/s.