### PR TITLE
chore: bump tari to v5.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,7 +3847,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4986,8 +4986,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_app_grpc"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -5017,8 +5017,8 @@ dependencies = [
 
 [[package]]
 name = "minotari_ledger_wallet_common"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "borsh",
  "bs58",
@@ -5027,16 +5027,16 @@ dependencies = [
 
 [[package]]
 name = "minotari_node_grpc_client"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "minotari_app_grpc",
 ]
 
 [[package]]
 name = "minotari_node_wallet_client"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5499,7 +5499,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -5950,7 +5950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -9198,8 +9198,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -9222,8 +9222,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_sqlite"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "diesel",
  "diesel_migrations",
@@ -9239,8 +9239,8 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -9276,8 +9276,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9323,8 +9323,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_dht"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -9357,8 +9357,8 @@ dependencies = [
 
 [[package]]
 name = "tari_comms_rpc_macros"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9367,8 +9367,8 @@ dependencies = [
 
 [[package]]
 name = "tari_core"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9450,13 +9450,13 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 
 [[package]]
 name = "tari_hashing"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -9466,8 +9466,8 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -9480,8 +9480,8 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "borsh",
  "serde",
@@ -9503,8 +9503,8 @@ dependencies = [
 
 [[package]]
 name = "tari_mmr"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -9516,8 +9516,8 @@ dependencies = [
 
 [[package]]
 name = "tari_node_components"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -9536,8 +9536,8 @@ dependencies = [
 
 [[package]]
 name = "tari_p2p"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "futures",
@@ -9562,8 +9562,8 @@ dependencies = [
 
 [[package]]
 name = "tari_script"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -9580,8 +9580,8 @@ dependencies = [
 
 [[package]]
 name = "tari_service_framework"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9595,16 +9595,16 @@ dependencies = [
 
 [[package]]
 name = "tari_shutdown"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "futures",
 ]
 
 [[package]]
 name = "tari_sidechain"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "borsh",
  "hex",
@@ -9620,8 +9620,8 @@ dependencies = [
 
 [[package]]
 name = "tari_storage"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "bincode",
  "lmdb-zero",
@@ -9632,8 +9632,8 @@ dependencies = [
 
 [[package]]
 name = "tari_test_utils"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "futures",
  "rand 0.10.1",
@@ -9644,8 +9644,8 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_components"
-version = "5.4.0-rc.1"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0-rc.1#ae9ccf0efb7950e04a6b965db9a6049485970ff4"
+version = "5.4.0"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.4.0#03e7ccd3257d669f8d73662bb214602fe0987c17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10179,7 +10179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,8 +53,8 @@ keyring = { version = "3.0.5", features = [
 tauri-remote-ui = { path = "tauri-remote-ui-patched", optional = true }
 log = "0.4.22"
 log4rs = "1.3.0"
-minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
-minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+minotari_node_grpc_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
+minotari_node_wallet_client = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
 monero-address-creator = { git = "https://github.com/tari-project/monero-address-creator.git", rev = "6129ca0" }
 nix = { version = "0.29.0", features = ["signal"] }
 nvml-wrapper = "0.10.0"
@@ -85,11 +85,11 @@ starship-battery = "0.10.3"
 sys-locale = "0.3.1"
 sysinfo = "0.31.2"
 tar = "0.4.26"
-tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
-tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_common = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
+tari_common_types = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
 tari_crypto = "0.23.1"
-tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
-tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0-rc.1" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
+tari_transaction_components = { git = "https://github.com/tari-project/tari.git", tag = "v5.4.0" }
 tari_utilities = "0.10.0"
 tauri = { version = "2", features = [
   "protocol-asset",

--- a/src-tauri/binaries-versions/binaries_versions_mainnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_mainnet.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
-        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
+        "minotari_node": "5.4.0 | 03e7ccd",
+        "mmproxy": "5.4.0 | 03e7ccd",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.4.0-rc.1 | ae9ccf0",
+        "wallet": "5.4.0 | 03e7ccd",
         "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_nextnet.json
+++ b/src-tauri/binaries-versions/binaries_versions_nextnet.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
-        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
+        "minotari_node": "5.4.0 | 03e7ccd",
+        "mmproxy": "5.4.0 | 03e7ccd",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.4.0-rc.1 | ae9ccf0",
+        "wallet": "5.4.0 | 03e7ccd",
         "xmrig": "6.26.0"
     }
 }

--- a/src-tauri/binaries-versions/binaries_versions_testnets.json
+++ b/src-tauri/binaries-versions/binaries_versions_testnets.json
@@ -2,11 +2,11 @@
     "binaries": {
         "bridge": "0.4.2",
         "lolminer": "1.98a",
-        "minotari_node": "5.4.0-rc.1 | ae9ccf0",
-        "mmproxy": "5.4.0-rc.1 | ae9ccf0",
+        "minotari_node": "5.4.0 | 03e7ccd",
+        "mmproxy": "5.4.0 | 03e7ccd",
         "sha-p2pool": "1.0.3 | cff9241",
         "tor": "15.0.5",
-        "wallet": "5.4.0-rc.1 | ae9ccf0",
+        "wallet": "5.4.0 | 03e7ccd",
         "xmrig": "6.26.0"
     }
 }


### PR DESCRIPTION
## What

Bumps Tari from the **v5.4.0-rc.1** release candidate (current `main`) to the final **v5.4.0** release — both the downloaded binaries and the `tari` Cargo dependencies.

### Binary downloads
`minotari_node`, `mmproxy`, `wallet`: `5.4.0-rc.1 | ae9ccf0` → `5.4.0 | 03e7ccd` across mainnet / nextnet / testnets. The `03e7ccd` hash matches the commit behind the [`v5.4.0` release assets](https://github.com/tari-project/tari/releases/tag/v5.4.0) (`tari_suite-5.4.0-…-03e7ccd-*`).

### Cargo dependencies
tari git crates (`minotari_node_grpc_client`, `minotari_node_wallet_client`, `tari_common`, `tari_common_types`, `tari_shutdown`, `tari_transaction_components`): tag `v5.4.0-rc.1` → `v5.4.0`. `Cargo.lock` regenerated.

`rc.1` and final are API-identical, so **no code changes are required** — no diff outside the version pins and lockfile.

## Testing
`cargo check` compiles clean, and the full pre-push preflight (`cargo fmt --check`, `cargo lints clippy --all-targets --all-features`, `cargo machete`, `npm run lint`) passes.