### PR TITLE
Add show window on startup setting

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -207,6 +207,10 @@
     "description": "When enabled, the app will start automatically when you log in to your computer.",
     "title": "Auto-start on system boot"
   },
+  "show-window-on-startup": {
+    "description": "When enabled, Tari Universe opens its main window after startup. Turn this off to launch directly to the task tray.",
+    "title": "Show window on startup"
+  },
   "should-use-system-language": "Use system language",
   "stable-version-note": "By turning off the pre-release version of the application, you will revert to the stable release, which prioritizes reliability and consistency. While you may miss out on the latest features and enhancements.",
   "stats-server-port": "Stats server port",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -184,6 +184,19 @@ pub async fn frontend_ready(
     EventsEmitter::load_app_handle(app.clone()).await;
     FrontendReadyChannel::current().set_ready();
 
+    if *ConfigUI::content().await.show_window_on_startup() {
+        match app.get_webview_window("main") {
+            Some(window) => {
+                if let Err(error) = window.show() {
+                    error!(target: LOG_TARGET_APP_LOGIC, "Could not show main window on startup: {error:?}");
+                }
+            }
+            None => {
+                error!(target: LOG_TARGET_APP_LOGIC, "Could not find main window to show on startup");
+            }
+        }
+    }
+
     let state_inner = state.inner().clone();
 
     TasksTrackers::current()
@@ -1219,6 +1232,20 @@ pub async fn set_show_experimental_settings(
     ConfigUI::update_field(
         ConfigUIContent::set_show_experimental_settings,
         show_experimental_settings,
+    )
+    .await
+    .map_err(InvokeError::from_anyhow)?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_show_window_on_startup(
+    show_window_on_startup: bool,
+) -> Result<(), InvokeError> {
+    ConfigUI::update_field(
+        ConfigUIContent::set_show_window_on_startup,
+        show_window_on_startup,
     )
     .await
     .map_err(InvokeError::from_anyhow)?;

--- a/src-tauri/src/configs/config_ui.rs
+++ b/src-tauri/src/configs/config_ui.rs
@@ -86,6 +86,7 @@ pub struct ConfigUIContent {
     sharing_enabled: bool,
     visual_mode: bool,
     show_experimental_settings: bool,
+    show_window_on_startup: bool,
     was_staged_security_modal_shown: bool, // TODO: Migrated to ConfigWallet, remove after some time
     wallet_ui_mode: WalletUIMode,
     feedback: HashMap<String, FeedbackPrompt>,
@@ -104,6 +105,7 @@ impl Default for ConfigUIContent {
             sharing_enabled: true,
             visual_mode: true,
             show_experimental_settings: false,
+            show_window_on_startup: true,
             was_staged_security_modal_shown: false,
             wallet_ui_mode: WalletUIMode::Standard,
             feedback: HashMap::from([

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -475,6 +475,7 @@ fn main() {
             commands::confirm_exchange_address,
             commands::select_exchange_miner,
             commands::set_show_experimental_settings,
+            commands::set_show_window_on_startup,
             commands::set_should_always_use_system_language,
             commands::set_should_auto_launch,
             commands::set_tor_config,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -96,7 +96,7 @@
                 "resizable": true,
                 "fullscreen": false,
                 "transparent": false,
-                "visible": true,
+                "visible": false,
                 "center": true,
                 "useHttpsScheme": true,
                 "width": 1280,

--- a/src/containers/floating/Settings/sections/general/GeneralSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import LogsSettings from './LogsSettings.tsx';
 import LanguageSettings from './LanguageSettings.tsx';
 import { ResetSettingsButton } from './ResetSettingsButton.tsx';
 import StartApplicationOnBootSettings from './StartApplicationOnBootSettings.tsx';
+import ShowWindowOnStartupSettings from './ShowWindowOnStartupSettings.tsx';
 import AutoUpdate from './AutoUpdate.tsx';
 import PreReleaseSettings from './PreReleaseSettings.tsx';
 import VisualMode from '@app/containers/main/Dashboard/components/VisualMode.tsx';
@@ -17,6 +18,7 @@ export const GeneralSettings = () => {
     return (
         <>
             <StartApplicationOnBootSettings />
+            <ShowWindowOnStartupSettings />
             <AutoUpdate />
             <PreReleaseSettings />
             <TaskTrayModeSettings />

--- a/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
@@ -1,0 +1,36 @@
+import { Typography } from '@app/components/elements/Typography.tsx';
+import { ToggleSwitch } from '@app/components/elements/inputs/switch/ToggleSwitch';
+import { setShowWindowOnStartup, useConfigUIStore } from '@app/store';
+import { useTranslation } from 'react-i18next';
+import {
+    SettingsGroup,
+    SettingsGroupAction,
+    SettingsGroupContent,
+    SettingsGroupTitle,
+    SettingsGroupWrapper,
+} from '../../components/SettingsGroup.styles';
+
+export default function ShowWindowOnStartupSettings() {
+    const { t } = useTranslation(['settings'], { useSuspense: false });
+    const showWindowOnStartup = useConfigUIStore((s) => s.show_window_on_startup);
+
+    return (
+        <SettingsGroupWrapper>
+            <SettingsGroup>
+                <SettingsGroupContent>
+                    <SettingsGroupTitle>
+                        <Typography variant="h6">{t('show-window-on-startup.title')}</Typography>
+                    </SettingsGroupTitle>
+                    <Typography variant="p">{t('show-window-on-startup.description')}</Typography>
+                </SettingsGroupContent>
+                <SettingsGroupAction>
+                    <ToggleSwitch
+                        data-testid="settings-toggle-show-window-on-startup"
+                        checked={showWindowOnStartup}
+                        onChange={(event) => setShowWindowOnStartup(event.target.checked)}
+                    />
+                </SettingsGroupAction>
+            </SettingsGroup>
+        </SettingsGroupWrapper>
+    );
+}

--- a/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
+++ b/src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx
@@ -12,7 +12,7 @@ import {
 
 export default function ShowWindowOnStartupSettings() {
     const { t } = useTranslation(['settings'], { useSuspense: false });
-    const showWindowOnStartup = useConfigUIStore((s) => s.show_window_on_startup);
+    const showWindowOnStartup = useConfigUIStore((s) => s.show_window_on_startup) ?? true;
 
     return (
         <SettingsGroupWrapper>

--- a/src/store/actions/appConfigStoreActions.test.ts
+++ b/src/store/actions/appConfigStoreActions.test.ts
@@ -16,7 +16,11 @@ import i18next, { changeLanguage } from 'i18next';
 import { Language } from '@app/i18initializer.ts';
 import { MiningModeType, PauseOnBatteryModeState } from '@app/types/configs';
 import { setError } from './appStateStoreActions.ts';
-import { setApplicationLanguage, setShouldAlwaysUseSystemLanguage } from './appConfigStoreActions.ts';
+import {
+    setApplicationLanguage,
+    setShouldAlwaysUseSystemLanguage,
+    setShowWindowOnStartup,
+} from './appConfigStoreActions.ts';
 import { useConfigUIStore } from '../useAppConfigStore.ts';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -533,6 +537,46 @@ describe('appConfigStoreActions', () => {
             expect(useConfigUIStore.getState().application_language).toBe('en');
             expect(changeLanguageMock).not.toHaveBeenCalled();
             expect(setErrorMock).toHaveBeenCalledWith('Could not resolve system language');
+        });
+    });
+
+    describe('show window on startup action', () => {
+        const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
+        const setErrorMock = setError as unknown as ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+            useConfigUIStore.setState((state) => ({ ...state, show_window_on_startup: true }));
+        });
+
+        it('optimistically updates the setting and persists it', async () => {
+            invokeMock.mockResolvedValue(undefined);
+
+            await setShowWindowOnStartup(false);
+
+            expect(useConfigUIStore.getState().show_window_on_startup).toBe(false);
+            expect(invokeMock).toHaveBeenCalledWith('set_show_window_on_startup', { showWindowOnStartup: false });
+        });
+
+        it('rolls back and surfaces an error when persistence fails', async () => {
+            invokeMock.mockRejectedValue(new Error('failed'));
+
+            await setShowWindowOnStartup(false);
+            await Promise.resolve();
+
+            expect(useConfigUIStore.getState().show_window_on_startup).toBe(true);
+            expect(setErrorMock).toHaveBeenCalledWith('Could not change startup window setting');
+        });
+
+        it('restores the previous value when persistence fails without a value change', async () => {
+            invokeMock.mockRejectedValue(new Error('failed'));
+            useConfigUIStore.setState((state) => ({ ...state, show_window_on_startup: false }));
+
+            await setShowWindowOnStartup(false);
+            await Promise.resolve();
+
+            expect(useConfigUIStore.getState().show_window_on_startup).toBe(false);
+            expect(setErrorMock).toHaveBeenCalledWith('Could not change startup window setting');
         });
     });
 

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -366,6 +366,16 @@ export const setShowExperimentalSettings = async (showExperimentalSettings: bool
     });
 };
 
+export const setShowWindowOnStartup = async (showWindowOnStartup: boolean) => {
+    const previousShowWindowOnStartup = useConfigUIStore.getState().show_window_on_startup;
+    useConfigUIStore.setState((c) => ({ ...c, show_window_on_startup: showWindowOnStartup }));
+    invoke('set_show_window_on_startup', { showWindowOnStartup }).catch((e) => {
+        console.error('Could not set show window on startup', e);
+        setError('Could not change startup window setting');
+        useConfigUIStore.setState((c) => ({ ...c, show_window_on_startup: previousShowWindowOnStartup }));
+    });
+};
+
 export const setDisplayMode = async (displayMode: displayMode) => {
     const previousDisplayMode = useConfigUIStore.getState().display_mode;
     useConfigUIStore.setState((c) => ({ ...c, display_mode: displayMode }));

--- a/src/store/actions/appConfigStoreActions.ts
+++ b/src/store/actions/appConfigStoreActions.ts
@@ -369,11 +369,13 @@ export const setShowExperimentalSettings = async (showExperimentalSettings: bool
 export const setShowWindowOnStartup = async (showWindowOnStartup: boolean) => {
     const previousShowWindowOnStartup = useConfigUIStore.getState().show_window_on_startup;
     useConfigUIStore.setState((c) => ({ ...c, show_window_on_startup: showWindowOnStartup }));
-    invoke('set_show_window_on_startup', { showWindowOnStartup }).catch((e) => {
+    try {
+        await invoke('set_show_window_on_startup', { showWindowOnStartup });
+    } catch (e) {
         console.error('Could not set show window on startup', e);
         setError('Could not change startup window setting');
         useConfigUIStore.setState((c) => ({ ...c, show_window_on_startup: previousShowWindowOnStartup }));
-    });
+    }
 };
 
 export const setDisplayMode = async (displayMode: displayMode) => {

--- a/src/store/actions/index.ts
+++ b/src/store/actions/index.ts
@@ -15,6 +15,7 @@ export {
     setMoneroAddress,
     setShouldAlwaysUseSystemLanguage,
     setShowExperimentalSettings,
+    setShowWindowOnStartup,
     setVisualMode,
 } from './appConfigStoreActions.ts';
 

--- a/src/store/useAppConfigStore.test.ts
+++ b/src/store/useAppConfigStore.test.ts
@@ -96,6 +96,7 @@ describe('useAppConfigStore', () => {
             has_system_language_been_proposed: false,
             sharing_enabled: true,
             show_experimental_settings: false,
+            show_window_on_startup: true,
             should_always_use_system_language: false,
             visual_mode: true,
             wallet_ui_mode: WalletUIMode.Standard,
@@ -121,6 +122,10 @@ describe('useAppConfigStore', () => {
 
         it('has show_experimental_settings as false by default', () => {
             expect(configUIInitialState.show_experimental_settings).toBe(false);
+        });
+
+        it('has show_window_on_startup as true by default', () => {
+            expect(configUIInitialState.show_window_on_startup).toBe(true);
         });
 
         it('has visual_mode as true by default', () => {

--- a/src/store/useAppConfigStore.ts
+++ b/src/store/useAppConfigStore.ts
@@ -44,6 +44,7 @@ const configUIInitialState: UIConfigStoreState = {
     has_system_language_been_proposed: false,
     sharing_enabled: true,
     show_experimental_settings: false,
+    show_window_on_startup: true,
     should_always_use_system_language: false,
     visual_mode: true,
     wallet_ui_mode: WalletUIMode.Standard,

--- a/src/types/configs.ts
+++ b/src/types/configs.ts
@@ -17,6 +17,7 @@ export interface ConfigUI {
     sharing_enabled: boolean;
     visual_mode: boolean;
     show_experimental_settings: boolean;
+    show_window_on_startup: boolean;
     wallet_ui_mode: WalletUIMode;
     was_staged_security_modal_shown: boolean;
     feedback?: FeedbackPrompts;

--- a/src/types/invoke.d.ts
+++ b/src/types/invoke.d.ts
@@ -26,6 +26,7 @@ declare module '@tauri-apps/api/core' {
     ): Promise<void>;
     function invoke(param: 'get_application_language'): Promise<string>;
     function invoke(param: 'set_should_auto_launch', payload: { shouldAutoLaunch: boolean }): Promise<void>;
+    function invoke(param: 'set_show_window_on_startup', payload: { showWindowOnStartup: boolean }): Promise<void>;
     function invoke(param: 'set_application_language', payload: { applicationLanguage: Language }): Promise<void>;
     function invoke(param: 'frontend_ready'): Promise<void>;
     function invoke(param: 'download_and_start_installer', payload: { id: string }): Promise<void>;


### PR DESCRIPTION
## Description

Adds a persisted setting that lets users choose whether Tari Universe shows the main window on startup or starts directly in the tray.

Fixes #3279.

## Motivation and Context

This gives users who prefer tray-first startup behavior a dedicated General Settings toggle while preserving the current visible-on-startup default for existing installs.

## How Has This Been Tested?

- `pnpm exec vitest run src/store/actions/appConfigStoreActions.test.ts src/store/useAppConfigStore.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/containers/floating/Settings/sections/general/GeneralSettings.tsx src/containers/floating/Settings/sections/general/ShowWindowOnStartupSettings.tsx src/store/actions/index.ts src/store/actions/appConfigStoreActions.ts src/store/actions/appConfigStoreActions.test.ts src/store/useAppConfigStore.ts src/store/useAppConfigStore.test.ts src/types/configs.ts src/types/invoke.d.ts`
- `git diff --check`

Rust-side checks were not run locally because `rustc` is not available in my environment.

## What process can a PR reviewer use to test or verify this change?

1. Start Tari Universe with the default config and confirm the main window appears after frontend readiness.
2. Open General Settings and disable **Show window on startup**.
3. Restart the app and confirm the main window remains hidden while the app continues running in the tray.
4. Re-enable the setting and restart to confirm the main window appears again.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify