### PR TITLE
fix(#3210): use H/s for CPU/RandomX hashrate, G/s only for C29

### DIFF
--- a/src/containers/navigation/components/MiningTiles/CPU.tsx
+++ b/src/containers/navigation/components/MiningTiles/CPU.tsx
@@ -5,6 +5,7 @@ import MinerTile from './Miner.tsx';
 import { useEffect, useRef } from 'react';
 import { useSetupStore } from '@app/store/useSetupStore.ts';
 import { setupStoreSelectors } from '@app/store/selectors/setupStoreSelectors.ts';
+import { GpuMiningAlgorithm } from '@app/types/events-payloads.ts';
 
 export default function CPUTile() {
     const cpuPoolStats = useMiningPoolsStore((s) => s.cpuPoolStats);
@@ -39,6 +40,8 @@ export default function CPUTile() {
             progressDiff={rewardsRef.current?.rewardValue}
             unpaidFMT={rewardsRef.current?.unpaidFMT || '-'}
             minerModuleState={cpuMiningModuleState}
+            // CPU mining uses RandomX (H/s) — macOS does not support C29/Cuckoo Cycle
+            algo={GpuMiningAlgorithm.RandomX}
         />
     );
 }

--- a/src/types/events-payloads.ts
+++ b/src/types/events-payloads.ts
@@ -104,6 +104,7 @@ export enum GpuMinerFeature {
 
 export enum GpuMiningAlgorithm {
     C29 = 'C29',
+    RandomX = 'RandomX',
 }
 
 export enum MinerControlsState {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -13,6 +13,7 @@ import {
     removeXTMCryptoDecimals,
     formatValue,
 } from './formatters';
+import { GpuMiningAlgorithm } from '@app/types/events-payloads';
 
 vi.mock('i18next', () => ({
     default: {
@@ -188,54 +189,81 @@ describe('formatters', () => {
     });
 
     describe('formatHashrate', () => {
-        it('formats small hashrates with G/s unit', () => {
+        // ── C29 (default) — unit base is G ──────────────────────────────────
+        it('C29: formats small hashrates with G/s unit', () => {
             const result = formatHashrate(500);
             expect(result).toEqual({ value: 500, unit: 'G/s' });
         });
 
-        it('formats hashrates >= 1000 with kG/s', () => {
+        it('C29: formats hashrates >= 1000 with kG/s', () => {
             const result = formatHashrate(1500);
             expect(result).toEqual({ value: 1.5, unit: ' kG/s' });
         });
 
-        it('formats hashrates >= 1000000 with MG/s', () => {
+        it('C29: formats hashrates >= 1000000 with MG/s', () => {
             const result = formatHashrate(1_500_000);
             expect(result).toEqual({ value: 1.5, unit: ' MG/s' });
         });
 
-        it('formats hashrates >= 1000000000 with GG/s', () => {
+        it('C29: formats hashrates >= 1000000000 with GG/s', () => {
             const result = formatHashrate(1_500_000_000);
             expect(result).toEqual({ value: 1.5, unit: ' GG/s' });
         });
 
-        it('formats hashrates >= 1000000000000 with TG/s', () => {
+        it('C29: formats hashrates >= 1000000000000 with TG/s', () => {
             const result = formatHashrate(1_500_000_000_000);
             expect(result).toEqual({ value: 1.5, unit: ' TG/s' });
         });
 
-        it('formats hashrates >= 1000000000000000 with PG/s', () => {
+        it('C29: formats hashrates >= 1000000000000000 with PG/s', () => {
             const result = formatHashrate(1_500_000_000_000_000);
             expect(result).toEqual({ value: 1.5, unit: ' PG/s' });
         });
 
-        it('returns short unit when joinUnit is false', () => {
+        it('C29: returns short unit when joinUnit is false', () => {
             const result = formatHashrate(1_500_000, false);
             expect(result).toEqual({ value: 1.5, unit: 'M' });
         });
 
-        it('handles edge case at exactly 1000', () => {
+        it('C29: handles edge case at exactly 1000', () => {
             const result = formatHashrate(1000);
             expect(result).toEqual({ value: 1, unit: ' kG/s' });
         });
 
-        it('handles zero hashrate', () => {
+        it('C29: handles zero hashrate', () => {
             const result = formatHashrate(0);
             expect(result).toEqual({ value: 0, unit: 'G/s' });
         });
 
-        it('rounds large values to 1 decimal', () => {
+        it('C29: rounds large values to 1 decimal', () => {
             const result = formatHashrate(150);
             expect(result).toEqual({ value: 150, unit: 'G/s' });
+        });
+
+        // ── RandomX (CPU mining, H/s) ────────────────────────────────────────
+        it('RandomX: formats small hashrates with H/s unit', () => {
+            const result = formatHashrate(500, true, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 500, unit: 'H/s' });
+        });
+
+        it('RandomX: formats hashrates >= 1000 with kH/s', () => {
+            const result = formatHashrate(1500, true, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: ' kH/s' });
+        });
+
+        it('RandomX: formats hashrates >= 1000000 with MH/s', () => {
+            const result = formatHashrate(1_500_000, true, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: ' MH/s' });
+        });
+
+        it('RandomX: handles zero hashrate with H/s', () => {
+            const result = formatHashrate(0, true, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 0, unit: 'H/s' });
+        });
+
+        it('RandomX: short unit when joinUnit false', () => {
+            const result = formatHashrate(1_500_000, false, GpuMiningAlgorithm.RandomX);
+            expect(result).toEqual({ value: 1.5, unit: 'M' });
         });
     });
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -126,8 +126,20 @@ interface Hashrate {
     unit: string;
 }
 
-export function formatHashrate(hashrate: number, joinUnit = true, _algo = GpuMiningAlgorithm.C29): Hashrate {
-    const unit = 'G';
+/**
+ * Returns the base unit letter for a mining algorithm.
+ * - C29 (Cuckoo Cycle) uses G (graphs/sec)
+ * - All other algorithms (RandomX, SHA-3, …) use H (hashes/sec)
+ *
+ * macOS does not support C29 mining at all, so CPU tiles always pass
+ * `GpuMiningAlgorithm.RandomX` and will correctly show H/s.
+ */
+export function hashrateBaseUnit(algo: GpuMiningAlgorithm): 'G' | 'H' {
+    return algo === GpuMiningAlgorithm.C29 ? 'G' : 'H';
+}
+
+export function formatHashrate(hashrate: number, joinUnit = true, algo = GpuMiningAlgorithm.C29): Hashrate {
+    const unit = hashrateBaseUnit(algo);
     const fixed = (val: number, dec = 2) => Number(val.toFixed(val >= 100 ? 1 : dec));
     if (hashrate < 1000) {
         return {


### PR DESCRIPTION
Fixes #3210

## Root Cause

`formatHashrate()` accepted an `_algo` parameter but **ignored it completely**, always hardcoding `const unit = "G"`. The CPU tile (`CPU.tsx`) also passed **no `algo` prop**, defaulting to `GpuMiningAlgorithm.C29` — so every CPU hashrate displayed in G/s regardless of platform or algorithm.

macOS does not support Cuckoo Cycle (c29) mining. CPU mining runs RandomX exclusively. The unit for RandomX is H/s (hashes per second), not G/s.

## Changes

| File | Change |
|------|--------|
| `src/types/events-payloads.ts` | Add `RandomX = "RandomX"` to `GpuMiningAlgorithm` enum |
| `src/utils/formatters.ts` | Add `hashrateBaseUnit(algo)` helper; wire `algo` param through `formatHashrate()` (was dead `_algo`) |
| `src/containers/navigation/components/MiningTiles/CPU.tsx` | Pass `algo={GpuMiningAlgorithm.RandomX}` to `<MinerTile>` |
| `src/utils/formatters.test.ts` | Add 5 RandomX/H/s test cases; prefix existing C29 tests |

## Acceptance Criteria

- [x] CPU hashrate on macOS is displayed in H/s (not G/s)
- [x] The unit correctly reflects the active mining algorithm (H/s for RandomX, G/s for c29 on platforms that support it)
- [x] No regression on other platforms — GPU/C29 tile still shows G/s

## Verification

```bash
npm run test -- src/utils/formatters.test.ts
```

All existing C29 tests pass. 5 new RandomX/H/s tests added and passing.

**Payout wallets:** ETH: `0xeaCAb48a4bfA0CED0e668c166615927115655594` | SOL: `C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW`