### PR TITLE
fix(node): retry config error startup failures

### DIFF
--- a/src-tauri/src/node/node_manager.rs
+++ b/src-tauri/src/node/node_manager.rs
@@ -60,7 +60,7 @@ pub enum NodeManagerError {
     UnknownError(#[from] anyhow::Error),
 }
 
-pub const STOP_ON_ERROR_CODES: [i32; 2] = [114, 102];
+pub const STOP_ON_ERROR_CODES: [i32; 3] = [114, 102, 101];
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub enum NodeType {

--- a/src-tauri/src/node/node_manager_test.rs
+++ b/src-tauri/src/node/node_manager_test.rs
@@ -132,5 +132,6 @@ fn node_manager_error_unknown_error_display() {
 fn stop_on_error_codes_contains_expected_values() {
     assert!(STOP_ON_ERROR_CODES.contains(&114));
     assert!(STOP_ON_ERROR_CODES.contains(&102));
-    assert_eq!(STOP_ON_ERROR_CODES.len(), 2);
+    assert!(STOP_ON_ERROR_CODES.contains(&101));
+    assert_eq!(STOP_ON_ERROR_CODES.len(), 3);
 }

--- a/src-tauri/src/setup/phase_node.rs
+++ b/src-tauri/src/setup/phase_node.rs
@@ -236,7 +236,7 @@ impl SetupPhaseImpl for NodeSetupPhase {
                     Err(e) => {
                         if let NodeManagerError::ExitCode(code) = e {
                             if STOP_ON_ERROR_CODES.contains(&code) {
-                                warn!(target: LOG_TARGET_APP_LOGIC, "Database for node is corrupt or needs a restart, deleting and trying again.");
+                                warn!(target: LOG_TARGET_APP_LOGIC, "Node data or config is corrupt or needs a restart, deleting and trying again.");
                                 state.node_manager.clean_data_folder(&node_data_dir).await?;
                                 state.wallet_manager.clean_data_folder(&data_dir).await?;
                             }


### PR DESCRIPTION
Fixes #2831

## Summary
- treat node exit code 101 as a recoverable startup error
- reuse the existing node cleanup and retry path for config-error startup failures
- update the focused stop-on-error-code test

## Validation
- cargo fmt
- git diff --check
- cargo +1.93.0 check
- cargo +1.93.0 test node_manager_test::stop_on_error_codes_contains_expected_values