### PR TITLE
chore: bump tari to v5.4.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -194,12 +194,13 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.4.1"
+version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
 dependencies = [
  "base64ct",
- "blake2",
+ "blake2 0.11.0-rc.6",
+ "cpufeatures 0.3.0",
  "password-hash",
 ]
 
@@ -551,7 +552,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core 0.4.5",
- "bytes 1.11.1",
+ "bytes",
  "futures-util",
  "http",
  "http-body",
@@ -584,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
- "bytes 1.11.1",
+ "bytes",
  "form_urlencoded",
  "futures-util",
  "http",
@@ -617,7 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
- "bytes 1.11.1",
+ "bytes",
  "futures-util",
  "http",
  "http-body",
@@ -637,7 +638,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -666,10 +667,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base58-monero"
@@ -771,7 +794,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -801,6 +833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -871,12 +912,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
@@ -919,12 +954,6 @@ name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -1118,7 +1147,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1173,20 +1202,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -1217,7 +1235,7 @@ version = "4.5.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
 dependencies = [
- "clap 4.5.58",
+ "clap",
 ]
 
 [[package]]
@@ -1244,7 +1262,7 @@ version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
 dependencies = [
- "clap 4.5.58",
+ "clap",
  "roff",
 ]
 
@@ -1265,6 +1283,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cocoa"
@@ -1308,7 +1332,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "memchr",
 ]
 
@@ -1377,6 +1401,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
@@ -1538,15 +1568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,10 +1795,25 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "fiat-crypto",
- "group",
- "rand_core 0.6.4",
+ "fiat-crypto 0.2.9",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "rustcrypto-group",
  "serde",
  "subtle",
  "zeroize",
@@ -1885,6 +1939,26 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "data-url"
@@ -2144,9 +2218,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2408,7 +2493,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2466,18 +2551,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
 
 [[package]]
 name = "enumflags2"
@@ -2619,6 +2692,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -3105,23 +3184,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3329,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -3450,26 +3529,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
-name = "hickory-proto"
-version = "0.26.0-alpha.1"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62d7684f766b0f96344be88c023f9b6650039aea09d526b4974cce302eb61b1"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
- "bytes 1.11.1",
+ "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "rustls",
- "rustls-platform-verifier 0.5.3",
+ "rustls-platform-verifier 0.7.0",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3479,26 +3557,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.26.0-alpha.1"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbab5e26a7f82341145ba1fbd1f1858d0490624fcc46270db2d3c4a101f763f4"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -3507,7 +3619,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3548,7 +3660,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "itoa",
 ]
 
@@ -3558,7 +3670,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "http",
 ]
 
@@ -3568,7 +3680,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -3606,13 +3718,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "h2",
@@ -3664,7 +3785,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -3681,7 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "futures-channel",
  "futures-util",
  "http",
@@ -3740,9 +3861,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
 dependencies = [
  "anyhow",
- "blake2",
+ "blake2 0.10.6",
  "blake3",
- "bytes 1.11.1",
+ "bytes",
  "hex",
  "informalsystems-pbjson",
  "prost 0.13.5",
@@ -3832,12 +3953,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -4025,6 +4140,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -4081,15 +4199,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4134,7 +4243,7 @@ checksum = "bf2a10370b45cd850e64993ccd81d25ea2d4b5b0d0312546e7489fed82064f2e"
 dependencies = [
  "anyhow",
  "borsh",
- "digest",
+ "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
  "ics23",
@@ -4158,7 +4267,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4166,10 +4275,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "jobserver"
@@ -4291,12 +4449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,6 +4522,20 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "bs58",
+ "hkdf",
+ "multihash",
+ "sha2",
+ "thiserror 2.0.18",
+ "tracing",
+]
 
 [[package]]
 name = "libredox"
@@ -4594,6 +4760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4662,18 +4839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
 ]
 
 [[package]]
@@ -4806,15 +4971,15 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "argon2",
  "base64 0.22.1",
  "borsh",
  "log",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rcgen",
  "subtle",
  "tari_common_types",
@@ -4837,25 +5002,26 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
- "bs58 0.5.1",
+ "borsh",
+ "bs58",
  "serde",
 ]
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4943,7 +5109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25218523ad4a171ddda05251669afb788cdc2f0df94082aab856a2b09541c3f"
 dependencies = [
  "base58-monero",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "fixed-hash",
  "hex",
  "hex-literal",
@@ -4960,7 +5126,7 @@ source = "git+https://github.com/tari-project/monero-address-creator.git?rev=612
 dependencies = [
  "base58-monero",
  "crc 1.8.1",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand 0.8.6",
  "sha3",
  "thiserror 1.0.69",
@@ -4999,14 +5165,15 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.14.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
  "byteorder",
  "data-encoding",
+ "libp2p-identity",
+ "multibase",
  "multihash",
  "percent-encoding",
  "serde",
@@ -5016,28 +5183,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "multihash"
-version = "0.16.3"
+name = "multibase"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
- "core2",
- "multihash-derive",
- "unsigned-varint",
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
-name = "multihash-derive"
-version = "0.8.1"
+name = "multihash"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5076,7 +5240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -5096,7 +5260,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -5918,20 +6082,13 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "getrandom 0.4.3",
+ "phc",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -5957,7 +6114,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -6006,6 +6163,17 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -6148,7 +6316,7 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074aae809a0547b32f75030b1980ede0874a4819487d30391aec5e0546922fda"
 dependencies = [
- "clap 4.5.58",
+ "clap",
  "clap_complete",
  "clap_mangen",
  "include-lines",
@@ -6405,6 +6573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6558,7 +6737,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "prost-derive 0.11.9",
 ]
 
@@ -6568,7 +6747,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "prost-derive 0.13.5",
 ]
 
@@ -6578,7 +6757,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "heck 0.4.1",
  "itertools 0.10.5",
  "lazy_static",
@@ -6723,7 +6902,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
@@ -6743,7 +6922,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -6786,6 +6965,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r2d2"
@@ -6846,8 +7031,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6881,6 +7066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,9 +7104,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -7107,7 +7302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "cookie",
  "cookie_store 0.22.0",
  "encoding_rs",
@@ -7158,7 +7353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -7287,7 +7482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccce7bae150b815f0811db41b8312fcb74bffa4cab9cee5429ee00f356dd5bd4"
 dependencies = [
  "aead",
- "digest",
+ "digest 0.10.7",
  "ecdsa",
  "ed25519",
  "generic-array",
@@ -7305,7 +7500,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7316,7 +7511,7 @@ checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "chrono",
  "futures",
  "http",
@@ -7393,6 +7588,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
 ]
 
 [[package]]
@@ -7474,34 +7690,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.5.1",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -7510,7 +7705,28 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.5.1",
  "security-framework-sys",
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
  "windows-sys 0.61.2",
 ]
 
@@ -8034,15 +8250,14 @@ dependencies = [
 
 [[package]]
 name = "serde_valid"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
+checksum = "4b441ba4464f0faf811267a3392ff53e2d9a2f8c4f23941b62ec7c452dd80451"
 dependencies = [
  "indexmap 2.13.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-traits",
  "once_cell",
- "paste",
  "regex",
  "serde",
  "serde_json",
@@ -8054,13 +8269,11 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_derive"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
+checksum = "5cd65e72e4b76575cde962665a131c1c83c2fe1c328c27e2f036a16567fe59af"
 dependencies = [
- "itertools 0.13.0",
- "paste",
- "proc-macro-error2",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "strsim",
@@ -8069,11 +8282,10 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_literal"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
+checksum = "3728389b4f730ec97f933664f5db0731f80b64c3b23ff904a5dec5f93f205ce9"
 dependencies = [
- "paste",
  "regex",
 ]
 
@@ -8196,7 +8408,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8213,7 +8425,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8222,7 +8434,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -8297,6 +8509,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -8374,9 +8602,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
 dependencies = [
  "aes-gcm",
- "blake2",
+ "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "rustc_version",
  "sha2",
@@ -8489,7 +8717,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-util",
  "http-body",
  "http-body-util",
@@ -8571,30 +8799,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -8691,18 +8895,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -8792,7 +8984,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "lazy_static",
  "libc",
  "log",
@@ -8871,7 +9063,7 @@ dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
  "bincode",
- "blake2",
+ "blake2 0.10.6",
  "chrono",
  "console-subscriber",
  "croner",
@@ -8968,29 +9160,30 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e43bc4d522de252647e34e72aef4d5e33f845a6acc23fb7b1f4e877a7f9053"
+checksum = "ed4257cfd0352ab95e186798feaa22f37a7de403e67ff32004c650e19f6bc1d6"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "byteorder",
- "curve25519-dalek",
- "digest",
- "ff",
+ "curve25519-dalek 5.0.0-pre.6",
+ "digest 0.10.7",
+ "getrandom 0.4.3",
  "itertools 0.12.1",
- "merlin",
  "once_cell",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
  "serde",
  "sha3",
+ "tari_merlin",
  "thiserror-no-std",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_common"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -9005,7 +9198,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "structopt",
  "tari_features",
  "tempfile",
  "thiserror 2.0.18",
@@ -9014,14 +9206,14 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "diesel",
  "diesel_migrations",
  "lazy_static",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_utilities",
@@ -9031,25 +9223,26 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "argon2",
  "base64 0.22.1",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "bs58 0.5.1",
+ "bs58",
  "chacha20 0.7.3",
  "chacha20poly1305",
  "crc32fast",
- "digest",
+ "digest 0.10.7",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "js-sys",
  "newtype-ops",
  "once_cell",
  "primitive-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "strum 0.22.0",
@@ -9067,21 +9260,21 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 2.10.0",
- "blake2",
- "bytes 1.11.1",
+ "blake2 0.10.6",
+ "bytes",
  "chrono",
  "cidr",
  "data-encoding",
  "derivative",
  "diesel",
  "diesel_migrations",
- "digest",
+ "digest 0.10.7",
  "futures",
  "local-ip-address",
  "log",
@@ -9090,7 +9283,7 @@ dependencies = [
  "once_cell",
  "pin-project 1.1.10",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9114,24 +9307,24 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "chacha20 0.7.3",
  "chacha20poly1305",
  "chrono",
  "diesel",
  "diesel_migrations",
- "digest",
+ "digest 0.10.7",
  "futures",
  "futures-util",
  "log",
  "pin-project 0.4.30",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -9148,8 +9341,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9158,17 +9351,16 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "chacha20poly1305",
  "chrono",
- "digest",
+ "digest 0.10.7",
  "dirs-next",
  "fs2",
  "futures",
@@ -9182,7 +9374,7 @@ dependencies = [
  "once_cell",
  "primitive-types",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "randomx-rs",
  "serde",
  "serde_json",
@@ -9220,18 +9412,17 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74b1ee79be37e04fcdb307b2809e658f19e05f31a2b5263c128fc3a5e2dee16"
+checksum = "5f139af279824e2e0925b169319397646c5e6c1e622b62548588e609eeef9c45"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "curve25519-dalek",
- "digest",
+ "curve25519-dalek 5.0.0-pre.6",
+ "digest 0.10.7",
  "log",
- "merlin",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "sha3",
  "snafu",
@@ -9243,27 +9434,27 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 
 [[package]]
 name = "tari_hashing"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "digest",
+ "digest 0.10.7",
  "tari_crypto",
 ]
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "borsh",
- "digest",
+ "digest 0.10.7",
  "indexmap 2.13.0",
  "serde",
  "tari_crypto",
@@ -9273,8 +9464,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "borsh",
  "serde",
@@ -9283,12 +9474,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_merlin"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3a83eb69bafaa639abc3573614acaa47abd1fc9fc35d12cab2df8e45352b83"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
 name = "tari_mmr"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "borsh",
- "digest",
+ "digest 0.10.7",
  "serde",
  "tari_crypto",
  "tari_utilities",
@@ -9297,13 +9500,14 @@ dependencies = [
 
 [[package]]
 name = "tari_node_components"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "chrono",
- "digest",
+ "digest 0.10.7",
+ "getrandom 0.2.17",
  "js-sys",
  "primitive-types",
  "serde",
@@ -9316,8 +9520,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "futures",
@@ -9325,7 +9529,7 @@ dependencies = [
  "hickory-resolver",
  "log",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_common",
  "tari_common_sqlite",
@@ -9342,12 +9546,12 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "digest",
+ "digest 0.10.7",
  "integer-encoding",
  "serde",
  "sha2",
@@ -9360,8 +9564,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9375,16 +9579,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "borsh",
  "hex",
@@ -9400,8 +9604,8 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -9412,12 +9616,11 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "futures",
- "rand 0.8.6",
- "tari_comms",
+ "rand 0.10.1",
  "tari_shutdown",
  "tempfile",
  "tokio",
@@ -9425,20 +9628,20 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.2.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.2.1#c79f5557b1d214cdca7b4e52f02ddb729600e7cd"
+version = "5.4.0-rc.1"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitflags 2.10.0",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
- "bytes 0.5.6",
+ "bytes",
  "chacha20poly1305",
  "chrono",
  "decimal-rs",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "integer-encoding",
  "log",
  "minotari_ledger_wallet_common",
@@ -9447,7 +9650,7 @@ dependencies = [
  "num-format",
  "num-traits",
  "primitive-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "semver",
  "serde",
  "serde_json",
@@ -9463,7 +9666,6 @@ dependencies = [
  "tari_sidechain",
  "tari_utilities",
  "thiserror 2.0.18",
- "tokio",
  "utoipa",
  "uuid",
  "zeroize",
@@ -9471,9 +9673,9 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539470532a8ca1a8a1aa26f6240586f7d0f7d90ab94ae67f092bcd75a1bb4060"
+checksum = "59020053bb363474087e5b170acbf0e1a848b1af5736e058a0332ce69b6dbf9e"
 dependencies = [
  "base58-monero",
  "base64 0.13.1",
@@ -9495,7 +9697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463ae8677aa6d0f063a900b9c41ecd4ac2b7ca82f0b058cc4491540e55b20129"
 dependencies = [
  "anyhow",
- "bytes 1.11.1",
+ "bytes",
  "cookie",
  "dirs 6.0.0",
  "dunce",
@@ -9507,7 +9709,7 @@ dependencies = [
  "http",
  "http-range",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -9629,7 +9831,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e78fb2c09a81546bcd376d34db4bda5769270d00990daa9f0d6e7ac1107e25"
 dependencies = [
- "clap 4.5.58",
+ "clap",
  "log",
  "serde",
  "serde_json",
@@ -9699,7 +9901,7 @@ version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f069451c4e87e7e2636b7f065a4c52866c4ce5e60e2d53fa1038edb6d184dc"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "cookie_store 0.21.1",
  "data-url",
  "http",
@@ -9840,7 +10042,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -9863,7 +10065,7 @@ checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -9941,7 +10143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -9995,15 +10197,6 @@ dependencies = [
  "quote",
  "syn 2.0.115",
  "test-case-core",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -10170,7 +10363,7 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "libc",
  "mio",
  "parking_lot 0.12.5",
@@ -10256,7 +10449,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -10271,7 +10464,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -10402,7 +10595,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.9",
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "h2",
  "http",
  "http-body",
@@ -10431,7 +10624,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.8",
  "base64 0.22.1",
- "bytes 1.11.1",
+ "bytes",
  "h2",
  "http",
  "http-body",
@@ -10514,7 +10707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -10640,7 +10833,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "data-encoding",
  "http",
  "httparse",
@@ -10669,9 +10862,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds"
@@ -10783,12 +10976,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10800,7 +10987,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -10821,9 +11008,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -11044,15 +11231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11118,28 +11296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11178,18 +11334,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
 ]
 
 [[package]]
@@ -11324,15 +11468,6 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
@@ -12078,88 +12213,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.13.0",
- "prettyplease 0.2.37",
- "syn 2.0.115",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease 0.2.37",
- "proc-macro2",
- "quote",
- "syn 2.0.115",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.10.0",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -12215,7 +12268,7 @@ dependencies = [
  "html5ever",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",
@@ -12353,7 +12406,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -12518,7 +12571,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,8 +51,8 @@ keyring = { version = "3.0.5", features = [
 ] }
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
-minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -83,12 +83,12 @@ starship-battery = "0.10.3"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
-tari_crypto = "0.22.1"
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.2.1" }
-tari_utilities = "0.8.0"
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_crypto = "0.23.1"
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_utilities = "0.10.0"
 tauri = { version = "2", features = [
   "protocol-asset",
   "isolation",

--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.2.1 | c79f555",
-        "mmproxy": "5.2.1 | c79f555",
+        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
+        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.2.1 | c79f555",
+        "wallet": "5.4.0-rc.1 | ae9ccf0",
         "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.2.1 | c79f555",
-        "mmproxy": "5.2.1 | c79f555",
+        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
+        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.2.1 | c79f555",
+        "wallet": "5.4.0-rc.1 | ae9ccf0",
         "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.2.1 | c79f555",
-        "mmproxy": "5.2.1 | c79f555",
+        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
+        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.2.1 | c79f555",
+        "wallet": "5.4.0-rc.1 | ae9ccf0",
         "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/src/node/node_adapter.rs
+++ b/src-tauri/src/node/node_adapter.rs
@@ -714,6 +714,7 @@ impl From<ReadinessStatus> for minotari_node_grpc_client::grpc::ReadinessStatus 
                     progress_percentage: migration.progress_percentage,
                     current_db_version: migration.current_db_version,
                     target_db_version: migration.target_db_version,
+                    phase: minotari_node_grpc_client::grpc::MigrationPhase::Unspecified as i32,
                 };
                 minotari_node_grpc_client::grpc::readiness_status::Status::Migration(
                     migration_proto,


### PR DESCRIPTION
## Description

Bumps the `tari-project/tari` dependencies and the bundled node/wallet binaries from v5.2.1 to v5.4.0-rc.1.

What's in here:

- **Cargo deps:** the six tari git deps move to v5.4.0-rc.1. `tari_crypto` goes 0.22.1 -> 0.23.1 and `tari_utilities` 0.8.0 -> 0.10.0, because that's the crypto stack 5.4 pulls in and mixing versions doesn't compile.
- **binaries-versions:** `minotari_node`, `mmproxy`, and `wallet` move to `5.4.0-rc.1 | ae9ccf0` for mainnet, nextnet, and testnets.
- **node_adapter:** 5.4 added a `phase` field to the `MigrationProgress` gRPC message, so the local-to-proto conversion sets it.

## Motivation and Context

We're three releases behind on tari core, still pinned to v5.2.1.

Two things worth knowing about why this lands on an rc:

- 5.3.x is a dead end for us. The whole 5.3.x line (5.3.0 and 5.3.1) shipped without macOS binaries, so the app can't download a node or wallet on Mac. macOS builds come back in v5.4.0-rc.1.
- v5.4.0 isn't stable yet. The rc is the earliest tag that both compiles and has macOS binaries.

Heads up on nextnet: tari only publishes `esme` and `mainnet` builds. There's no nextnet binary at any version, so the nextnet pin is cosmetic and won't download regardless of what we name. I bumped it anyway so the three files stay consistent.

## How Has This Been Tested?

- rc.1: `cargo build` clean, and `cargo fmt --check`, `cargo lints clippy --all-targets --all-features`, and `cargo machete` all pass.
- Full app run was done on rc.0 (this bump started there before rc.1 landed). On esmeralda the node/wallet/mmproxy binaries downloaded, passed checksum validation, and every setup phase (Core, Node, Wallet, CPU, GPU) completed. The node synced and the wallet loaded its balance. rc.1 is the same bump with only the version and commit hash changed, and it compiles clean, but I have not re-run the full app download/sync on rc.1 specifically.

## What process can a PR reviewer use to test or verify this change?

- Build and run on macOS, the platform 5.3.x couldn't serve.
- Watch the logs for the download. You should see it pull `tari_suite-5.4.0-rc.1-<network>-ae9ccf0-<platform>.zip`, pass checksum validation, and start the node.
- Confirm the node syncs and the wallet loads.
- One thing I did not test: starting over an existing v5.2.1 data directory. 5.4 carries an on-disk DB migration (that's what the new `MigrationProgress.phase` reports), so first run on an old data dir may kick off that migration. Worth a look from someone with a populated 5.2.1 profile.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
