### PR TITLE
chore: update Bridge tapplet version to v0.4.2

### DIFF
--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.1",
+        "bridge": "0.4.2",
         "lolminer": "1.98",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.1",
+        "bridge": "0.4.2",
         "lolminer": "1.98",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,6 +1,6 @@
 {
     "binaries": {
-        "bridge": "0.4.1",
+        "bridge": "0.4.2",
         "lolminer": "1.98",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",

--- a/src-tauri/src/mining/pools/mod.rs
+++ b/src-tauri/src/mining/pools/mod.rs
@@ -37,7 +37,7 @@ pub mod gpu_pool_manager;
 pub mod pools_manager;
 
 #[derive(Clone, Debug, Serialize, Default)]
-pub(crate) struct PoolStatus {
+pub struct PoolStatus {
     pub accepted_shares: u64,
     pub unpaid: f64,
     pub balance: f64,


### PR DESCRIPTION
## Description

Updates Bridge tapplet version to `v0.4.2`

## Motivation and Context

Bridge wallet connections used to rely on a single built-in Ethereum gateway that was not responding lately, which could stop the bridge from loading balances or processing transfers.
The app now pulls its list of Ethereum gateways from our backend, with automatic fallback between several providers.
If one goes down, we can swap it instantly from the backend — no new app or Tari Universe release required.

## How Has This Been Tested?

Tested locally, API call is made, viem is configured. I could connect my wallet.

```
[ TAPPLET-BRIDGE ] loaded public ethereum nodes
  Array (3)
  0
  {chainId: 1, urls: ["https://eth.drpc.org", "https://eth-mainnet.public.blastapi.io"]}
  1
  {chainId: 84532, urls: ["https://sepolia.base.org", "https://base-sepolia-rpc.publicnode.com"]}
  2
  {chainId: 11155111, urls: ["https://ethereum-sepolia-rpc.publicnode.com", "https://sepolia.drpc.org"]}
```

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
