### PR TITLE
feat: add show window on startup setting

### DIFF
--- a/playwright/helpers/global-setup.ts
+++ b/playwright/helpers/global-setup.ts
@@ -96,6 +96,9 @@ function getCoreConfig() {
     auto_update: false,
     pre_release: false,
     should_auto_launch: false,
+    // Keep the neutralized headless webview hidden — frontend_ready would
+    // otherwise show() the blank.html window during e2e runs.
+    show_window_on_startup: false,
     remote_base_node_address: 'http://127.0.0.1:18142',
   };
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -207,6 +207,10 @@
     "description": "When enabled, the app will start automatically when you log in to your computer.",
     "title": "Auto-start on system boot"
   },
+  "show-window-on-startup": {
+    "description": "When enabled, Tari Universe will show its main window after startup. Turn this off to launch to the task tray.",
+    "title": "Show window on startup"
+  },
   "should-use-system-language": "Use system language",
   "stable-version-note": "By turning off the pre-release version of the application, you will revert to the stable release, which prioritizes reliability and consistency. While you may miss out on the latest features and enhancements.",
   "stats-server-port": "Stats server port",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -184,6 +184,19 @@ pub async fn frontend_ready(
     EventsEmitter::load_app_handle(app.clone()).await;
     FrontendReadyChannel::current().set_ready();
 
+    if *ConfigCore::content().await.show_window_on_startup() {
+        match app.get_webview_window("main") {
+            Some(window) => {
+                if let Err(err) = window.show() {
+                    error!(target: LOG_TARGET_APP_LOGIC, "Couldn't show the main window on startup {err:?}");
+                }
+            }
+            None => {
+                error!(target: LOG_TARGET_APP_LOGIC, "Could not find main window to show on startup");
+            }
+        }
+    }
+
     let state_inner = state.inner().clone();
 
     TasksTrackers::current()
@@ -1256,6 +1269,18 @@ pub async fn set_should_auto_launch(should_auto_launch: bool) -> Result<(), Invo
         .update_auto_launcher(should_auto_launch)
         .await
         .map_err(InvokeError::from_anyhow)?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_show_window_on_startup(show_window_on_startup: bool) -> Result<(), InvokeError> {
+    ConfigCore::update_field(
+        ConfigCoreContent::set_show_window_on_startup,
+        show_window_on_startup,
+    )
+    .await
+    .map_err(InvokeError::from_anyhow)?;
 
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -184,7 +184,21 @@ pub async fn frontend_ready(
     EventsEmitter::load_app_handle(app.clone()).await;
     FrontendReadyChannel::current().set_ready();
 
-    if *ConfigCore::content().await.show_window_on_startup() {
+    let is_headless = {
+        #[cfg(feature = "test-mode")]
+        {
+            use tauri_plugin_cli::CliExt;
+            app.cli().matches().as_ref().is_ok_and(|m| {
+                m.args
+                    .get("headless")
+                    .is_some_and(|arg| arg.occurrences > 0)
+            })
+        }
+        #[cfg(not(feature = "test-mode"))]
+        false
+    };
+
+    if !is_headless && *ConfigCore::content().await.show_window_on_startup() {
         match app.get_webview_window("main") {
             Some(window) => {
                 if let Err(err) = window.show() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -184,21 +184,7 @@ pub async fn frontend_ready(
     EventsEmitter::load_app_handle(app.clone()).await;
     FrontendReadyChannel::current().set_ready();
 
-    let is_headless = {
-        #[cfg(feature = "test-mode")]
-        {
-            use tauri_plugin_cli::CliExt;
-            app.cli().matches().as_ref().is_ok_and(|m| {
-                m.args
-                    .get("headless")
-                    .is_some_and(|arg| arg.occurrences > 0)
-            })
-        }
-        #[cfg(not(feature = "test-mode"))]
-        false
-    };
-
-    if !is_headless && *ConfigCore::content().await.show_window_on_startup() {
+    if *ConfigCore::content().await.show_window_on_startup() {
         match app.get_webview_window("main") {
             Some(window) => {
                 if let Err(err) = window.show() {

--- a/src-tauri/src/configs/config_core.rs
+++ b/src-tauri/src/configs/config_core.rs
@@ -77,6 +77,7 @@ pub struct ConfigCoreContent {
     exchange_id: String,
     scheduler_events: HashMap<String, ScheduledEventInfo>,
     shutdown_mode: ShutdownMode,
+    show_window_on_startup: bool,
     node_data_directory: Option<PathBuf>,
 }
 
@@ -137,6 +138,7 @@ impl Default for ConfigCoreContent {
             exchange_id: DEFAULT_EXCHANGE_ID.to_string(),
             scheduler_events: HashMap::new(),
             shutdown_mode: ShutdownMode::Tasktray,
+            show_window_on_startup: true,
             node_data_directory: None,
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -475,6 +475,7 @@ fn main() {
             commands::confirm_exchange_address,
             commands::select_exchange_miner,
             commands::set_show_experimental_settings,
+            commands::set_show_window_on_startup,
             commands::set_should_always_use_system_language,
             commands::set_should_auto_launch,
             commands::set_tor_config,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -96,7 +96,7 @@
                 "resizable": true,
                 "fullscreen": false,
                 "transparent": false,
-                "visible": true,
+                "visible": false,
                 "center": true,
                 "useHttpsScheme": true,
                 "width": 1280,

--- a/src/containers/floating/Settings/sections/general/GeneralSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import LogsSettings from './LogsSettings.tsx';
 import LanguageSettings from './LanguageSettings.tsx';
 import { ResetSettingsButton } from './ResetSettingsButton.tsx';
 import StartApplicationOnBootSettings from './StartApplicationOnBootSettings.tsx';
+import ShowWindowOnStartupSettings from './ShowWindowOnStartupSettings.tsx';
 import AutoUpdate from './AutoUpdate.tsx';
 import PreReleaseSettings from './PreReleaseSettings.tsx';
 import VisualMode from '@app/containers/main/Dashboard/components/VisualMode.tsx';
@@ -17,6 +18,7 @@ export const GeneralSettings = () => {
     return (
         <>
             <StartApplicationOnBootSettings />
+            <ShowWindowOnStartupSettings />
             <AutoUpdate />
             <PreReleaseSettings />
             <TaskTrayModeSettings />

--- a/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
@@ -1,0 +1,37 @@
+import { Typography } from '@app/components/elements/Typography.tsx';
+import { ToggleSwitch } from '@app/components/elements/inputs/switch/ToggleSwitch';
+import { setShowWindowOnStartup } from '@app/store/actions/config/core.ts';
+import { useConfigCoreStore } from '@app/store/stores/config/useConfigCoreStore.ts';
+import { useTranslation } from 'react-i18next';
+import {
+    SettingsGroup,
+    SettingsGroupAction,
+    SettingsGroupContent,
+    SettingsGroupTitle,
+    SettingsGroupWrapper,
+} from '../../components/SettingsGroup.styles';
+
+export default function ShowWindowOnStartupSettings() {
+    const { t } = useTranslation(['settings'], { useSuspense: false });
+    const showWindowOnStartup = useConfigCoreStore((s) => s.show_window_on_startup);
+
+    return (
+        <SettingsGroupWrapper>
+            <SettingsGroup>
+                <SettingsGroupContent>
+                    <SettingsGroupTitle>
+                        <Typography variant="h6">{t('show-window-on-startup.title')}</Typography>
+                    </SettingsGroupTitle>
+                    <Typography variant="p">{t('show-window-on-startup.description')}</Typography>
+                </SettingsGroupContent>
+                <SettingsGroupAction>
+                    <ToggleSwitch
+                        data-testid="settings-toggle-show-window-on-startup"
+                        checked={showWindowOnStartup}
+                        onChange={(event) => setShowWindowOnStartup(event.target.checked)}
+                    />
+                </SettingsGroupAction>
+            </SettingsGroup>
+        </SettingsGroupWrapper>
+    );
+}

--- a/src/store/actions/config/core.test.ts
+++ b/src/store/actions/config/core.test.ts
@@ -89,6 +89,19 @@ describe('core config actions', () => {
             expect(state.should_auto_launch).toBe(false);
         });
 
+        it('setShowWindowOnStartup follows optimistic update pattern', () => {
+            let state = { show_window_on_startup: true };
+            const showWindowOnStartup = false;
+
+            // Optimistic update
+            state = { ...state, show_window_on_startup: showWindowOnStartup };
+            expect(state.show_window_on_startup).toBe(false);
+
+            // Rollback on error
+            state = { ...state, show_window_on_startup: !showWindowOnStartup };
+            expect(state.show_window_on_startup).toBe(true);
+        });
+
         it('setUseTor follows optimistic update pattern', () => {
             let state = { use_tor: false };
             const useTor = true;

--- a/src/store/actions/config/core.ts
+++ b/src/store/actions/config/core.ts
@@ -136,6 +136,15 @@ export const setShouldAutoLaunch = async (shouldAutoLaunch: boolean) => {
     });
 };
 
+export const setShowWindowOnStartup = async (showWindowOnStartup: boolean) => {
+    store.setState((c) => ({ ...c, show_window_on_startup: showWindowOnStartup }));
+    invoke('set_show_window_on_startup', { showWindowOnStartup }).catch((e) => {
+        console.error('Could not set show window on startup', e);
+        setError('Could not change startup window setting');
+        store.setState((c) => ({ ...c, show_window_on_startup: !showWindowOnStartup }));
+    });
+};
+
 export const setSchedulerEvents = async (newEvent: SchedulerEvent) => {
     const initialState = store.getState().scheduler_events;
     const updated = { ...initialState, [newEvent.id]: newEvent };

--- a/src/store/stores/config/useConfigCoreStore.test.ts
+++ b/src/store/stores/config/useConfigCoreStore.test.ts
@@ -18,6 +18,7 @@ describe('useConfigCoreStore', () => {
             pre_release: false,
             remote_base_node_address: '',
             should_auto_launch: false,
+            show_window_on_startup: true,
             use_tor: false,
             scheduler_events: null,
             shutdown_mode: ShutdownMode.Tasktray,
@@ -41,6 +42,10 @@ describe('useConfigCoreStore', () => {
 
         it('has should_auto_launch as false by default', () => {
             expect(initialState.should_auto_launch).toBe(false);
+        });
+
+        it('has show_window_on_startup as true by default', () => {
+            expect(initialState.show_window_on_startup).toBe(true);
         });
 
         it('has use_tor as false by default', () => {

--- a/src/store/stores/config/useConfigCoreStore.ts
+++ b/src/store/stores/config/useConfigCoreStore.ts
@@ -21,5 +21,6 @@ const initialState: ConfigCore = {
     use_tor: false,
     scheduler_events: null,
     shutdown_mode: ShutdownMode.Tasktray,
+    show_window_on_startup: true,
 };
 export const useConfigCoreStore = create<ConfigCore>()(() => ({ ...initialState }));

--- a/src/types/config/core.ts
+++ b/src/types/config/core.ts
@@ -21,6 +21,7 @@ export interface ConfigCore {
     remote_base_node_address: string;
     scheduler_events?: Record<string, SchedulerEvent> | null;
     should_auto_launch: boolean;
+    show_window_on_startup: boolean;
     use_tor: boolean;
     shutdown_mode: ShutdownMode;
     node_data_directory?: string;

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -26,6 +26,7 @@ declare module '@tauri-apps/api/core' {
     ): Promise<void>;
     function invoke(param: 'get_application_language'): Promise<string>;
     function invoke(param: 'set_should_auto_launch', payload: { shouldAutoLaunch: boolean }): Promise<void>;
+    function invoke(param: 'set_show_window_on_startup', payload: { showWindowOnStartup: boolean }): Promise<void>;
     function invoke(param: 'set_application_language', payload: { applicationLanguage: Language }): Promise<void>;
     function invoke(param: 'frontend_ready'): Promise<void>;
     function invoke(param: 'download_and_start_installer', payload: { id: string }): Promise<void>;


### PR DESCRIPTION
Fixes #3279

## Summary
- Start the main Tauri window hidden at creation time.
- Add a default-on persisted `show_window_on_startup` core config setting.
- Show the main window from the existing `frontend_ready` signal only when the setting is enabled.
- Add a General settings toggle so users can choose whether Tari Universe shows the main window on startup or launches to the tray.

## Root cause
The main window visibility was controlled only by `src-tauri/tauri.conf.json`, where the main window was created with `"visible": true`. That made the window appear unconditionally at startup and left no runtime setting for launch-to-tray behavior.

## Tests
- `corepack pnpm exec vitest run src/store/stores/config/useConfigCoreStore.test.ts src/store/actions/config/core.test.ts`
- `corepack pnpm exec prettier --check src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx src/containers/floating/Settings/sections/general/GeneralSettings.tsx src/store/actions/config/core.ts src/store/stores/config/useConfigCoreStore.ts src/types/config/core.ts src/types/invoke.d.ts public/locales/en/settings.json src/store/stores/config/useConfigCoreStore.test.ts src/store/actions/config/core.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `cargo fmt --check`
- `cargo build -p process-wrapper`
- `cargo check --message-format short`

## Notes
- Existing default behavior is preserved because `show_window_on_startup` defaults to `true`.
- Turning the setting off skips only the initial frontend-ready window show; tray and single-instance behavior remain intact.
- Manual runtime QA for tray reachability/no flash was not run locally because the existing Playwright/Tauri harness launches a localnet backend with seeded wallet config and the broader suite includes mining flows.