### PR TITLE
fix: stop reporting recoverable binary download errors to Sentry

### DIFF
--- a/src-tauri/src/requests/clients/http_client.rs
+++ b/src-tauri/src/requests/clients/http_client.rs
@@ -71,10 +71,7 @@ impl HttpClient {
             if response.status().is_success() {
                 return Ok(response);
             } else {
-                return Err(anyhow!(
-                    "HEAD request failed with status code: {}",
-                    response.status()
-                ));
+                return Err(classify_status_error("HEAD", response.status()));
             }
         };
         head_response.map_err(|e| {
@@ -91,13 +88,27 @@ impl HttpClient {
             if response.status().is_success() {
                 return Ok(response);
             } else {
-                return Err(anyhow!(
-                    "GET request failed with status code: {}",
-                    response.status()
-                ));
+                return Err(classify_status_error("GET", response.status()));
             }
         };
 
         get_response.map_err(|e| anyhow!("GET request failed with error: {}", e))
+    }
+}
+
+/// Classify a non-success HTTP status returned while probing a download URL.
+/// Transient/server-side statuses (request timeout, rate limiting, 5xx such as
+/// 504 Gateway Timeout) are user-environment/CDN issues that must not be
+/// reported to Sentry. Other statuses (e.g. a genuinely wrong 404 release URL)
+/// stay as plain errors so they continue to surface as real bugs.
+fn classify_status_error(method: &str, status: reqwest::StatusCode) -> anyhow::Error {
+    let message = format!("{method} request failed with status code: {status}");
+    if status.is_server_error()
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        BinaryDownloadError::NetworkError(message).into()
+    } else {
+        anyhow!(message)
     }
 }

--- a/src-tauri/src/requests/clients/http_file_client.rs
+++ b/src-tauri/src/requests/clients/http_file_client.rs
@@ -169,13 +169,13 @@ impl HttpFileClient {
 
         if destination_file.exists() {
             std::fs::remove_file(destination_file.clone())
-                .map_err(|e| anyhow::anyhow!("Failed to remove file: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to remove file", &e))?;
         }
 
         if !destination.exists() {
             create_dir_all(destination)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to create directory: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to create directory", &e))?;
         }
 
         let mut file = File::options()
@@ -184,7 +184,7 @@ impl HttpFileClient {
             .truncate(true)
             .open(destination_file)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?;
+            .map_err(|e| Self::classify_fs_error("Failed to create file", &e))?;
 
         self.download_file(expected_size, &mut file, false).await?;
 
@@ -216,14 +216,14 @@ impl HttpFileClient {
         if !destination.exists() {
             create_dir_all(destination)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to create directory: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to create directory", &e))?;
         }
 
         if !destination_file.exists() {
             info!(target: LOG_TARGET_APP_LOGIC, "File does not exist, creating new file at {}", destination_file.display());
             File::create(&destination_file)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to create file", &e))?;
         }
 
         let file_size = get_content_size_from_file(
@@ -235,18 +235,18 @@ impl HttpFileClient {
             warn!(target: LOG_TARGET_APP_LOGIC, "File is probably corrupted, expected size: {expected_size}, but got: {file_size}");
             info!(target: LOG_TARGET_APP_LOGIC, "Removing corrupted file: {}", destination_file.display());
             std::fs::remove_file(&destination_file)
-                .map_err(|e| anyhow::anyhow!("Failed to remove corrupted file: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to remove corrupted file", &e))?;
             info!(target: LOG_TARGET_APP_LOGIC, "Creating new file at {}", destination_file.display());
             File::create(&destination_file)
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?;
+                .map_err(|e| Self::classify_fs_error("Failed to create file", &e))?;
         }
 
         let mut file = File::options()
             .append(true)
             .open(&destination_file)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to open file: {}", e))?;
+            .map_err(|e| Self::classify_fs_error("Failed to open file", &e))?;
 
         let mut internet_connection_check_attempt_count = 0;
         let mut file_download_attempt_count = 0;
@@ -425,6 +425,21 @@ impl HttpFileClient {
             }
         }
         BinaryDownloadError::CorruptDownload(format!("Extraction failed: {}", e))
+    }
+
+    /// Classify a filesystem error hit while preparing download targets
+    /// (creating directories/files, removing stale files). Permission denied
+    /// (AV quarantine, Windows file locks) and already-exists (concurrent
+    /// instance or leftover partial download) are user-environment issues that
+    /// must not be reported to Sentry; the download retry path recovers from
+    /// them. Any other kind stays a plain error so real bugs still surface.
+    fn classify_fs_error(context: &str, e: &std::io::Error) -> anyhow::Error {
+        match e.kind() {
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::AlreadyExists => {
+                BinaryDownloadError::FileAccessDenied(format!("{context}: {e}")).into()
+            }
+            _ => anyhow::anyhow!("{context}: {e}"),
+        }
     }
 
     async fn extract_inner(&self) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Description

Closes two gaps in the `BinaryDownloadError` classifier (added in #3156) so recoverable user-environment download failures stop being reported to Sentry. Two paths were never classified and kept calling `sentry::capture_message`, which is why several issues #3156 resolved reappeared as regressions:

- **HTTP status failures** — non-success statuses on the download HEAD/GET probe (e.g. `504 Gateway Timeout`) were plain `anyhow` errors; only transport-level failures were classified. Added `classify_status_error`: transient/server statuses (5xx, 408, 429) → `BinaryDownloadError::NetworkError`; other statuses (e.g. a genuinely wrong 404 release URL) stay reportable.
- **Filesystem failures** — `create_dir` / `create_file` / `remove_file` errors (`os error 5` access-denied, `os error 183`/`80` already-exists) were plain `anyhow` errors. Added `classify_fs_error`: `PermissionDenied` / `AlreadyExists` → `BinaryDownloadError::FileAccessDenied`; other IO kinds stay reportable. Applied to every fs site in the default and resume download flows.

## Motivation and Context

These failures are user-environment issues (AV quarantine, Windows file locks, `C:\Users\TEMP` sandboxes, CDN 504s) — 0 users impacted, all recovered by the existing 3-attempt retry. #3156 resolved them by suppressing them from Sentry, but the classifier only covered HEAD transport errors and some extraction errors, so the uncovered paths kept firing and the issues regressed. The split is deliberately conservative: a broken release URL (404) or a corrupt archive still surfaces as a real error.

Resolves: TARI-UNIVERSE-S, TARI-UNIVERSE-26, TARI-UNIVERSE-1R

## How Has This Been Tested?

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo lints clippy --all-targets --all-features` (CI lint, `-D dead-code`)

## What process can a PR reviewer use to test or verify this change?

- Review the two helpers and confirm the transient-vs-real split: 5xx/408/429 and `PermissionDenied`/`AlreadyExists` are suppressed; other 4xx and other IO kinds still report.
- Optional manual check: point a binary download at a URL that returns 504, or make the target binary directory read-only, and confirm the failure is logged at info level (not sent to Sentry) and retried.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify