### PR TITLE
fix(wallet): start sync countdown when estimate is ready

### DIFF
--- a/src/components/wallet/components/loaders/SyncLoading/SyncCountdown.test.tsx
+++ b/src/components/wallet/components/loaders/SyncLoading/SyncCountdown.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const countdownMock = vi.hoisted(() => ({
+    value: -1,
+}));
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock('@app/containers/main/Sync/components/useProgressCountdown.ts', () => ({
+    useProgressCountdown: () => ({ countdown: countdownMock.value }),
+}));
+
+import { render, screen, waitFor } from '@app/test/test-utils';
+import SyncCountdown from './SyncCountdown';
+
+describe('SyncCountdown', () => {
+    beforeEach(() => {
+        countdownMock.value = -1;
+    });
+
+    it('starts after a sync estimate becomes available', async () => {
+        const onCompleted = vi.fn();
+        const onStarted = vi.fn();
+        const { rerender } = render(<SyncCountdown onCompleted={onCompleted} onStarted={onStarted} />);
+
+        expect(screen.getByText('setup-progresses:calculating_time')).toBeInTheDocument();
+        expect(onStarted).not.toHaveBeenCalled();
+
+        countdownMock.value = 120;
+        rerender(<SyncCountdown onCompleted={onCompleted} onStarted={onStarted} />);
+
+        await waitFor(() => expect(onStarted).toHaveBeenCalledOnce());
+        expect(screen.getByText('2m')).toBeInTheDocument();
+        expect(onCompleted).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/wallet/components/loaders/SyncLoading/SyncCountdown.tsx
+++ b/src/components/wallet/components/loaders/SyncLoading/SyncCountdown.tsx
@@ -41,7 +41,7 @@ export default function SyncCountdown({ onCompleted, onStarted, isCompact = fals
         }
     }, [countdown]);
 
-    if (!startedRef.current) {
+    if (countdown === -1) {
         return <LoadingText text={t('setup-progresses:calculating_time', { context: isCompact ? 'compact' : '' })} />;
     }
 


### PR DESCRIPTION
## Description

Mounts `SyncCountdown` as soon as `useProgressCountdown` returns a valid estimate instead of waiting for `startedRef`, which can only be updated after the countdown component mounts.

Adds a focused regression test covering the transition from an unavailable estimate to an active countdown.

Closes #3339

## Motivation and Context

The previous loading guard returned before `<Countdown>` could mount. As a result, `countdownRef.current` stayed `null`, the start effect could not call the countdown API, and `onStarted` was never invoked.

The new guard uses the hook's existing `-1` sentinel for an unavailable estimate. Once an estimate is available, the countdown mounts and the existing start/complete behavior runs unchanged.

## How Has This Been Tested?

- `pnpm exec vitest run src/components/wallet/components/loaders/SyncLoading/SyncCountdown.test.tsx`
- `pnpm test` (46 test files, 1,058 tests passed)
- `pnpm lint`
- `pnpm build`
- `git diff --check`

All commands exited successfully. The Vitest runs retain the repository's existing Vite shutdown-timeout notice after successful test completion.

## What process can a PR reviewer use to test or verify this change?

1. Run the focused Vitest command above.
2. Confirm the component initially shows the calculating-time state while the mocked estimate is `-1`.
3. Confirm that changing the estimate to `120` mounts and starts the countdown, invokes `onStarted`, and renders `2m`.

No manual or hardware-dependent testing is required for this state-transition fix.

## Breaking Changes

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
