### PR TITLE
fix: case-insensitive process-name pre-filter on Windows

### DIFF
--- a/src-tauri/src/process_adapter.rs
+++ b/src-tauri/src/process_adapter.rs
@@ -180,7 +180,10 @@ pub(crate) trait ProcessAdapter {
         let expected = Self::canonicalized_or_original_path(expected_executable);
 
         for (pid, process) in sys.processes() {
-            if process.name() == binary_name
+            // Case-insensitive name pre-filter on Windows (process/file names
+            // are case-insensitive there); exact elsewhere. The authoritative
+            // check remains the canonicalized executable-path comparison.
+            if Self::paths_are_equivalent(Path::new(process.name()), Path::new(binary_name))
                 && Self::process_executable_matches_canonicalized(&expected, process.exe())
             {
                 return Some(pid.as_u32());


### PR DESCRIPTION
## Summary
`find_process_pid_by_name_and_executable` (used by the pid-file fallback in `kill_previous_instances`) pre-filtered processes with a case-sensitive `process.name() == binary_name` comparison. On Windows, process and file names are case-insensitive, so a casing mismatch (e.g. `xmrig.exe` vs `XMRig.exe`) would skip the matching process and leave a hanging instance.

## Change
Use the existing `paths_are_equivalent` helper for the name pre-filter — case-insensitive on Windows, exact elsewhere (no behavior change on macOS/Linux). The canonicalized executable-path comparison remains the authoritative match.

## Testing
`cargo fmt --check`, `cargo check`, `cargo test -p tari-universe process_adapter` all pass.

Surfaced by automated review on #3308; split out as its own change since it fixes pre-existing code on `main`. Not linked to a bounty.