### PR TITLE
fix: scope PoolManagerInterfaceTrait to crate to resolve E0446

### DIFF
--- a/src-tauri/src/mining/pools/mod.rs
+++ b/src-tauri/src/mining/pools/mod.rs
@@ -44,7 +44,7 @@ pub(crate) struct PoolStatus {
     pub min_payout: u64,
 }
 
-pub trait PoolManagerInterfaceTrait<T> {
+pub(crate) trait PoolManagerInterfaceTrait<T> {
     // =============== Getters ===============
 
     async fn get_write_manager() -> RwLockWriteGuard<'static, PoolManager>;


### PR DESCRIPTION
## Description

CI is red on `main` and on every open PR right now, and none of it is the PRs' fault. The whole tree fails to compile with three copies of the same error:

```
error[E0446]: crate-private type `mining::pools::PoolStatus` in public interface
```

The cause is one line. `PoolManagerInterfaceTrait` is declared `pub`, but one of its methods hands back a `PoolStatus`, and `PoolStatus` is only `pub(crate)`. So a public trait is leaking a crate-private type. This PR scopes the trait to `pub(crate)`, which matches its sibling `PoolApiAdapter` in the same module and makes the leak go away.

## Motivation and Context

The interesting part is that nobody broke this. The code didn't change. We pin the toolchain to `channel = "stable"`, which floats, and a newer stable rustc started treating E0446 as a hard error where the older one let it slide. I confirmed it locally: on 1.94.0 (March) the original `pub trait` compiles clean, but CI's newer stable rejects it. That's also why the daily Release workflow only started failing in the last few days.

Nothing outside the crate uses this trait. `tari-universe` is a binary, so there's no external consumer to care about the visibility either way. `pub(crate)` is the honest declaration.

Once this lands, the three blocked Dependabot PRs (#3265, #3267, #3280) should go green after a rebase, since they were only ever failing on this.

I left the toolchain on floating `stable` on purpose so CI verifies the fix against the exact compiler that flagged it. Pinning to a fixed version to stop this from happening again is worth doing, but it's a separate decision and a separate PR.

## How Has This Been Tested?

- `cargo check --bin tari-universe --tests` passes locally with the fix.
- Reverted the one line and confirmed local 1.94.0 does not reproduce E0446, which is why CI on the newer stable is the real gate here. Watching the checks on this PR before merging anything.

## What process can a PR reviewer use to test or verify this change?

Pull the branch and let CI run, or build locally on a recent stable toolchain (something newer than 1.94). The build that was failing with E0446 should now finish.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
