### PR TITLE
fix(e2e): make the MCP server specs deterministic on CI

### DIFF
--- a/playwright/helpers/mcp-client.ts
+++ b/playwright/helpers/mcp-client.ts
@@ -25,13 +25,30 @@ export interface ToolResult {
  * HTTP response (even a 401) means the listener is up; only a
  * connection-level error keeps us waiting.
  */
+
+/**
+ * The connection error code for a fetch failure, or undefined for anything
+ * that isn't a network error. Node's fetch wraps a refused connection as a
+ * TypeError whose `cause.code` is ECONNREFUSED, so key off cause.code, not
+ * the error name.
+ */
+function connErrorCode(err: unknown): string | undefined {
+  const e = err as { cause?: { code?: string }; code?: string } | undefined;
+  return e?.cause?.code ?? e?.code;
+}
+
+const RETRYABLE_CONN_CODES = new Set(['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT']);
+
 export async function waitForMcpUp(port: number, timeoutMs = 30_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       await fetch(`http://127.0.0.1:${port}/mcp`, { method: 'POST' });
       return; // connected — the socket is listening
-    } catch {
+    } catch (err) {
+      // Retry only on connection errors (server not up yet); let a real bug
+      // (e.g. a malformed URL → TypeError with no cause.code) surface fast.
+      if (!RETRYABLE_CONN_CODES.has(connErrorCode(err) ?? '')) throw err;
       await new Promise((r) => setTimeout(r, 500));
     }
   }
@@ -45,8 +62,13 @@ export async function waitForMcpDown(port: number, timeoutMs = 30_000): Promise<
     try {
       await fetch(`http://127.0.0.1:${port}/mcp`, { method: 'POST' });
       await new Promise((r) => setTimeout(r, 500)); // still up
-    } catch {
-      return; // connection refused — the listener is gone
+    } catch (err) {
+      const code = connErrorCode(err);
+      if (code === 'ECONNREFUSED') return; // listener is gone
+      // A transient network blip is not proof the server stopped — keep
+      // polling; anything that isn't a connection error is a real bug.
+      if (code !== 'ECONNRESET' && code !== 'ETIMEDOUT') throw err;
+      await new Promise((r) => setTimeout(r, 500));
     }
   }
   throw new Error(`MCP server still listening on port ${port} after ${timeoutMs}ms`);
@@ -150,7 +172,7 @@ export class McpClient {
         return await fn();
       } catch (e) {
         lastErr = e;
-        await new Promise((r) => setTimeout(r, delayMs));
+        if (i < attempts - 1) await new Promise((r) => setTimeout(r, delayMs));
       }
     }
     throw new Error(`${label} failed after ${attempts} attempts: ${String(lastErr)}`);

--- a/playwright/helpers/mcp-client.ts
+++ b/playwright/helpers/mcp-client.ts
@@ -17,6 +17,41 @@ export interface ToolResult {
   text: string;
 }
 
+/**
+ * Poll until the MCP server is actually accepting connections on `port`.
+ * The in-app UI status text ("running on port N") flips when the config
+ * updates, which can lead the real socket by a beat — on a loaded runner
+ * that gap is enough for an immediate client call to hit ECONNREFUSED. Any
+ * HTTP response (even a 401) means the listener is up; only a
+ * connection-level error keeps us waiting.
+ */
+export async function waitForMcpUp(port: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/mcp`, { method: 'POST' });
+      return; // connected — the socket is listening
+    } catch {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new Error(`MCP server did not start listening on port ${port} within ${timeoutMs}ms`);
+}
+
+/** Poll until the MCP server on `port` stops accepting connections. */
+export async function waitForMcpDown(port: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/mcp`, { method: 'POST' });
+      await new Promise((r) => setTimeout(r, 500)); // still up
+    } catch {
+      return; // connection refused — the listener is gone
+    }
+  }
+  throw new Error(`MCP server still listening on port ${port} after ${timeoutMs}ms`);
+}
+
 export class McpClient {
   private sessionId: string | null = null;
   private nextId = 1;

--- a/playwright/helpers/mcp-client.ts
+++ b/playwright/helpers/mcp-client.ts
@@ -136,12 +136,34 @@ export class McpClient {
     return json?.result;
   }
 
+  /**
+   * Retry an idempotent call a few times. A freshly (re)started server can
+   * transiently reject the first authenticated request even after its socket
+   * accepts connections (session table / auth layer still settling), so the
+   * handshake and read-only listing are retried; effectful tool calls are
+   * NOT routed through here.
+   */
+  private async withRetry<T>(label: string, fn: () => Promise<T>, attempts = 4, delayMs = 750): Promise<T> {
+    let lastErr: unknown;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        return await fn();
+      } catch (e) {
+        lastErr = e;
+        await new Promise((r) => setTimeout(r, delayMs));
+      }
+    }
+    throw new Error(`${label} failed after ${attempts} attempts: ${String(lastErr)}`);
+  }
+
   async initialize(): Promise<void> {
-    await this.rpc('initialize', {
-      protocolVersion: '2025-03-26',
-      capabilities: {},
-      clientInfo: { name: 'playwright-suite', version: '1.0.0' },
-    });
+    await this.withRetry('initialize', () =>
+      this.rpc('initialize', {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'playwright-suite', version: '1.0.0' },
+      })
+    );
     // Fire-and-forget per spec: notifications get 202 Accepted, no body.
     await fetch(`${this.baseUrl}/mcp`, {
       method: 'POST',
@@ -151,7 +173,9 @@ export class McpClient {
   }
 
   async listTools(): Promise<string[]> {
-    const result = (await this.rpc('tools/list')) as { tools?: { name: string }[] };
+    const result = (await this.withRetry('tools/list', () => this.rpc('tools/list'))) as {
+      tools?: { name: string }[];
+    };
     return (result.tools ?? []).map((t) => t.name);
   }
 

--- a/playwright/helpers/settings.ts
+++ b/playwright/helpers/settings.ts
@@ -30,6 +30,24 @@ export async function openSettingsTab(page: Page, tab: string) {
  * Toggle a ToggleSwitch (checkbox input carrying the testid) by clicking
  * its wrapper, verify the checked state flipped, then restore it.
  */
+/**
+ * Drive a ToggleSwitch to a desired checked state and converge on it. A
+ * single wrapper click can be lost (framer-motion remount, or the store
+ * update lagging behind under load), leaving the state unflipped — so poll
+ * the real `checked` value and re-click until it matches, or time out.
+ */
+export async function setToggleState(page: Page, selector: string, desired: boolean, timeout = 15_000) {
+  const input = page.locator(selector);
+  const wrapper = input.locator('..');
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if ((await input.isChecked().catch(() => !desired)) === desired) return;
+    await wrapper.click({ timeout: 5_000, force: true }).catch(() => {});
+    await page.waitForTimeout(750);
+  }
+  throw new Error(`Toggle ${selector} did not reach checked=${desired} within ${timeout}ms`);
+}
+
 export async function toggleAndRestore(page: Page, selector: string) {
   const input = page.locator(selector);
   const wrapper = input.locator('..');

--- a/playwright/tests/10-mcp-server.spec.ts
+++ b/playwright/tests/10-mcp-server.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../helpers/fixtures';
 import { sel } from '../helpers/selectors';
-import { openSettingsTab } from '../helpers/settings';
-import { McpClient } from '../helpers/mcp-client';
+import { openSettingsTab, setToggleState } from '../helpers/settings';
+import { McpClient, waitForMcpUp, waitForMcpDown } from '../helpers/mcp-client';
 import { waitForMiningReady, waitForMiningActive, waitForMiningStopped } from '../helpers/wait-for';
 import type { Page } from '@playwright/test';
 
@@ -33,9 +33,11 @@ test.describe.serial('MCP Server', () => {
     await toggle.waitFor({ state: 'visible', timeout: 15_000 });
     await expect(toggle).not.toBeChecked(); // off by default
 
-    await toggle.locator('..').click({ timeout: 5_000 });
-    await expect(toggle).toBeChecked({ timeout: 15_000 });
+    await setToggleState(page, sel.mcp.serverToggle, true);
     await waitForServerStatus(page, new RegExp(`running.*${MCP_PORT}`, 'i'));
+    // Gate on the real listener, not just the UI status text: later tests
+    // (and the token below) act against the socket.
+    await waitForMcpUp(MCP_PORT, 30_000);
 
     // Token renders redacted: tu_ prefix + bullets, no full token in the DOM.
     const tokenValue = page.locator(sel.mcp.tokenValue);
@@ -127,15 +129,13 @@ test.describe.serial('MCP Server', () => {
     const client = new McpClient(baseUrl(MCP_PORT), token);
     await client.initialize();
 
-    await readTier.locator('..').click({ timeout: 5_000 });
-    await expect(readTier).not.toBeChecked({ timeout: 10_000 });
+    await setToggleState(page, sel.mcp.tierRead, false);
 
     const blocked = await client.callTool('get_wallet_balance');
     expect(blocked.isError).toBe(true);
     expect(blocked.text).toMatch(/read tier is disabled/i);
 
-    await readTier.locator('..').click({ timeout: 5_000 });
-    await expect(readTier).toBeChecked({ timeout: 10_000 });
+    await setToggleState(page, sel.mcp.tierRead, true);
 
     const allowed = await client.callTool('get_wallet_balance');
     expect(allowed.isError).toBe(false);
@@ -152,17 +152,22 @@ test.describe.serial('MCP Server', () => {
     await portInput.press('Enter');
     await waitForServerStatus(page, new RegExp(`running.*${ALT_PORT}`, 'i'), 60_000);
 
-    // Old port refuses connections; new port serves the same token.
-    await expect(fetch(`${baseUrl(MCP_PORT)}/mcp`, { method: 'POST' })).rejects.toThrow();
+    // Wait for the real listeners to settle: the new port must be up and the
+    // old one refused before we probe them (the socket lags the UI text).
+    await waitForMcpUp(ALT_PORT, 60_000);
+    await waitForMcpDown(MCP_PORT, 60_000);
 
     const client = new McpClient(baseUrl(ALT_PORT), token);
     await client.initialize();
     expect(await client.listTools()).toContain('get_wallet_balance');
 
-    // Restore the default port.
+    // Restore the default port and confirm it is actually serving again, so
+    // the following tests start from a live socket on MCP_PORT.
     await portInput.fill(String(MCP_PORT));
     await portInput.press('Enter');
     await waitForServerStatus(page, new RegExp(`running.*${MCP_PORT}`, 'i'), 60_000);
+    await waitForMcpUp(MCP_PORT, 60_000);
+    await waitForMcpDown(ALT_PORT, 60_000);
   });
 
   test('revoke clears the token, disables MCP and stops the server', async ({ appPage: page }) => {
@@ -175,7 +180,7 @@ test.describe.serial('MCP Server', () => {
     await expect(page.locator(sel.mcp.serverToggle)).not.toBeChecked({ timeout: 15_000 });
     await expect(page.locator(sel.mcp.tokenValue)).not.toBeVisible({ timeout: 10_000 });
 
-    // The server is really gone.
-    await expect(fetch(`${baseUrl(MCP_PORT)}/mcp`, { method: 'POST' })).rejects.toThrow();
+    // The server is really gone (poll until the listener actually stops).
+    await waitForMcpDown(MCP_PORT, 30_000);
   });
 });

--- a/playwright/tests/10-mcp-server.spec.ts
+++ b/playwright/tests/10-mcp-server.spec.ts
@@ -78,8 +78,9 @@ test.describe.serial('MCP Server', () => {
     const client = new McpClient(baseUrl(MCP_PORT), token);
     await client.initialize();
 
-    const tools = await client.listTools();
-    for (const expected of [
+    // Poll the listing until the full tool set is registered: on a cold
+    // backend the first tools/list can land before every tool is wired up.
+    const expectedTools = [
       'get_wallet_address',
       'get_wallet_balance',
       'get_transaction_history',
@@ -89,10 +90,21 @@ test.describe.serial('MCP Server', () => {
       'start_mining',
       'stop_mining',
       'send_transaction',
-    ]) {
-      expect(tools).toContain(expected);
-    }
+    ];
+    await expect
+      .poll(() => client.listTools().catch(() => [] as string[]), { timeout: 30_000 })
+      .toEqual(expect.arrayContaining(expectedTools));
 
+    // A read-tier tool depends on the WALLET being started. On a cold
+    // backend (every CI run is one) the wallet is still spinning up when
+    // this test runs, so get_wallet_balance transiently returns an error
+    // result — poll until it succeeds rather than asserting on the first
+    // call. This is the read an agent would retry too.
+    await expect
+      .poll(async () => (await client.callTool('get_wallet_balance').catch(() => ({ isError: true }))).isError, {
+        timeout: 120_000,
+      })
+      .toBe(false);
     const balance = await client.callTool('get_wallet_balance');
     expect(balance.isError).toBe(false);
     expect(balance.text.length).toBeGreaterThan(0);

--- a/playwright/tests/95-security-pin.spec.ts
+++ b/playwright/tests/95-security-pin.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '../helpers/fixtures';
 import { sel } from '../helpers/selectors';
 import { TEST_WALLET } from '../helpers/test-wallet';
-import { openSettingsTab } from '../helpers/settings';
+import { openSettingsTab, setToggleState } from '../helpers/settings';
 import { enterPinDigits, answerPinPrompt, TEST_PIN, WRONG_PIN } from '../helpers/pin';
 import { ensureBalance } from '../helpers/wait-for';
-import { McpClient } from '../helpers/mcp-client';
+import { McpClient, waitForMcpUp } from '../helpers/mcp-client';
 import type { Page } from '@playwright/test';
 
 /**
@@ -169,13 +169,11 @@ test.describe.serial('Security PIN', () => {
     await openSettingsTab(page, 'mcp');
 
     // 10-mcp-server revoked the token, so MCP is disabled — enable it
-    // fresh; a new token gets generated.
-    const toggle = page.locator(sel.mcp.serverToggle);
-    await toggle.waitFor({ state: 'visible', timeout: 15_000 });
-    if (!(await toggle.isChecked())) {
-      await toggle.locator('..').click({ timeout: 5_000 });
-      await expect(toggle).toBeChecked({ timeout: 15_000 });
-    }
+    // fresh; a new token gets generated. Gate on the real listener so the
+    // send test's client (below) doesn't race the socket coming up.
+    await page.locator(sel.mcp.serverToggle).waitFor({ state: 'visible', timeout: 15_000 });
+    await setToggleState(page, sel.mcp.serverToggle, true);
+    await waitForMcpUp(19222, 30_000);
 
     // Reveal now runs through the PIN prompt.
     await page.locator(sel.mcp.tokenReveal).click({ timeout: 10_000 });
@@ -189,6 +187,9 @@ test.describe.serial('Security PIN', () => {
     const txTier = page.locator(sel.mcp.tierTransactions);
     await txTier.waitFor({ state: 'visible', timeout: 15_000 });
     await expect(txTier).not.toBeChecked(); // off by default
+    // The tier toggle opens a PIN prompt; click once and answer it, then
+    // confirm the state took. (Don't use the converging helper here — each
+    // extra click would raise another PIN prompt.)
     await txTier.locator('..').click({ timeout: 5_000 });
     await page.locator(sel.pin.input).waitFor({ state: 'visible', timeout: 15_000 });
     await answerPinPrompt(page, TEST_PIN);
@@ -199,6 +200,10 @@ test.describe.serial('Security PIN', () => {
     test.setTimeout(600_000);
     expect(mcpToken, 'token captured by the reveal test').toMatch(/^tu_/);
 
+    // Fresh page (fixture): make sure the server socket is up before the
+    // client connects — the UI enabled it in the previous test, but the
+    // listener readiness is what this raw HTTP client actually needs.
+    await waitForMcpUp(19222, 30_000);
     const client = new McpClient('http://127.0.0.1:19222', mcpToken);
     await client.initialize();
 


### PR DESCRIPTION
## What

The MCP server specs (`10-mcp-server`, and the MCP portion of `95-security-pin`, both merged in #3316) were flaky on the CI runner. Two CI runs failed on two *different* MCP tests — the signature of non-determinism, not a real break.

## Root cause (confirmed by reproduction, not inference)

Reproduced deterministically by running `10-mcp-server` under 12-core CPU load on a self-hosted-like box: run 1 failed at `10-mcp-server.spec.ts:97`, `expect(balance.isError).toBe(false)`.

On a **cold backend — and every CI run is a cold start** — the wallet is still starting when the "authenticated agent lists tools" test runs, so the MCP `get_wallet_balance` read returns an error result (`isError: true`). The assertion failed at ~60ms, before any retry could run, because it was a synchronous check on a successful-but-error tool result. The fast local box has a warm backend by the time these tests run, so it almost never reproduced there — CI, being cold every time, hit it regularly.

Two contributing races were also fixed along the way:
- The HTTP socket lagging the in-app "running on port N" status text, so an immediate client call after enabling/port-change hit `ECONNREFUSED 127.0.0.1:19222`.
- Occasional lost `ToggleSwitch` clicks (framer-motion remount / store-update lag), failing an intermediate checked-state assertion.

## Fixes (playwright helpers + specs only — no app or Rust changes)

- **Wait for real readiness** (the actual root cause): the read-tier test polls `get_wallet_balance` until it succeeds and `tools/list` until the full tool set is registered, instead of asserting on the first call. Both guard transient throws so a cold first call keeps polling.
- **`waitForMcpUp` / `waitForMcpDown`**: poll the real socket for listening/refused after every server state change (enable, port change, revoke), before probing it.
- **`setToggleState`**: click a `ToggleSwitch` and converge on the desired checked state (re-click if a click was lost).
- **MCP client retries** the idempotent handshake (`initialize`) and tool listing.
- The `95` MCP send flow gates on the socket being up before the client connects.

## Validation

- Reproduced the failure under 12-core CPU load on the pre-fix code (caught on run 1).
- With the fix, ran `10-mcp-server` **10× under the same load — 10/10 green**.

CI over repeated runs remains the real arbiter for flakiness; this makes the tests wait for the conditions they actually depend on rather than assuming a warm backend.

## Unblocks

Release PR #3318 and #3319 both failed on these same merged MCP tests; this fixes them at the source on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
