### PR TITLE
chore: bump xmrig to 6.26.0 and lolMiner to 1.98a

### DIFF
--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -1,12 +1,12 @@
 {
     "binaries": {
         "bridge": "0.4.1",
-        "lolminer": "1.98",
+        "lolminer": "1.98a",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
         "wallet": "5.2.1 | c79f555",
-        "xmrig": "6.25.0"
+        "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -1,12 +1,12 @@
 {
     "binaries": {
         "bridge": "0.4.1",
-        "lolminer": "1.98",
+        "lolminer": "1.98a",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
         "wallet": "5.2.1 | c79f555",
-        "xmrig": "6.25.0"
+        "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -1,12 +1,12 @@
 {
     "binaries": {
         "bridge": "0.4.1",
-        "lolminer": "1.98",
+        "lolminer": "1.98a",
         "minotari_node": "5.2.1 | c79f555",
         "mmproxy": "5.2.1 | c79f555",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
         "wallet": "5.2.1 | c79f555",
-        "xmrig": "6.25.0"
+        "xmrig": "6.26.0"
     }
 }


### PR DESCRIPTION
## Description

Bumps the two bundled miners to their latest upstream releases, across all three network configs (mainnet, testnets, nextnet):

- xmrig 6.25.0 to 6.26.0 (latest stable, released 2026-03-28)
- lolMiner 1.98 to 1.98a (latest, a hotfix revision, released 2025-09-21)

## Motivation and Context

Both were a release behind. xmrig 6.26.0 is the current stable, and lolMiner 1.98a is the hotfix on top of the 1.98 we're pinning.

These two binaries don't carry checksums in the repo (the ones with a `| hash` suffix in the JSON are the Tari binaries; xmrig and lolMiner fetch their checksums from the upstream release at download time). The version string is also used verbatim to build the download URL, so the `1.98a` letter suffix needs no special handling in the resolver.

I checked every release asset resolves before opening this. All five return HTTP 200, including the lolMiner path that drops the leading `v`:

- `xmrig-6.26.0-linux-static-x64.tar.gz`, `-macos-arm64.tar.gz`, `-macos-x64.tar.gz`, `-windows-x64.zip`
- `lolMiner_v1.98a_Lin64.tar.gz`, `lolMiner_v1.98a_Win64.zip`

Stacked on #3300 (the E0446 fix) so the Rust checks pass. The `audit` check will stay red until the npm fix in #3301 lands, which has nothing to do with these miner versions.

## How Has This Been Tested?

Version-string and URL verification only (no code change). Confirmed the release assets exist and download (HTTP 200) for all platforms. Worth a real mining smoke test on each OS before release, since this is what users actually run.

## What process can a PR reviewer use to test or verify this change?

Run the app, let it download the miners, and confirm CPU (xmrig) and GPU (lolMiner) mining both start on the new versions. The download URLs the app builds are the ones verified above.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
