### PR TITLE
ci: notarize macOS via App Store Connect API key

### DIFF
--- a/.github/workflows/release-exchange.yml
+++ b/.github/workflows/release-exchange.yml
@@ -244,6 +244,12 @@ jobs:
             cargo build --release --manifest-path process-wrapper/Cargo.toml
           fi
 
+      - name: Prepare macOS notary API key
+        if: ${{ startsWith(runner.os, 'macOS') }}
+        env:
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: printf '%s' "$MACOS_NOTARY_KEY" > "$RUNNER_TEMP/notary_key.p8"
+
       - name: Build Tauri Apps
         id: build
         uses: tauri-apps/tauri-action@v0
@@ -253,9 +259,9 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notary_key.p8
           AZURE_TENANT_ID: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,12 @@ jobs:
             cargo build --release --manifest-path process-wrapper/Cargo.toml
           fi
 
+      - name: Prepare macOS notary API key
+        if: ${{ startsWith(runner.os, 'macOS') }}
+        env:
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: printf '%s' "$MACOS_NOTARY_KEY" > "$RUNNER_TEMP/notary_key.p8"
+
       - name: Build Tauri Apps
         id: build
         uses: tauri-apps/tauri-action@v0
@@ -360,9 +366,9 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_ISSUER: ${{ secrets.MACOS_NOTARY_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notary_key.p8
           AZURE_TENANT_ID: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ startsWith(runner.os,'Windows') && secrets.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
## Problem

macOS notarization in `release.yml` and `release-exchange.yml` authenticated as an **individual team member's Apple ID** via Tauri's `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`. That identity has to remain a member of the Apple developer team. When the member is removed, notarization fails with:

```
HTTP status code: 403. Invalid or inaccessible developer team ID for the
provided Apple ID. Ensure the Team ID is correct and that you are a member
of that team.
```

(Same root cause just fixed in tari-core [#7913](https://github.com/tari-project/tari/pull/7913). The old `APPLE_ID`/`APPLE_PASSWORD`/`APPLE_TEAM_ID` secrets were already dead and have been removed from this repo.)

## Fix

Switch to a **team-scoped App Store Connect API key** (survives membership changes):

- New step writes the `.p8` (`MACOS_NOTARY_KEY`) to the runner temp dir on macOS.
- `tauri-action` gets `APPLE_API_ISSUER` / `APPLE_API_KEY` / `APPLE_API_KEY_PATH` instead of the Apple-ID trio.
- Code-signing (`APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` / `APPLE_SIGNING_IDENTITY`) is unchanged.

## Required repo secrets (already set)

| Secret | Value |
|---|---|
| `MACOS_NOTARY_KEY` | `.p8` API key contents |
| `MACOS_NOTARY_KEY_ID` | Key ID → `APPLE_API_KEY` |
| `MACOS_NOTARY_ISSUER` | Issuer ID → `APPLE_API_ISSUER` |