### PR TITLE
chore(deps): bump rmcp from 0.15 to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2218,7 +2218,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2524,7 +2524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3711,7 +3711,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5771,7 +5771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6600,7 +6600,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -7310,12 +7310,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.15.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
  "base64 0.22.1",
  "bytes 1.11.1",
  "chrono",
@@ -7325,7 +7324,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -7342,9 +7341,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7433,7 +7432,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7512,7 +7511,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9945,7 +9944,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11456,7 +11455,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,7 +65,7 @@ reqwest = { version = "0.12.5", features = ["stream", "json", "multipart"] }
 reqwest-middleware = "0.4.0"
 reqwest-retry = "0.7.0"
 ring = "0.17.8"
-rmcp = { version = "0.15", features = [
+rmcp = { version = "2.0", features = [
   "server",
   "macros",
   "transport-streamable-http-server",

--- a/src-tauri/src/mcp/tools/mod.rs
+++ b/src-tauri/src/mcp/tools/mod.rs
@@ -55,9 +55,12 @@ pub struct TariMcpHandler {
 }
 
 // rmcp 2.0's `#[tool_handler]` defaults to rebuilding the router via
-// `Self::tool_router()`; point it at the prebuilt field so it's constructed
-// once and cloned per request (and to keep the `tool_router` field live).
-#[tool_handler(router = self.tool_router.clone())]
+// `Self::tool_router()`; point it at the prebuilt field by reference so it's
+// constructed once and borrowed per request (and to keep the `tool_router`
+// field live). ToolRouter::{call,list_all,get} all take `&self`. The parens
+// are required: the macro expands `#router.call(..)`, so a bare
+// `&self.tool_router` would bind `&` to the call result, not the field.
+#[tool_handler(router = (&self.tool_router))]
 impl ServerHandler for TariMcpHandler {
     fn get_info(&self) -> ServerInfo {
         // rmcp 2.0 marked ServerInfo (InitializeResult) and Implementation as

--- a/src-tauri/src/mcp/tools/mod.rs
+++ b/src-tauri/src/mcp/tools/mod.rs
@@ -54,28 +54,27 @@ pub struct TariMcpHandler {
     wallet_manager: WalletManager,
 }
 
-#[tool_handler]
+// rmcp 2.0's `#[tool_handler]` defaults to rebuilding the router via
+// `Self::tool_router()`; point it at the prebuilt field so it's constructed
+// once and cloned per request (and to keep the `tool_router` field live).
+#[tool_handler(router = self.tool_router.clone())]
 impl ServerHandler for TariMcpHandler {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2025_03_26,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "tari-universe".to_string(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                title: Some("Tari Universe MCP Server".to_string()),
-                description: Some(
-                    "MCP server for controlling mining, querying wallet state, and reading chain data."
-                        .to_string(),
-                ),
-                website_url: None,
-                icons: None,
-            },
-            instructions: Some(
-                "Tari Universe MCP server. Available tool categories: mining (start/stop/mode), wallet (address/balance), chain (block height/sync status), and scheduler (scheduled mining events). Use get_mining_status, get_wallet_address, and get_chain_status to get an overview."
-                    .to_string(),
-            ),
-        }
+        // rmcp 2.0 marked ServerInfo (InitializeResult) and Implementation as
+        // #[non_exhaustive], so they must be built via constructors + `with_*`
+        // setters rather than struct literals.
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2025_03_26)
+            .with_server_info(
+                Implementation::new("tari-universe", env!("CARGO_PKG_VERSION"))
+                    .with_title("Tari Universe MCP Server")
+                    .with_description(
+                        "MCP server for controlling mining, querying wallet state, and reading chain data.",
+                    ),
+            )
+            .with_instructions(
+                "Tari Universe MCP server. Available tool categories: mining (start/stop/mode), wallet (address/balance), chain (block height/sync status), and scheduler (scheduled mining events). Use get_mining_status, get_wallet_address, and get_chain_status to get an overview.",
+            )
     }
 }
 


### PR DESCRIPTION
## What

Bumps `rmcp` (the MCP Rust SDK) from **0.15.0 → 2.0.0** and adapts our MCP server to the 2.0 breaking changes. Supersedes Dependabot's plain version bump in #3310 (which fails to compile on its own).

## Breaking changes handled

All fallout is contained to `src-tauri/src/mcp/tools/mod.rs`:

1. **`ServerInfo` (`InitializeResult`) and `Implementation` are now `#[non_exhaustive]`** (spec alignment + new `_meta` field), so they can't be built with struct literals anymore. `get_info()` now uses the constructors + `with_*` builders:
   ```rust
   ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
       .with_protocol_version(ProtocolVersion::V_2025_03_26)
       .with_server_info(
           Implementation::new("tari-universe", env!("CARGO_PKG_VERSION"))
               .with_title("Tari Universe MCP Server")
               .with_description("..."),
       )
       .with_instructions("...")
   ```

2. **`#[tool_handler]` changed its default** from reading the `self.tool_router` field to rebuilding via `Self::tool_router()`, which left the field dead (`field is never read` → fails CI under `-D warnings`). Pinned it back to the prebuilt field so the router is built once and cloned per request:
   ```rust
   #[tool_handler(router = self.tool_router.clone())]
   ```

Everything else (transport, `StreamableHttpService`, `LocalSessionManager`, `Parameters`, the `#[tool]` macros, `Result<String, String>` returns) is source-compatible.

## Why not just merge #3310

Dependabot only edits `Cargo.toml`/`Cargo.lock`, so it leaves two `E0639` compile errors. This PR includes the code changes to actually build.

## Testing

- `cargo check` — 0 errors, 0 warnings
- `cargo fmt --check` — clean
- **End-to-end against a live MCP client** on the built app: `initialize` returns the expected `serverInfo`/capabilities/instructions, `tools/list` returns all 16 tools, and tool calls succeed across the read/control tiers with correct gating on the disabled transaction tier.

## Notes

- 2.0 also pulls in upstream security fixes we currently lack: OAuth resource-spoofing/SSRF guards and a streamable-HTTP session-leak fix.
- Unused 2.0 breaking changes (roots/sampling/logging deprecation, `Audio` prompt variant, `structuredContent` type) don't affect us — we only `enable_tools()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)