### PR TITLE
fix: delete Windows admin auto-start scheduled task

### DIFF
--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -226,14 +226,25 @@ impl AutoLauncher {
             return Ok(());
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let output_text = format!("{stdout}\n{stderr}");
+        let task_exists = match tokio::process::Command::new("schtasks")
+            .args(windows_admin_auto_start_query_args())
+            .output()
+            .await
+        {
+            Ok(output) => output.status.success(),
+            Err(error) => {
+                warn!(target: LOG_TARGET_APP_LOGIC, "Failed to query admin auto-start task after delete failure: {error}");
+                true
+            }
+        };
 
-        if is_missing_admin_auto_start_task_error(&output_text) {
+        if !task_exists {
             info!(target: LOG_TARGET_APP_LOGIC, "Task scheduler for admin startup was already absent");
             return Ok(());
         }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
 
         Err(anyhow!(
             "schtasks failed with status {:?}. stdout: {} stderr: {}",
@@ -403,29 +414,13 @@ fn windows_admin_auto_start_delete_args() -> [&'static str; 4] {
 }
 
 #[cfg(any(target_os = "windows", test))]
-fn is_missing_admin_auto_start_task_error(output: &str) -> bool {
-    let output = output.to_ascii_lowercase();
-    output.contains("cannot find")
-        || output.contains("does not exist")
-        || output.contains("not found")
+fn windows_admin_auto_start_query_args() -> [&'static str; 3] {
+    ["/Query", "/TN", WINDOWS_ADMIN_AUTO_START_TASK_NAME]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn missing_admin_auto_start_task_errors_are_idempotent() {
-        assert!(is_missing_admin_auto_start_task_error(
-            "ERROR: The system cannot find the file specified."
-        ));
-        assert!(is_missing_admin_auto_start_task_error(
-            "ERROR: The specified task name \"Tari Universe startup\" does not exist in the system."
-        ));
-        assert!(is_missing_admin_auto_start_task_error(
-            "ERROR: The scheduled task was not found."
-        ));
-    }
 
     #[test]
     fn delete_args_target_the_admin_auto_start_task() {
@@ -436,13 +431,11 @@ mod tests {
     }
 
     #[test]
-    fn non_missing_admin_auto_start_task_errors_are_not_ignored() {
-        assert!(!is_missing_admin_auto_start_task_error(
-            "ERROR: Access is denied."
-        ));
-        assert!(!is_missing_admin_auto_start_task_error(
-            "ERROR: Invalid argument/option - '/TN'."
-        ));
+    fn query_args_target_the_admin_auto_start_task() {
+        assert_eq!(
+            windows_admin_auto_start_query_args(),
+            ["/Query", "/TN", "Tari Universe startup",]
+        );
     }
 
     #[test]

--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -172,10 +172,17 @@ impl AutoLauncher {
             match PlatformUtils::detect_current_os() {
                 CurrentOperatingSystem::Windows => {
                     #[cfg(target_os = "windows")]
-                    let _unused = self.toggle_windows_admin_auto_launcher(false).await.inspect_err(|e| {
-                        warn!(target: LOG_TARGET_APP_LOGIC, "Failed to disable admin auto-launcher: {}", e)
-                    });
-                    auto_launcher.disable()?;
+                    {
+                        let admin_auto_launcher_result = self.toggle_windows_admin_auto_launcher(false).await;
+                        auto_launcher.disable()?;
+                        admin_auto_launcher_result.inspect_err(|e| {
+                            warn!(target: LOG_TARGET_APP_LOGIC, "Failed to disable admin auto-launcher: {}", e)
+                        })?;
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        auto_launcher.disable()?;
+                    }
                 }
                 _ => {
                     auto_launcher.disable()?;

--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -44,6 +44,8 @@ use crate::{
 };
 
 static INSTANCE: LazyLock<AutoLauncher> = LazyLock::new(AutoLauncher::new);
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_ADMIN_AUTO_START_TASK_NAME: &str = "Tari Universe startup";
 
 pub struct AutoLauncher {
     auto_launcher: RwLock<Option<AutoLaunch>>,
@@ -200,12 +202,46 @@ impl AutoLauncher {
 
         if !should_be_enabled {
             info!(target: LOG_TARGET_APP_LOGIC, "Disabling admin auto-launcher");
-            self.create_task_scheduler_for_admin_startup(false)
+            self.delete_task_scheduler_for_admin_startup()
                 .await
-                .map_err(|e| anyhow!("Failed to create task scheduler for admin startup: {}", e))?;
+                .map_err(|e| anyhow!("Failed to delete task scheduler for admin startup: {}", e))?;
         };
 
         Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn delete_task_scheduler_for_admin_startup(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        info!(target: LOG_TARGET_APP_LOGIC, "Deleting task scheduler for admin startup");
+
+        let output = tokio::process::Command::new("schtasks")
+            .args(windows_admin_auto_start_delete_args())
+            .output()
+            .await?;
+
+        if output.status.success() {
+            info!(target: LOG_TARGET_APP_LOGIC, "Task scheduler for admin startup deleted");
+            return Ok(());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let output_text = format!("{stdout}\n{stderr}");
+
+        if is_missing_admin_auto_start_task_error(&output_text) {
+            info!(target: LOG_TARGET_APP_LOGIC, "Task scheduler for admin startup was already absent");
+            return Ok(());
+        }
+
+        Err(anyhow!(
+            "schtasks failed with status {:?}. stdout: {} stderr: {}",
+            output.status.code(),
+            stdout.trim(),
+            stderr.trim()
+        )
+        .into())
     }
 
     #[cfg(target_os = "windows")]
@@ -283,7 +319,7 @@ impl AutoLauncher {
             .delay(delay_duration)?
             .build()?
             .register(
-                "Tari Universe startup",
+                WINDOWS_ADMIN_AUTO_START_TASK_NAME,
                 TaskCreationFlags::CreateOrUpdate as i32,
             )?;
 
@@ -361,9 +397,53 @@ impl AutoLauncher {
     }
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn windows_admin_auto_start_delete_args() -> [&'static str; 4] {
+    ["/Delete", "/TN", WINDOWS_ADMIN_AUTO_START_TASK_NAME, "/F"]
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_missing_admin_auto_start_task_error(output: &str) -> bool {
+    let output = output.to_ascii_lowercase();
+    output.contains("cannot find")
+        || output.contains("does not exist")
+        || output.contains("not found")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_admin_auto_start_task_errors_are_idempotent() {
+        assert!(is_missing_admin_auto_start_task_error(
+            "ERROR: The system cannot find the file specified."
+        ));
+        assert!(is_missing_admin_auto_start_task_error(
+            "ERROR: The specified task name \"Tari Universe startup\" does not exist in the system."
+        ));
+        assert!(is_missing_admin_auto_start_task_error(
+            "ERROR: The scheduled task was not found."
+        ));
+    }
+
+    #[test]
+    fn delete_args_target_the_admin_auto_start_task() {
+        assert_eq!(
+            windows_admin_auto_start_delete_args(),
+            ["/Delete", "/TN", "Tari Universe startup", "/F",]
+        );
+    }
+
+    #[test]
+    fn non_missing_admin_auto_start_task_errors_are_not_ignored() {
+        assert!(!is_missing_admin_auto_start_task_error(
+            "ERROR: Access is denied."
+        ));
+        assert!(!is_missing_admin_auto_start_task_error(
+            "ERROR: Invalid argument/option - '/TN'."
+        ));
+    }
 
     #[test]
     fn quote_windows_path_wraps_paths_with_spaces() {

--- a/src-tauri/src/auto_launcher.rs
+++ b/src-tauri/src/auto_launcher.rs
@@ -173,7 +173,8 @@ impl AutoLauncher {
                 CurrentOperatingSystem::Windows => {
                     #[cfg(target_os = "windows")]
                     {
-                        let admin_auto_launcher_result = self.toggle_windows_admin_auto_launcher(false).await;
+                        let admin_auto_launcher_result =
+                            self.toggle_windows_admin_auto_launcher(false).await;
                         auto_launcher.disable()?;
                         admin_auto_launcher_result.inspect_err(|e| {
                             warn!(target: LOG_TARGET_APP_LOGIC, "Failed to disable admin auto-launcher: {}", e)


### PR DESCRIPTION
## Description

Fixes #3306.

Disabling Windows auto-start now deletes the elevated `Tari Universe startup` scheduled task instead of re-registering it with a disabled trigger.

The normal auto-launch registry cleanup still runs as before. The admin scheduled-task delete path now checks for idempotency by querying the task after a failed delete instead of parsing localized `schtasks` output.

## Motivation and Context

The previous disable path called `create_task_scheduler_for_admin_startup(false)`, which used `TaskCreationFlags::CreateOrUpdate` and left the task behind with only the logon trigger disabled. That made disabling admin auto-start asymmetric with the regular Run-key auto-start cleanup.

## How Has This Been Tested?

- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked auto_launcher`
- `cargo check --locked`

Additional note: I attempted `cargo check --locked --target x86_64-pc-windows-msvc`, but this local macOS toolchain does not have that Rust target installed (`E0463: can't find crate for core`). The shared command-argument helpers are covered by the focused tests, and the delete path now uses `schtasks /Query` after delete failure to avoid localized error-string parsing. I could not run the actual Windows Task Scheduler command from this environment.

## What process can a PR reviewer use to test or verify this change?

On Windows:

1. Enable "start on system startup" in Tari Universe.
2. Confirm both the regular Run-key value and the `Tari Universe startup` scheduled task exist.
3. Disable "start on system startup".
4. Confirm the Run-key value is removed.
5. Confirm `schtasks /Query /TN "Tari Universe startup"` no longer finds the scheduled task.
6. Disable the setting again and confirm it does not error when the scheduled task is already absent.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
